### PR TITLE
docs(readme): add missing browser UI build step to Part 1 quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,17 +135,22 @@ groups, no replay. That's the build ahead.
 
 ## Quick start
 
-### Part 1 — Browser (no install required)
+### Part 1 — Browser (no Rust, no desktop app)
 
 The fastest path. The pi extension HTTP-serves Accordion in your browser — no Rust, no
 desktop app needed. Single session only.
 
-**1. Clone and install the extension:**
+**1. Clone, build the browser UI, and install the extension:**
 
 ```bash
 git clone https://github.com/a-Fig/accordion.git
-cd accordion/extension && npm install
+cd accordion
+npm install --prefix app && npm run build --prefix app   # builds the static browser bundle (app/build)
+cd extension && npm install                              # the pi extension that serves it
 ```
+
+> The extension serves the UI from `app/build` (produced by `npm run build` above).
+> Without that build, `/accordion` opens to a "No browser build found" page.
 
 **2. Register it with pi** — add to `~/.pi/agent/settings.json`:
 


### PR DESCRIPTION
## Problem

Following the README "Part 1 — Browser (no install required)" quick start as written, `/accordion` opens to a **"No browser build found"** page.

The instructions only run `npm install` inside `extension/`:

```bash
git clone https://github.com/a-Fig/accordion.git
cd accordion/extension && npm install
```

But the extension serves the browser UI from a **pre-built SvelteKit bundle**. `extension/accordion.ts → resolveClientRoot()` probes two locations:

1. `extension/dist/client`
2. `app/build`

Neither is created by the documented steps, so the static-file handler hits its fallback:

```
"No browser build found. Run `npm run build` in app/, or `npm run build:client` in extension/."
```

`CONTRIBUTING.md` already documents the correct full setup (install both `app/` and `extension/`, run `npm run build` in `app/`), but the README quick start omits the app build — which is the first thing a new user following "the fastest path" hits.

## Fix

Add the missing `npm install --prefix app && npm run build --prefix app` step to Part 1, and retitle the section from the misleading **"(no install required)"** to **"(no Rust, no desktop app)"** — which is what the body text already claims and is accurate (the build needs Node only, not Rust/Tauri).

The added note explains *why* the build is needed (the extension serves from `app/build`) so the failure mode is recognizable if a user skips it.

## Verification

Reproduced the original failure on a clean checkout, then confirmed that after `npm install --prefix app && npm run build --prefix app` the `app/build` directory is produced and `resolveClientRoot()` resolves it, so `/accordion` serves the UI.

## Notes / possible alternative

A nicer long-term UX would be for the extension to auto-build (or auto-run `npm run build:client`) when no client root is found, instead of rendering a dead-end page. That is a bigger behavioral change so I kept this PR scoped to the docs fix; happy to open a separate issue for the auto-build idea if maintainers want it.

Also relates to #6 (bring setup under 5 minutes for new users) — the missing step is exactly the kind of thing that stalls a first run.