### PR TITLE
fix(engine): make group-collapse token accounting mirror the wire (#13)

### DIFF
--- a/app/src/lib/engine/store.svelte.ts
+++ b/app/src/lib/engine/store.svelte.ts
@@ -14,6 +14,7 @@
 import type { Block, Actor, SessionMeta, ParsedSession, Group } from "./types";
 import { digest, digestTokens, foldTag, groupDigest, groupDigestTokens, substTokens, wireFoldable } from "./digest";
 import { estTokens, BLOCK_OVERHEAD } from "./tokens";
+import { isDurableId } from "../live/mapping";
 import type { Conductor, ConductorView, Command, ClampReport, ClampReason, LockName, ConductorHost, CompletionRequest, CompletionResult, JSONValue } from "$conductors/contract";
 import { hasLock } from "$conductors/contract";
 import { BuiltinConductor } from "$conductors";
@@ -28,6 +29,13 @@ interface GroupShape {
 	stragglers: Set<string>;
 	/** First collapsed member (by order): the one block that "carries" the summary's token cost. */
 	carrier: string | null;
+	/**
+	 * The collapsed members split into maximal contiguous RUNS (in member/conversation order),
+	 * each run uninterrupted by a straggler. The wire inserts ONE summary message per run, so the
+	 * VIEW must charge one summary cost per run too (ADR 0006 §5 — see `groupWire`/`groupLiveTokens`).
+	 * The first block of each run "carries" that run's summary cost; the rest carry 0.
+	 */
+	collapsedRuns: Block[][];
 }
 
 // The fold-ranking (which kinds fold first) moved to `conductors/builtin/builtin.ts` — it is the
@@ -199,6 +207,19 @@ export class AccordionStore {
 	 * before depending on it; the host rejects if it is called while null.
 	 */
 	completer: ((req: CompletionRequest) => Promise<CompletionResult>) | null = null;
+
+	/**
+	 * True iff a live pi WIRE is attached (the live client sets this to true on connect and
+	 * false on disconnect, alongside `completer`). This is the precise "a wire is involved"
+	 * signal for the view-mirrors-wire invariant (issue #13): only in a live session does
+	 * `classifyGroup` enforce durability-aware accounting (non-durable-id members stay live,
+	 * splitting the collapsed run — exactly what the wire's `applyPlan` does). Demo / loaded
+	 * sessions, and conductor STRATEGY tests that inject only a fake `completer`, leave this
+	 * false → durability-AGNOSTIC collapse (the GUI shows the logical grouping, which the issue
+	 * explicitly permits whenever "no wire is involved"). NOT implied by `completer`: a strategy
+	 * test may set `completer` to drive a conductor without any wire being live.
+	 */
+	wireAttached = false;
 
 	/**
 	 * Optional prose-compression backend injected by the app layer. Set from outside (the
@@ -676,16 +697,14 @@ export class AccordionStore {
 		for (const g of this.groups) {
 			if (!g.folded) continue;
 			const c = this.classifyGroup(g);
-			// Carrier token cost mirrors groupLiveTokens: drop → 0, custom digest → its tokens,
-			// default recap → groupDigestTokens. Non-carrier collapsed members always 0.
-			let summaryTok = 0;
-			if (c.carrier) {
-				if (this.isDropGroup(g)) summaryTok = 0; // drop group
-				else if (typeof g.digest === "string") summaryTok = estTokens(g.digest) + BLOCK_OVERHEAD; // custom literal
-				else summaryTok = groupDigestTokens(g, c.collapsedMembers); // default recap
-			}
+			// The wire inserts ONE summary message PER contiguous collapsed run (applyPlan Phase B).
+			// So the VIEW charges one summary cost to the FIRST block of EACH run; every other
+			// collapsed member holds 0. The per-run summaries are byte-identical, so each costs the
+			// same `summaryTok` (drop → 0, custom literal → its tokens, default recap → digest).
+			const summaryTok = this.groupSummaryTok(g, c);
+			const runFirsts = new Set(c.collapsedRuns.map((r) => r[0].id));
 			for (const b of c.members) {
-				if (c.collapsed.has(b.id)) m.set(b.id, { tokens: b.id === c.carrier ? summaryTok : 0, collapsed: true });
+				if (c.collapsed.has(b.id)) m.set(b.id, { tokens: runFirsts.has(b.id) ? summaryTok : 0, collapsed: true });
 				else m.set(b.id, { tokens: b.tokens, collapsed: false }); // straggler: live, full
 			}
 		}
@@ -693,11 +712,42 @@ export class AccordionStore {
 	});
 
 	/**
+	 * The token cost of ONE of a folded group's summary messages — drop group → 0, custom literal
+	 * digest → its own token cost, default recap → `groupDigestTokens` over ALL collapsed members.
+	 * The wire emits one such summary per contiguous run, all byte-identical, so each run costs this.
+	 * Returns 0 when nothing collapses (no carrier). Shared by `groupWire` + `groupLiveTokens`.
+	 */
+	private groupSummaryTok(g: Group, c: GroupShape): number {
+		if (!c.carrier) return 0;
+		if (this.isDropGroup(g)) return 0; // drop group: no wire message inserted
+		if (typeof g.digest === "string" && g.digest) return estTokens(g.digest) + BLOCK_OVERHEAD; // custom literal
+		return groupDigestTokens(g, c.collapsedMembers); // default recap
+	}
+
+	/**
 	 * Split a group's members into what collapses (whole, tool-pair-balanced messages →
 	 * the one summary) vs. what stays live (a tool-pair half whose partner sits outside the
-	 * group — the owner's "leave straggler live" rule). Pure; no durability gate here (that
-	 * is the WIRE's concern in `plan.ts` — the GUI shows the logical collapse so the demo /
-	 * loaded sessions render real savings).
+	 * group — the owner's "leave straggler live" rule). Pure.
+	 *
+	 * The removable set is the SAME MESSAGE-LEVEL FIXPOINT the wire runs in `applyPlan`'s
+	 * Phase A (`mapping.ts`): start with every member message removable, then repeatedly demote
+	 * any removable message that holds a tool_call whose callId is not among the removable set's
+	 * results, OR a tool_result whose callId is not among the removable set's calls — until
+	 * stable. A single pass is NOT enough: demoting one message can orphan a tool-pair partner in
+	 * another still-removable message, which must then be demoted too (e.g. parallel tool calls
+	 * where one result is outside the group — the assistant message can't be removed, so neither
+	 * can the call whose result IS inside, cascading until nothing collapses). Mirroring the wire
+	 * here keeps the VIEW's token accounting byte-faithful to what the agent actually receives.
+	 *
+	 * DURABILITY (ADR: the GUI must mirror exactly what the agent receives, issue #13): the wire
+	 * (`computeGroupOps` → `applyPlan`) strips non-durable ids, so a message containing a
+	 * POSITIONAL (non-durable) id is NEVER removed on the wire — it stays live and splits the
+	 * collapsed run around it. In a LIVE session (`wireAttached` — a real pi wire is attached, so a
+	 * model actually receives what `applyPlan` produces) the view mirrors that exactly: such a
+	 * message is a straggler here too. In a DEMO / loaded session there is no wire (no model
+	 * receives anything), so the view stays durability-AGNOSTIC — it shows the logical collapse so
+	 * demo/loaded sessions render real savings. This is the group-analog of the already-accepted
+	 * "non-durable folds preview in demo" behavior; only live sessions enforce the mirror invariant.
 	 */
 	private classifyGroup(g: Group): GroupShape {
 		const members: Block[] = [];
@@ -705,22 +755,8 @@ export class AccordionStore {
 			const b = this.get(id);
 			if (b) members.push(b);
 		}
-		// Pairing WITHIN the member set: a tool_call is balanced iff its result is also a
-		// member; a tool_result iff its call is. A block whose partner is outside is a straggler.
-		const memberCalls = new Set<string>();
-		const memberResults = new Set<string>();
-		for (const b of members) {
-			if (!b.callId) continue;
-			if (b.kind === "tool_call") memberCalls.add(b.callId);
-			else if (b.kind === "tool_result") memberResults.add(b.callId);
-		}
-		const balanced = (b: Block): boolean => {
-			if (b.kind === "tool_call") return !b.callId || memberResults.has(b.callId);
-			if (b.kind === "tool_result") return !b.callId || memberCalls.has(b.callId);
-			return true;
-		};
-		// Removal is per MESSAGE: a message collapses only if ALL its member blocks are
-		// balanced (so a message holding an unbalanced tool_call stays whole/live).
+		// Group member blocks by their message key — removal is per MESSAGE (a group never splits
+		// an assistant message's parts), so the fixpoint reasons about whole messages.
 		const byMsg = new Map<string, Block[]>();
 		for (const b of members) {
 			const k = messageKey(b.id);
@@ -728,18 +764,76 @@ export class AccordionStore {
 			if (arr) arr.push(b);
 			else byMsg.set(k, [b]);
 		}
-		const removable = new Set<string>(); // message keys that collapse
-		for (const [k, msgBlocks] of byMsg) if (msgBlocks.every(balanced)) removable.add(k);
+		// Map preserves insertion order → these are the message keys in member/conversation order.
+		const msgOrder = [...byMsg.keys()];
+		// Per-message tool-pair callIds (mirror of mapping.ts `messageInfo`): a message's `calls`
+		// are its tool_call callIds, its `results` the tool_result callIds it emits.
+		const msgCalls = new Map<string, string[]>();
+		const msgResults = new Map<string, string[]>();
+		for (const k of msgOrder) {
+			const calls: string[] = [];
+			const results: string[] = [];
+			for (const b of byMsg.get(k)!) {
+				if (!b.callId) continue;
+				if (b.kind === "tool_call") calls.push(b.callId);
+				else if (b.kind === "tool_result") results.push(b.callId);
+			}
+			msgCalls.set(k, calls);
+			msgResults.set(k, results);
+		}
+		// Initial removable set: every member message EXCEPT those the wire would never remove.
+		// In a LIVE session a message holding a POSITIONAL (non-durable) id stays live on the wire
+		// (computeGroupOps/applyPlan strip non-durable ids → the message isn't group-removable), so
+		// it starts as a straggler here too — the view mirrors the wire (issue #13). In demo/loaded
+		// sessions there is no wire, so the view stays durability-agnostic and collapses through it.
+		const live = this.wireAttached;
+		const removable = new Set<string>();
+		for (const k of msgOrder) {
+			const msgBlocks = byMsg.get(k)!;
+			if (live && msgBlocks.some((b) => !isDurableId(b.id))) continue; // #13: non-durable → straggler on the wire
+			removable.add(k);
+		}
+		// Fixpoint cascade (mirror of applyPlan Phase A): keep a removal only if its tool pairs are
+		// fully inside the removal set. Repeat to a fixpoint (demoting one message can orphan a
+		// partner in another, which must then be demoted too).
+		let changed = true;
+		do {
+			changed = false;
+			const calls = new Set<string>();
+			const results = new Set<string>();
+			for (const k of msgOrder) {
+				if (!removable.has(k)) continue;
+				for (const c of msgCalls.get(k)!) calls.add(c);
+				for (const c of msgResults.get(k)!) results.add(c);
+			}
+			for (const k of msgOrder) {
+				if (!removable.has(k)) continue;
+				const unbalanced = msgCalls.get(k)!.some((c) => !results.has(c)) || msgResults.get(k)!.some((c) => !calls.has(c));
+				if (unbalanced) {
+					removable.delete(k); // straggler: a tool-pair half is outside → keep this message live
+					changed = true;
+				}
+			}
+		} while (changed);
 		const collapsed = new Set<string>();
 		const stragglers = new Set<string>();
 		const collapsedMembers: Block[] = [];
+		// Maximal contiguous runs of collapsed members (in member order), split by any straggler —
+		// the same run boundaries the wire's Phase B uses to insert one summary per run.
+		const collapsedRuns: Block[][] = [];
+		let run: Block[] | null = null;
 		for (const b of members) {
 			if (removable.has(messageKey(b.id))) {
 				collapsed.add(b.id);
 				collapsedMembers.push(b);
-			} else stragglers.add(b.id);
+				if (run) run.push(b);
+				else collapsedRuns.push((run = [b]));
+			} else {
+				stragglers.add(b.id);
+				run = null; // a straggler breaks the run
+			}
 		}
-		return { members, collapsedMembers, collapsed, stragglers, carrier: collapsedMembers[0]?.id ?? null };
+		return { members, collapsedMembers, collapsed, stragglers, carrier: collapsedMembers[0]?.id ?? null, collapsedRuns };
 	}
 
 	/**
@@ -1429,7 +1523,7 @@ export class AccordionStore {
 		for (const b of this.groupMembers(g)) n += b.tokens;
 		return n;
 	}
-	/** What the group costs live: folded → one summary (+ any straggler full); open → members' own eff. */
+	/** What the group costs live: folded → one summary PER run (+ any straggler full); open → members' own eff. */
 	groupLiveTokens(g: Group): number {
 		if (!g.folded) {
 			let n = 0;
@@ -1437,20 +1531,11 @@ export class AccordionStore {
 			return n;
 		}
 		const c = this.classifyGroup(g);
-		// Drop group: the carrier contributes 0 (no wire message inserted).
-		// Custom-digest group: the carrier contributes the literal summary's token cost.
-		// Default recap group: carrier contributes the group digest tokens (unchanged).
-		let carrierTokens = 0;
-		if (c.carrier) {
-			if (this.isDropGroup(g)) {
-				carrierTokens = 0;
-			} else if (typeof g.digest === "string" && g.digest) {
-				carrierTokens = estTokens(g.digest) + BLOCK_OVERHEAD;
-			} else {
-				carrierTokens = groupDigestTokens(g, c.collapsedMembers);
-			}
-		}
-		let n = carrierTokens;
+		// The wire inserts ONE summary message per contiguous collapsed RUN (a straggler in the
+		// middle of the group splits the collapsed members into multiple runs). So the live cost is
+		// (run count × one summary) + every straggler's full tokens. For a drop group summaryTok is
+		// 0, so the run count is irrelevant (stays 0). One run (or none) reduces to the old behavior.
+		let n = c.collapsedRuns.length * this.groupSummaryTok(g, c);
 		for (const id of c.stragglers) n += this.get(id)?.tokens ?? 0;
 		return n;
 	}

--- a/app/src/lib/live/group.crossvalidate.test.ts
+++ b/app/src/lib/live/group.crossvalidate.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect } from "vitest";
+import { applyPlan, linearize, wireToBlock, type PiMessage } from "./mapping";
+import { computeFoldOps, computeGroupOps } from "./plan";
+import { AccordionStore } from "../engine/store.svelte";
+import type { ParsedSession } from "../engine/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CROSS-VALIDATION — the engine VIEW must mirror the WIRE byte-for-byte.
+//
+// The cardinal invariant (CLAUDE.md): the GUI's claimed savings must equal what
+// the agent's context actually changes by. The engine keeps a re-implementation
+// of the wire's group-collapse algorithm (classifyGroup / groupLiveTokens) and it
+// had drifted in two ways (PR #66) plus a residual in live sessions (issue #13):
+//   1. a SINGLE-PASS removable set (vs. the wire's message-level fixpoint cascade)
+//      → wrongly collapsed a parallel-tool-call group the wire leaves whole;
+//   2. ONE summary charged per group (vs. the wire's one summary PER contiguous run)
+//      → undercounted live tokens when an interior straggler split the group;
+//   3. (#13) durability-AGNOSTIC collapse in a LIVE session: a non-durable-id
+//      interior member is collapsed-through by the view, but the wire (computeGroupOps
+//      → applyPlan) strips it, keeping that message live and splitting the run around it.
+//      The view over-counted savings the agent never received. Fixed by making
+//      classifyGroup durability-aware when `wireAttached` is true.
+//
+// These tests build the SAME source as both a `PiMessage[]` (the wire's input) and
+// an `AccordionStore` (the engine's view) — by linearizing the messages into wire
+// blocks and converting them to engine blocks, the durable ids are IDENTICAL on
+// both sides. We then assert the engine's claimed group savings EQUALS the wire's
+// measured token delta after `applyPlan`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Total estimated tokens of a message array, measured exactly as the engine/wire do. */
+function wireTokens(messages: PiMessage[]): number {
+	return linearize(messages).reduce((n, b) => n + b.tokens, 0);
+}
+
+/** Build an AccordionStore whose blocks share the EXACT durable ids `linearize(messages)` emits. */
+function storeFrom(messages: PiMessage[]): AccordionStore {
+	const blocks = linearize(messages).map(wireToBlock);
+	const parsed: ParsedSession = { meta: { format: "pi", title: "t", cwd: "", model: "" }, blocks, lineCount: 0, skipped: 0 };
+	const s = new AccordionStore(parsed);
+	s.detach(); // no conductor — isolate pure group behavior (no auto-folds to confound the delta)
+	s.setBudget(1_000_000); // never auto-fold under budget pressure
+	s.setProtect(0); // disable the protected tail — every block is groupable
+	return s;
+}
+
+/** Apply the engine's CURRENT plan (folds + groups) to the messages and measure the wire delta. */
+function wireDelta(store: AccordionStore, messages: PiMessage[]): number {
+	const before = wireTokens(messages);
+	const after = wireTokens(applyPlan(messages, computeFoldOps(store), computeGroupOps(store)));
+	return before - after;
+}
+
+describe("group accounting cross-validates against the wire (applyPlan)", () => {
+	// One assistant message with ONE tool call + its result. Grouping the whole turn is the
+	// clean, no-straggler case: the wire collapses both messages into one summary.
+	function oneCall(): PiMessage[] {
+		return [
+			{ role: "user", content: "u0 " + "x".repeat(40), timestamp: 1000 }, // m0 u:1000
+			{
+				role: "assistant",
+				responseId: "resp_a",
+				timestamp: 1001,
+				content: [
+					{ type: "text", text: "reading " + "y".repeat(200) },
+					{ type: "toolCall", id: "call_1", name: "read", arguments: { path: "a.ts" } },
+				],
+			}, // m1 a:resp_a:p0 (text), a:resp_a:p1 (call_1)
+			{ role: "toolResult", toolCallId: "call_1", toolName: "read", content: "file body " + "z".repeat(400) }, // m2 r:call_1
+			{ role: "user", content: "u1 newest " + "x".repeat(40), timestamp: 2000 }, // m3 u:2000
+		];
+	}
+
+	it("NO straggler (one run): engine savings == wire delta", () => {
+		const messages = oneCall();
+		const store = storeFrom(messages);
+		// group the assistant message + its tool result — balanced, nothing straggles.
+		const g = store.createGroup("a:resp_a:p0", "r:call_1")!;
+		expect(g).not.toBeNull();
+		expect(store.groupStragglerCount(g)).toBe(0);
+		const delta = wireDelta(store, messages);
+		expect(store.groupSavedTokens(g)).toBe(delta);
+		// and the global view agrees (only this group folded)
+		expect(store.savedTokens).toBe(delta);
+	});
+
+	// A LEADING straggler: a tool_result whose call is OUTSIDE the group sits at the FRONT,
+	// then a clean collapsible tail. One contiguous run after the straggler.
+	function leadingStraggler(): PiMessage[] {
+		return [
+			{ role: "user", content: "u0 " + "x".repeat(40), timestamp: 1000 }, // m0 u:1000
+			{
+				role: "assistant",
+				responseId: "resp_a",
+				timestamp: 1001,
+				content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+			}, // m1 a:resp_a:p0 (call_1) — OUTSIDE the group below
+			{ role: "toolResult", toolCallId: "call_1", toolName: "read", content: "body " + "z".repeat(300) }, // m2 r:call_1 — group starts here (straggler)
+			{ role: "user", content: "u1 " + "x".repeat(80), timestamp: 2000 }, // m3 u:2000 — collapses
+			{ role: "assistant", responseId: "resp_b", timestamp: 2001, content: [{ type: "text", text: "ok " + "y".repeat(200) }] }, // m4 a:resp_b:p0 — collapses
+			{ role: "user", content: "u2 newest", timestamp: 3000 }, // m5 u:3000
+		];
+	}
+
+	it("LEADING straggler (one run): engine savings == wire delta", () => {
+		const messages = leadingStraggler();
+		const store = storeFrom(messages);
+		// group r:call_1 .. a:resp_b:p0 — r:call_1's CALL (m1) is OUTSIDE → straggler; u:2000+resp_b collapse.
+		const g = store.createGroup("r:call_1", "a:resp_b:p0")!;
+		expect(g).not.toBeNull();
+		expect(store.groupStragglerCount(g)).toBe(1);
+		const delta = wireDelta(store, messages);
+		expect(store.groupSavedTokens(g)).toBe(delta);
+		expect(store.savedTokens).toBe(delta);
+	});
+
+	// A TRAILING straggler: a clean collapsible head, then a tool_call whose result is OUTSIDE
+	// at the END. One contiguous run before the straggler.
+	function trailingStraggler(): PiMessage[] {
+		return [
+			{ role: "user", content: "u0 " + "x".repeat(80), timestamp: 1000 }, // m0 u:1000 — collapses
+			{ role: "assistant", responseId: "resp_a", timestamp: 1001, content: [{ type: "text", text: "thinking " + "y".repeat(200) }] }, // m1 a:resp_a:p0 — collapses
+			{
+				role: "assistant",
+				responseId: "resp_b",
+				timestamp: 1002,
+				content: [{ type: "toolCall", id: "call_2", name: "edit", arguments: {} }],
+			}, // m2 a:resp_b:p0 (call_2) — its result m3 is OUTSIDE → straggler
+			{ role: "toolResult", toolCallId: "call_2", toolName: "edit", content: "done " + "z".repeat(300) }, // m3 r:call_2 — OUTSIDE the group
+			{ role: "user", content: "u1 newest", timestamp: 2000 }, // m4 u:2000
+		];
+	}
+
+	it("TRAILING straggler (one run): engine savings == wire delta", () => {
+		const messages = trailingStraggler();
+		const store = storeFrom(messages);
+		// group u:1000 .. a:resp_b:p0 — resp_b holds call_2 whose result is OUTSIDE → straggler; u:1000+resp_a collapse.
+		const g = store.createGroup("u:1000", "a:resp_b:p0")!;
+		expect(g).not.toBeNull();
+		expect(store.groupStragglerCount(g)).toBe(1);
+		const delta = wireDelta(store, messages);
+		expect(store.groupSavedTokens(g)).toBe(delta);
+		expect(store.savedTokens).toBe(delta);
+	});
+
+	// An INTERIOR straggler: collapsible head, a straggler in the MIDDLE, collapsible tail.
+	// This SPLITS the group into TWO contiguous runs → the wire inserts TWO summaries. The old
+	// engine charged ONE summary total and overstated savings by (runs-1) × summaryTok.
+	function interiorStraggler(): PiMessage[] {
+		return [
+			{ role: "user", content: "u0 " + "x".repeat(80), timestamp: 1000 }, // m0 u:1000 — run 1
+			{ role: "assistant", responseId: "resp_a", timestamp: 1001, content: [{ type: "text", text: "head " + "y".repeat(200) }] }, // m1 a:resp_a:p0 — run 1
+			{
+				role: "assistant",
+				responseId: "resp_b",
+				timestamp: 1002,
+				content: [{ type: "toolCall", id: "call_2", name: "edit", arguments: {} }],
+			}, // m2 a:resp_b:p0 (call_2) — its result m5 is OUTSIDE → interior straggler (splits the runs)
+			{ role: "user", content: "u1 " + "x".repeat(80), timestamp: 2000 }, // m3 u:2000 — run 2
+			{ role: "assistant", responseId: "resp_c", timestamp: 2001, content: [{ type: "text", text: "tail " + "y".repeat(200) }] }, // m4 a:resp_c:p0 — run 2
+			{ role: "toolResult", toolCallId: "call_2", toolName: "edit", content: "done " + "z".repeat(300) }, // m5 r:call_2 — OUTSIDE the group below
+			{ role: "user", content: "u2 newest", timestamp: 3000 }, // m6 u:3000
+		];
+	}
+
+	it("INTERIOR straggler (TWO runs): engine now charges TWO summaries == wire delta", () => {
+		const messages = interiorStraggler();
+		const store = storeFrom(messages);
+		// group u:1000 .. a:resp_c:p0 — m2 (call_2, result outside) is an interior straggler that
+		// splits the collapse into {u:1000, resp_a} and {u:2000, resp_c} → TWO summary messages.
+		const g = store.createGroup("u:1000", "a:resp_c:p0")!;
+		expect(g).not.toBeNull();
+		expect(store.groupStragglerCount(g)).toBe(1);
+		// The crux: the wire's delta reflects TWO inserted summaries; the engine must agree.
+		const delta = wireDelta(store, messages);
+		expect(store.groupSavedTokens(g)).toBe(delta);
+		expect(store.savedTokens).toBe(delta);
+		// And confirm the wire actually inserted two summary messages (sanity on the test fixture).
+		const out = applyPlan(messages, computeFoldOps(store), computeGroupOps(store));
+		const summary = computeGroupOps(store)[0].summaryText!;
+		const summaryCount = out.filter((m) => Array.isArray(m.content) && (m.content as any[])[0]?.text === summary).length;
+		expect(summaryCount).toBe(2);
+	});
+
+	// PARALLEL tool calls in ONE assistant message: c1, c2. The group includes c1's RESULT but
+	// NOT c2's result. The wire's fixpoint cascade: the assistant message can't be removed (c2's
+	// result is outside) → so c1's call stays → so c1's result can't be removed either → NOTHING
+	// collapses. The single-pass engine wrongly collapsed c1's result and counted savings.
+	function parallelCalls(): PiMessage[] {
+		return [
+			{ role: "user", content: "u0 " + "x".repeat(40), timestamp: 1000 }, // m0 u:1000
+			{
+				role: "assistant",
+				responseId: "resp_a",
+				timestamp: 1001,
+				content: [
+					{ type: "toolCall", id: "call_1", name: "read", arguments: { path: "a.ts" } },
+					{ type: "toolCall", id: "call_2", name: "read", arguments: { path: "b.ts" } },
+				],
+			}, // m1 a:resp_a:p0 (call_1), a:resp_a:p1 (call_2)
+			{ role: "toolResult", toolCallId: "call_1", toolName: "read", content: "body1 " + "z".repeat(400) }, // m2 r:call_1 — INSIDE the group
+			{ role: "toolResult", toolCallId: "call_2", toolName: "read", content: "body2 " + "z".repeat(400) }, // m3 r:call_2 — OUTSIDE the group
+			{ role: "user", content: "u1 newest", timestamp: 2000 }, // m4 u:2000
+		];
+	}
+
+	it("PARALLEL calls, one result outside: engine and wire AGREE — NOTHING collapses, 0 saved", () => {
+		const messages = parallelCalls();
+		const store = storeFrom(messages);
+		// Try to group the assistant message + ONLY call_1's result. createGroup must REFUSE it
+		// (cascade collapses nothing → carrier null → a group that does nothing is not created).
+		const g = store.createGroup("a:resp_a:p0", "r:call_1");
+		expect(g).toBeNull();
+		expect(store.groups.length).toBe(0);
+		// The engine view shows 0 saved, and the wire likewise leaves the messages untouched.
+		expect(store.savedTokens).toBe(0);
+		expect(wireDelta(store, messages)).toBe(0);
+		// Even if the group is FORCED into the store (bypassing createGroup's guard), the engine's
+		// classifyGroup cascade still collapses nothing → 0 saved, matching the wire exactly.
+		store.groups = [{ id: "g:a:resp_a:p0", memberIds: ["a:resp_a:p0", "a:resp_a:p1", "r:call_1"], folded: true, by: "auto" }];
+		expect(store.groupSavedTokens(store.groups[0])).toBe(0);
+		expect(store.savedTokens).toBe(0);
+		expect(wireDelta(store, messages)).toBe(0);
+		// applyPlan returns the messages structurally unchanged (identity).
+		expect(wireTokens(applyPlan(messages, [], computeGroupOps(store)))).toBe(wireTokens(messages));
+	});
+
+	// A DROP group (summaryText null / digest null) with an INTERIOR straggler: both summaries
+	// cost 0, so run-count is irrelevant — the saved tokens are just the collapsed full tokens,
+	// and the engine must match the wire (which removes the runs and inserts nothing).
+	it("DROP group with interior straggler: carrier cost 0 both sides, engine == wire", () => {
+		const messages = interiorStraggler();
+		const store = storeFrom(messages);
+		// Force a DROP group (digest null) over the same interior-straggler range.
+		store.groups = [
+			{
+				id: "g:u:1000",
+				memberIds: ["u:1000", "a:resp_a:p0", "a:resp_b:p0", "u:2000", "a:resp_c:p0"],
+				folded: true,
+				by: "auto",
+				digest: null,
+			},
+		];
+		const g = store.groups[0];
+		expect(store.isDropGroup(g)).toBe(true);
+		// Two runs, but drop summaries cost 0 → run count does not change the answer.
+		expect(store.groupStragglerCount(g)).toBe(1);
+		const delta = wireDelta(store, messages);
+		expect(store.groupSavedTokens(g)).toBe(delta);
+		expect(store.savedTokens).toBe(delta);
+	});
+
+	// ─────────────────────────────────────────────────────────────────────────
+	// ISSUE #13 — the residual PR #66 deferred: a group with a NON-DURABLE-ID interior
+	// member in a LIVE session. The wire (computeGroupOps → applyPlan) strips non-durable ids,
+	// so that message stays live and SPLITS the collapsed run around it. Before this fix the
+	// engine, being durability-agnostic, collapsed THROUGH it — over-counting savings. Now
+	// `classifyGroup` is durability-aware when `wireAttached` is true, mirroring the wire.
+	// ─────────────────────────────────────────────────────────────────────────
+
+	// A clean collapsible head (u:1000 + resp_a), then a user message with NO timestamp (→ a
+	// POSITIONAL id `m2:u`, non-durable) sitting in the MIDDLE, then a clean collapsible tail
+	// (resp_b). The non-durable interior message splits the group into TWO runs on the wire.
+	function nonDurableInteriorMember(): PiMessage[] {
+		return [
+			{ role: "user", content: "u0 " + "x".repeat(80), timestamp: 1000 }, // m0 u:1000 — run 1
+			{ role: "assistant", responseId: "resp_a", timestamp: 1001, content: [{ type: "text", text: "head " + "y".repeat(200) }] }, // m1 a:resp_a:p0 — run 1
+			{ role: "user", content: "anchorless " + "x".repeat(80) }, // m2 m2:u — NON-DURABLE (no timestamp) → interior straggler in LIVE
+			{ role: "assistant", responseId: "resp_b", timestamp: 2001, content: [{ type: "text", text: "tail " + "y".repeat(200) }] }, // m3 a:resp_b:p0 — run 2
+			{ role: "user", content: "u2 newest", timestamp: 3000 }, // m4 u:3000
+		];
+	}
+
+	it("#13 LIVE: non-durable interior member splits the run — engine mirrors wire", () => {
+		const messages = nonDurableInteriorMember();
+		const store = storeFrom(messages);
+		store.wireAttached = true; // a live pi wire is attached → view must mirror the wire
+
+		// The interior member m2:u is non-durable → on the wire it stays live and splits the
+		// collapse into {u:1000, resp_a} and {resp_b} → TWO summary messages.
+		store.groups = [
+			{
+				id: "g:u:1000",
+				memberIds: ["u:1000", "a:resp_a:p0", "m2:u", "a:resp_b:p0"],
+				folded: true,
+				by: "auto",
+			},
+		];
+		const g = store.groups[0];
+		// The non-durable member is a straggler in the live view (mirrors the wire).
+		expect(store.groupStragglerCount(g)).toBe(1);
+		const delta = wireDelta(store, messages);
+		expect(store.groupSavedTokens(g)).toBe(delta);
+		expect(store.savedTokens).toBe(delta);
+		// And the wire really did insert TWO summary messages (the run is split around m2:u).
+		const out = applyPlan(messages, computeFoldOps(store), computeGroupOps(store));
+		const summary = computeGroupOps(store)[0].summaryText!;
+		const summaryCount = out.filter((m) => Array.isArray(m.content) && (m.content as any[])[0]?.text === summary).length;
+		expect(summaryCount).toBe(2);
+	});
+
+	it("#13 LIVE: non-durable-only members collapse NOTHING — engine == wire (0 saved)", () => {
+		// Every member of this group is non-durable (positional ids). The wire strips them all
+		// → computeGroupOps emits no memberIds → nothing collapses → 0 saved. The live engine
+		// view must agree (every member is a straggler → carrier null → 0 saved).
+		const messages: PiMessage[] = [
+			{ role: "user", content: "a " + "x".repeat(80) }, // m0 m0:u — non-durable
+			{ role: "assistant", content: [{ type: "text", text: "b " + "y".repeat(80) }] }, // m1 m1:p0 — non-durable
+		];
+		const store = storeFrom(messages);
+		store.wireAttached = true;
+		store.groups = [{ id: "g:m0:u", memberIds: ["m0:u", "m1:p0"], folded: true, by: "auto" }];
+		expect(store.groupSavedTokens(store.groups[0])).toBe(0);
+		expect(store.savedTokens).toBe(0);
+		expect(wireDelta(store, messages)).toBe(0);
+		// The wire emits no group op at all (all memberIds stripped) → messages unchanged.
+		expect(wireTokens(applyPlan(messages, [], computeGroupOps(store)))).toBe(wireTokens(messages));
+	});
+
+	it("#13 DEMO: same non-durable interior member stays AGNOSTIC (NOT live) — previews logical collapse", () => {
+		// The SAME fixture as the live case, but `wireAttached` is false (demo / loaded session:
+		// no model receives anything, so the issue explicitly permits durability-agnostic collapse).
+		// Here the engine collapses THROUGH the non-durable member → ONE run / ONE summary,
+		// showing the logical grouping (this is the accepted "non-durable folds preview in demo"
+		// behavior the issue references). There is NO wire delta to match in a demo, so this only
+		// asserts the demo behavior is unchanged: a single collapsed run (one carrier), 0 stragglers.
+		const messages = nonDurableInteriorMember();
+		const store = storeFrom(messages);
+		// wireAttached stays false (demo).
+		store.groups = [
+			{
+				id: "g:u:1000",
+				memberIds: ["u:1000", "a:resp_a:p0", "m2:u", "a:resp_b:p0"],
+				folded: true,
+				by: "auto",
+			},
+		];
+		const g = store.groups[0];
+		// Demo is durability-agnostic → m2:u collapses too → no straggler, one contiguous run.
+		expect(store.groupStragglerCount(g)).toBe(0);
+		// Savings are positive (the whole range collapsed into one summary).
+		expect(store.groupSavedTokens(g)).toBeGreaterThan(0);
+	});
+});

--- a/app/src/lib/live/liveClient.svelte.ts
+++ b/app/src/lib/live/liveClient.svelte.ts
@@ -245,6 +245,7 @@ export function connectLive(port: number = DEFAULT_PORT): void {
 			// Cleared on disconnect/close so `host.can("complete")` returns false when
 			// there is no active model link.
 			session.store.completer = sendCompletion;
+			session.store.wireAttached = true; // live wire up → view mirrors the wire (issue #13)
 			if (typeof msg.meta.contextWindow === "number" && msg.meta.contextWindow > 0) {
 				session.store.setContextWindow(msg.meta.contextWindow);
 				session.store.setBudget(msg.meta.contextWindow);
@@ -272,6 +273,7 @@ export function connectLive(port: number = DEFAULT_PORT): void {
 				// Re-attach the completer: a structural reset builds a brand-new store object,
 				// so the reference from the hello path is gone. The socket is still live.
 				session.store.completer = sendCompletion;
+				session.store.wireAttached = true; // socket still live after structural reset (issue #13)
 			}
 			// Update contextWindow from the sync (refreshed each context hook, and pushed
 			// immediately on a `/model` swap). Snap the budget to the window the FIRST time
@@ -413,6 +415,7 @@ export function connectLive(port: number = DEFAULT_PORT): void {
 			// disconnected. Drain any pending completion promises with a disconnection error
 			// so they do not hang indefinitely.
 			if (session.store) session.store.completer = null;
+			if (session.store) session.store.wireAttached = false; // wire down → durability-agnostic view (issue #13)
 			drainPendingCompletions("disconnected");
 			if (!manualClose && live.status !== "error") {
 				live.status = "idle";
@@ -434,6 +437,7 @@ export function disconnectLive(): void {
 	// fire asynchronously; running it here ensures the completer is unavailable the
 	// moment the caller's disconnectLive() returns.
 	if (session.store) session.store.completer = null;
+	if (session.store) session.store.wireAttached = false; // closing → no wire (issue #13)
 	drainPendingCompletions("disconnected");
 	if (socket) {
 		try {


### PR DESCRIPTION
## Summary

Fixes #13 — group-collapse token accounting drifts on non-durable-id interior members in live sessions.

In a live session, the view-side `classifyGroup` was deliberately durability-agnostic: it collapsed *through* a non-durable-id interior member and charged token savings the agent never receives. On the wire, `computeGroupOps`/`applyPlan` strip non-durable ids — that message stays live and splits the collapsed run around it. So the budget readout was inflated and a block shown as compressed in the UI was actually held full by the agent, breaking the cardinal invariant that **the GUI mirrors exactly what the agent receives**.

### Changes
- `classifyGroup` now runs the **same message-level fixpoint** the wire runs in `applyPlan` Phase A, and — **only when a live wire is attached** (`store.wireAttached`) — treats a message containing a non-durable id as a straggler, splitting the collapsed run exactly as the wire does. Demo / loaded sessions keep the durability-agnostic logical collapse (no wire is involved), as the issue explicitly permits.
- Token accounting now charges **one summary message per contiguous collapsed run** (`collapsedRuns`) instead of one carrier total, matching `applyPlan` Phase B (a mid-group straggler produces multiple summaries on the wire).
- `liveClient` sets `store.wireAttached = true` on hello/sync and clears it on disconnect/close, alongside `completer`.
- New `app/src/lib/live/group.crossvalidate.test.ts` cross-validates the view's group token accounting directly against the wire output.

This is a clean extraction of the engine + test fix only — no README or asset changes.

#### Test plan
- [x] `npm run check` — 0 errors / 0 warnings
- [x] `npm run test` — 797 passed (788 prior + 9 new cross-validation tests), golden builtin/Keel tests unchanged
- [x] `node extension/smoke.mjs` — passes

Generated with [Devin](https://devin.ai)
