### PR TITLE
Improve responsive layout and increase text scale

### DIFF
--- a/app/src/app.css
+++ b/app/src/app.css
@@ -69,11 +69,11 @@
 	--sp-7: 48px; --sp-8: 64px; /* NEW (brand) */
 
 	/* ===== Type scale (NEW) ===== */
-	/* --fs-2xs (9px) is a deliberate floor for decorative micro-labels only
+	/* --fs-2xs is a deliberate floor for decorative micro-labels only
 	   (badges, the WEIGHT legend, the vertical token rail) — not body/UI text. */
-	--fs-2xs: 9px;
-	--fs-xs: 11px; --fs-sm: 12px; --fs-base: 13px;
-	--fs-md: 14px; --fs-lg: 16px; --fs-xl: 19px; --fs-2xl: 24px;
+	--fs-2xs: 10px;
+	--fs-xs: 12px; --fs-sm: 13px; --fs-base: 14px;
+	--fs-md: 15px; --fs-lg: 17px; --fs-xl: 20px; --fs-2xl: 26px;
 
 	/* ===== Elevation — consistent, dark-tuned (NEW) ===== */
 	--shadow-1: 0 1px 2px rgba(0,0,0,.4);
@@ -113,7 +113,7 @@ body {
 	background: var(--bg);
 	color: var(--text);
 	font-family: var(--sans);
-	font-size: 14px;
+	font-size: var(--fs-base);
 	line-height: 1.45;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;

--- a/app/src/lib/ui/map/ContextMap.svelte
+++ b/app/src/lib/ui/map/ContextMap.svelte
@@ -1194,6 +1194,8 @@
 		display: flex;
 		align-items: center;
 		gap: var(--sp-3);
+		row-gap: var(--sp-2);
+		flex-wrap: wrap;
 		padding: var(--sp-2) var(--sp-4);
 		background: var(--panel);
 		border-bottom: 1px solid var(--line-soft);
@@ -1206,6 +1208,9 @@
 		position: relative;
 		z-index: 2;
 	}
+	.toolbar > * {
+		min-width: 0;
+	}
 	/* subtle vertical divider between toolbar clusters */
 	.tb-divider {
 		width: 1px;
@@ -1214,7 +1219,8 @@
 		flex: 0 0 auto;
 	}
 	.grow {
-		flex: 1;
+		flex: 1 1 24px;
+		min-width: 24px;
 	}
 	.count {
 		font-size: var(--fs-xs);
@@ -1228,6 +1234,7 @@
 		display: inline-flex;
 		align-items: center;
 		gap: var(--sp-2);
+		flex: 0 1 auto;
 	}
 	.tlbl {
 		font-family: var(--mono);
@@ -1241,7 +1248,10 @@
 		display: inline-flex;
 		align-items: center;
 		gap: var(--sp-2);
+		row-gap: 5px;
 		min-width: 0;
+		flex: 1 1 310px;
+		flex-wrap: wrap;
 	}
 	.kind-pair {
 		display: inline-flex;
@@ -1337,6 +1347,7 @@
 		display: inline-flex;
 		align-items: center;
 		gap: var(--sp-3);
+		flex: 0 0 auto;
 	}
 	.sw-pair {
 		display: inline-flex;
@@ -1377,6 +1388,7 @@
 		border: 1px solid var(--line);
 		border-radius: var(--radius-sm);
 		overflow: hidden;
+		flex: 0 0 auto;
 	}
 	.density button {
 		display: flex;
@@ -1417,6 +1429,9 @@
 		display: inline-flex;
 		align-items: center;
 		gap: var(--sp-2);
+		row-gap: 5px;
+		flex-wrap: wrap;
+		min-width: 0;
 	}
 	/* Counter chip: pill shape, group-accent (smoke) family, signals "forming a new object". */
 	.range-chip {
@@ -2003,5 +2018,53 @@
 		color: var(--muted);
 		background: var(--panel-2);
 		border-color: var(--line);
+	}
+
+	@media (max-width: 820px) {
+		.toolbar {
+			gap: var(--sp-2);
+			padding: var(--sp-2) var(--sp-3);
+		}
+		.tb-divider {
+			display: none;
+		}
+		.grow {
+			display: none;
+		}
+		.kinds {
+			flex-basis: 100%;
+			order: 5;
+		}
+		.legend {
+			margin-left: auto;
+		}
+		.stage,
+		.stage.isgrid {
+			padding: var(--sp-2);
+		}
+	}
+
+	@media (max-width: 560px) {
+		.toolbar {
+			align-items: flex-start;
+		}
+		.tiers,
+		.legend,
+		.density,
+		.range-bar {
+			flex-basis: 100%;
+		}
+		.legend {
+			margin-left: 0;
+		}
+		.density button {
+			flex: 1 1 0;
+		}
+		.density-readout {
+			flex: 1 1 42px;
+		}
+		.transcript {
+			max-width: 100%;
+		}
 	}
 </style>

--- a/app/src/lib/ui/map/MapHeader.svelte
+++ b/app/src/lib/ui/map/MapHeader.svelte
@@ -369,6 +369,8 @@
 		display: flex;
 		align-items: flex-start;
 		gap: var(--sp-4);
+		flex-wrap: wrap;
+		min-width: 0;
 	}
 
 	/* ── Nums cluster — the brand data device ── */
@@ -392,7 +394,7 @@
 		font-weight: 600;
 		color: var(--text);
 		line-height: 1;
-		letter-spacing: -0.01em;
+		letter-spacing: 0;
 		transition: color var(--dur-fast) var(--ease-out);
 	}
 	.hero-stat.over {
@@ -418,8 +420,12 @@
 		margin-left: auto;
 		display: flex;
 		align-items: center;
-		gap: var(--sp-4);
-		flex: 0 0 auto;
+		justify-content: flex-end;
+		gap: var(--sp-3);
+		row-gap: var(--sp-2);
+		flex: 1 1 520px;
+		min-width: 0;
+		flex-wrap: wrap;
 	}
 
 	/* Eyebrow shared by every control field — mono, uppercase, wide tracking, faint. */
@@ -448,6 +454,7 @@
 		flex-direction: column;
 		gap: 5px;
 		cursor: default;
+		min-width: 0;
 	}
 
 	/* Read-only badge — mono eyebrow chip */
@@ -539,7 +546,7 @@
 
 	/* ── Slider knob ── */
 	.knob input[type="range"] {
-		width: 120px;
+		width: clamp(92px, 16vw, 150px);
 		height: 4px;
 		accent-color: var(--accent);
 		margin: 0;
@@ -612,6 +619,9 @@
 		border-radius: var(--radius-pill);
 		padding: 2px 6px;
 	}
+	.reset-btn {
+		white-space: nowrap;
+	}
 
 	/* Protect readout (the dial lives on the bar) */
 	.protect-read {
@@ -683,6 +693,7 @@
 		display: flex;
 		flex-direction: column;
 		gap: 5px;
+		min-width: 0;
 	}
 
 	/* Budget headroom: slack between usage and the ceiling */
@@ -849,5 +860,39 @@
 		background: var(--text);
 		border-radius: 50%;
 		box-shadow: 0 0 0 1px var(--panel-2);
+	}
+
+	@media (max-width: 920px) {
+		.hdr {
+			padding: var(--sp-3);
+		}
+		.top {
+			gap: var(--sp-3);
+		}
+		.ctl {
+			margin-left: 0;
+			justify-content: flex-start;
+			flex-basis: 100%;
+		}
+		.hero-line {
+			flex-wrap: wrap;
+			row-gap: 3px;
+		}
+	}
+
+	@media (max-width: 560px) {
+		.ctl {
+			align-items: stretch;
+		}
+		.fold-arm,
+		.reset-btn {
+			justify-content: center;
+		}
+		.knob {
+			flex: 1 1 180px;
+		}
+		.knob input[type="range"] {
+			width: 100%;
+		}
 	}
 </style>

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -428,11 +428,13 @@
 		align-items: center;
 		gap: var(--sp-3);
 		padding: 0 var(--sp-5);
-		height: 44px;
+		min-height: 44px;
 		border-bottom: 1px solid var(--line-soft);
 		background: var(--panel);
 		box-shadow: var(--shadow-1);
 		flex: 0 0 auto;
+		flex-wrap: wrap;
+		row-gap: var(--sp-2);
 	}
 	/* Smoky spectrum hairline along the bottom edge — brand spectrum kept low-key:
 	   1px tall, 20% opacity, faded at both ends so it's a wash, never a hard rainbow bar. */
@@ -467,7 +469,7 @@
 		font-size: var(--fs-md);
 		font-weight: 700;
 		color: var(--text);
-		letter-spacing: -0.02em;
+		letter-spacing: 0;
 		line-height: 1;
 	}
 
@@ -572,7 +574,8 @@
 		display: flex;
 		align-items: center;
 		gap: var(--sp-1);
-		flex: 0 0 auto;
+		flex: 0 1 auto;
+		min-width: 0;
 	}
 	.meta-chip {
 		font-size: var(--fs-xs);
@@ -592,6 +595,7 @@
 		align-items: center;
 		gap: var(--sp-2);
 		flex: 0 0 auto;
+		flex-wrap: wrap;
 	}
 	.nav-btn {
 		display: inline-flex;
@@ -642,6 +646,40 @@
 		min-width: 0;
 		min-height: 0;
 		overflow: hidden;
+	}
+
+	@media (max-width: 980px) {
+		.topbar {
+			padding: var(--sp-2) var(--sp-3);
+		}
+		.meta-row {
+			order: 5;
+			flex-basis: 100%;
+		}
+		.main.open,
+		.main.activity,
+		.main.open.activity {
+			grid-template-columns: minmax(0, 1fr);
+		}
+	}
+
+	@media (max-width: 620px) {
+		.topbar {
+			align-items: flex-start;
+		}
+		.brand {
+			flex-basis: 100%;
+		}
+		.session-cluster {
+			flex-basis: 100%;
+		}
+		.nav-row {
+			flex-basis: 100%;
+		}
+		.nav-btn {
+			flex: 1 1 140px;
+			justify-content: center;
+		}
 	}
 
 	/* ── Fallback / empty state ───────────────────────────────── */
@@ -701,7 +739,7 @@
 		font-size: var(--fs-xl);
 		font-weight: 700;
 		color: var(--text);
-		letter-spacing: -0.02em;
+		letter-spacing: 0;
 		line-height: 1;
 	}
 
@@ -712,7 +750,7 @@
 		font-size: clamp(var(--fs-2xl), 4vw, 40px);
 		font-weight: 600;
 		color: var(--text);
-		letter-spacing: -0.02em;
+		letter-spacing: 0;
 		line-height: 1.08;
 		margin: 0;
 	}


### PR DESCRIPTION
## Improve responsive layout and increase text scale

This PR bumps the base font-size scale up one step across the board and adds proper responsive/wrapping behavior to the three main UI surfaces (top bar, map header, context map toolbar) so they hold up on narrower viewports.

### Type scale bump (`app/src/app.css`)
- Raises every step of the `--fs-*` type scale by ~1px (e.g. `--fs-base` 13→14px, `--fs-lg` 16→17px, `--fs-2xl` 24→26px). The `--fs-2xs` floor moves 9→10px.
- `body` font-size now references `var(--fs-base)` instead of a hardcoded `14px`, so the scale is single-sourced.
- Drops the inline "9px" comment artifact.

### Responsive layout
- **`+page.svelte` (top bar):** switches the bar from a fixed `height: 44px` to `min-height` + `flex-wrap` so it can wrap gracefully. Adds `@media (max-width: 980px)` and `(max-width: 620px)` breakpoints that collapse the meta row, brand, session cluster, and nav onto their own lines and stack the main grid to a single column.
- **`MapHeader.svelte`:** makes the controls cluster wrap (`flex: 1 1 520px`) instead of being pinned to one line, fluidly clamps the slider width (`clamp(92px, 16vw, 150px)`), and adds 920px / 560px breakpoints.
- **`ContextMap.svelte` (toolbar):** adds `flex-wrap` + `row-gap` to the toolbar and its sub-clusters (kinds, range-bar, etc.), gives children `min-width: 0` to prevent overflow, and adds 820px / 560px breakpoints that hide dividers/spacers and reflow the kind legend.

### Cleanup
- Removes negative `letter-spacing` on several headings (brand title, hero stat, fallback title) in favor of `0`.
- Adds `white-space: nowrap` to the reset button so it doesn't break mid-label.

### Files changed
- `app/src/app.css`
- `app/src/lib/ui/map/ContextMap.svelte`
- `app/src/lib/ui/map/MapHeader.svelte`
- `app/src/routes/+page.svelte`

Closes #7