### PR TITLE
docs(readme): point quick start at npm package, add npm README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,28 +137,19 @@ groups, no replay. That's the build ahead.
 
 ### Part 1 — Browser (no Rust, no desktop app)
 
-The fastest path. The pi extension HTTP-serves Accordion in your browser — no Rust, no
-desktop app needed. Single session only.
+The fastest path. `pi install` the published package and the pi extension HTTP-serves
+Accordion in your browser — no clone, no build, no Rust. Single session only.
 
-**1. Clone, build the browser UI, and install the extension:**
+**1. Install the package:**
 
 ```bash
-git clone https://github.com/a-Fig/accordion.git
-cd accordion
-npm install --prefix app && npm run build --prefix app   # builds the static browser bundle (app/build)
-cd extension && npm install                              # the pi extension that serves it
+pi install npm:@a-fig/accordion
 ```
 
-> The extension serves the UI from `app/build` (produced by `npm run build` above).
-> Without that build, `/accordion` opens to a "No browser build found" page.
+This adds `npm:@a-fig/accordion` to `~/.pi/agent/settings.json` (the extension, the
+browser UI, and the `unfold` / `recall` skills are all in the package).
 
-**2. Register it with pi** — add to `~/.pi/agent/settings.json`:
-
-```json
-{ "extensions": ["<absolute-path-to-repo>/extension/accordion.ts"] }
-```
-
-**3. Run pi in any project, then open Accordion in your browser:**
+**2. Restart pi**, then in any project run:
 
 ```bash
 /accordion   # prints the local URL and opens it
@@ -166,6 +157,9 @@ cd extension && npm install                              # the pi extension that
 
 That's it. The page auto-connects to the running session. Folding is **off by default**;
 flip the **Folding** toggle in the header to start steering what the agent sees.
+
+> To try it without writing to settings, use `pi -e npm:@a-fig/accordion` (installs to a
+> temporary directory for the current run only).
 
 ---
 
@@ -187,7 +181,7 @@ git clone https://github.com/a-Fig/accordion.git
 cd accordion/app && npm install
 ```
 
-**2. Register the extension with pi** — same as above, in `~/.pi/agent/settings.json`:
+**2. Register the extension with pi** — add to `~/.pi/agent/settings.json`:
 
 ```json
 { "extensions": ["<absolute-path-to-repo>/extension/accordion.ts"] }

--- a/README.md
+++ b/README.md
@@ -137,33 +137,14 @@ groups, no replay. That's the build ahead.
 
 ### Part 1 — Browser (no Rust, no desktop app)
 
-The fastest path. `pi install` the published package and the pi extension HTTP-serves
-Accordion in your browser — no clone, no build, no Rust. Single session only.
-
-**1. Install the package:**
-
 ```bash
 pi install npm:@a-fig/accordion
 ```
-
-This adds `npm:@a-fig/accordion` to `~/.pi/agent/settings.json` (the extension, the
-browser UI, and the `unfold` / `recall` skills are all in the package).
-
-**2. Restart pi**, then in any project run:
-
-```bash
-/accordion   # prints the local URL and opens it
-```
-
-That's it. The page auto-connects to the running session. Folding is **off by default**;
-flip the **Folding** toggle in the header to start steering what the agent sees.
-
-> To try it without writing to settings, use `pi -e npm:@a-fig/accordion` (installs to a
-> temporary directory for the current run only).
+That's it, assuming you have [pi](https://github.com/earendil-works/pi)
 
 ---
 
-### Part 2 — Desktop app (full feature set)
+### Part 2 — Desktop app (Optional - full feature set)
 
 The desktop app adds **multi-session discovery** (switch between running pi sessions from
 a sidebar), conductors that require local model resources, and the `/accordion` command

--- a/extension/README.md
+++ b/extension/README.md
@@ -1,0 +1,108 @@
+<div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/a-Fig/Accordion/main/docs/assets/logo-lockup-white.png">
+  <img alt="Accordion" src="https://raw.githubusercontent.com/a-Fig/Accordion/main/docs/assets/logo-lockup-black.png" width="440">
+</picture>
+
+### /compact is the naive solution. Accordion is the intelligent one.
+
+**See everything your AI agent holds in context — and fold it like an accordion instead.**
+
+<img src="https://raw.githubusercontent.com/a-Fig/Accordion/main/docs/assets/accordion-hero.gif" alt="Accordion — the context map demo: blocks folding and unfolding while the protected tail stays intact" width="820">
+
+</div>
+
+---
+
+Accordion is a [pi](https://github.com/earendil-works/pi) extension that shows you your
+agent's entire context window at a glance and lets you manage it — manually or with
+intelligence through a **conductor**.
+
+This package ships the **pi extension** (the live link that streams context and applies
+your fold plan) plus a **browser-served UI**, so you can run Accordion with `pi install`
+alone — no Rust, no desktop app required.
+
+## Install
+
+```bash
+pi install npm:@a-fig/accordion
+```
+
+That adds the package to `~/.pi/agent/settings.json`. Restart pi, then in any project:
+
+```bash
+/accordion
+```
+
+The extension HTTP-serves the Accordion UI on a local ephemeral port and prints the URL
+(also opens it). The page auto-connects to the running session. Folding is **off by
+default** — flip the **Folding** toggle in the header to start steering what the agent
+sees.
+
+> **Single session, browser only.** This package serves the UI in your browser for the
+> current pi session. For multi-session discovery, conductors that need local model
+> resources, and the native window, build the
+> [desktop app](https://github.com/a-Fig/Accordion) from source.
+
+## How it works
+
+The **context Map** is the whole window at a glance: one square per block, sized by token
+weight (a dice face, 1–6), colored by kind — **user** messages, **assistant** responses,
+**thinking**, **tool calls**, and **tool results** each get their own hue. Bright = live;
+recessed and hatched = folded.
+
+Three hands share the controls:
+
+- **You** — fold, unfold, pin, and peek by hand. Your overrides always win.
+- **The agent** — reaches back to unfold or pin context it needs mid-task, or **recall**
+  a folded block as a tool result (like `read_file`) without changing what's standing in
+  context.
+- **The Conductor** — an automatic strategy that, between turns, folds what's gone cold
+  and unfolds what's becoming relevant. Collaborative by default; an *exclusive*
+  conductor you approve can take over specific controls, and **detach** is always your
+  kill switch.
+
+Every block is **Full**, **Folded** (shown as a short tagged summary), or **Pinned**
+(locked open). Folds are **content substitution, never removal** — provider-safe and
+fully reversible. The most recent ~20k tokens are a **protected working tail** the agent
+reasons over at full fidelity.
+
+<div align="center">
+<img src="https://raw.githubusercontent.com/a-Fig/Accordion/main/docs/assets/attention-conductor.png" alt="Attention conductor view — each block tinted by how much the working tail still attends back to it" width="600">
+</div>
+
+## Skills included
+
+This package registers two pi skills the agent uses to interact with folded context:
+
+- **accordion-context-folding** — the `unfold` tool: restore a folded block into standing
+  context (sticky, attributed to the agent).
+- **accordion-context-recall** — the `recall` tool: read a folded block's full content as
+  a tool result *without* mutating the view, like `read_file`. Never lockable.
+
+## What works today
+
+- ✅ Browser-served UI — no desktop app required
+- ✅ Live link to a running pi session
+- ✅ Opt-in live steering — apply your fold plan to what the agent is shown
+- ✅ Reversible, provider-safe folding with deterministic `{#code FOLDED}` digests
+- ✅ Agent-driven unfold + `recall`, involvement locks
+- ✅ The Conductor — automatic fold/unfold between turns
+- ✅ LLM-generated summaries, computed once and cached
+
+## Links
+
+- **Source & full docs:** [github.com/a-Fig/Accordion](https://github.com/a-Fig/Accordion)
+- **Vision:** [VISION.md](https://github.com/a-Fig/Accordion/blob/main/VISION.md)
+- **pi (the harness):** [github.com/earendil-works/pi](https://github.com/earendil-works/pi)
+
+---
+
+<div align="center">
+
+🏆 &nbsp;Built at the **AI Hackathon 2026 @ UC Berkeley** — a winning project.
+
+🪗
+
+</div>

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@a-fig/accordion",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Accordion live link — a pi extension that streams context to the Accordion GUI and applies the fold plan the GUI returns.",
   "keywords": ["pi-package"],
@@ -16,7 +16,8 @@
   "files": [
     "accordion.js",
     "dist",
-    "skills"
+    "skills",
+    "README.md"
   ],
   "dependencies": {
     "ws": "^8.18.0"


### PR DESCRIPTION
## What

Updates the Quick start instructions to lead with the now-published npm package, and adds a dedicated README for the npm tarball.

## Why

`@a-fig/accordion@0.1.1` is live on npm. The root README's browser quick start still told users to clone the repo, build `app/`, install extension deps, and register a local-path extension — all unnecessary now that `pi install npm:@a-fig/accordion` ships the extension, browser UI, and skills in one package.

## Changes

- **`README.md`** — Quick start Part 1 (Browser) now leads with `pi install npm:@a-fig/accordion` + restart + `/accordion`. Adds a `pi -e` try-without-installing note. Part 2 (Desktop app) keeps the clone-and-build-from-source flow (still required for multi-session discovery / native window).
- **`extension/README.md`** (new) — the npm package README. Uses absolute `raw.githubusercontent.com` image URLs (with `main` branch ref) so the logo/hero/conductor images render on npmjs.com instead of broken relative links. Covers install, how it works, the two included skills, and links back to the source repo.
- **`extension/package.json`** — bump to `0.1.1` and add `README.md` to the `files` whitelist, matching what is published on npm (`@a-fig/accordion@0.1.1`).

## Notes

- The npm package (`0.1.1`) was already published with this README; this PR lands the source-of-truth changes in the repo so they stay in sync.
- Image URLs point at the `main` branch — they'll resolve once `devmain` next promotes to `main`. Until then they 404 on npm (cosmetic only; text renders fine).