### PR TITLE
chore(extension): guard package publishing

### DIFF
--- a/extension/build-client.mjs
+++ b/extension/build-client.mjs
@@ -9,7 +9,8 @@
  * resolveClientRoot() probes). This script produces that copy.
  *
  * Run: node ./build-client.mjs   (or `npm run build:client`)
- * Prereq: run `npm run build` in ../app first so app/build exists.
+ * Prereq when called directly: run `npm run build` in ../app first so app/build exists.
+ * The package-level `npm run build` / `npm pack` path runs that app build for you.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";

--- a/extension/package.json
+++ b/extension/package.json
@@ -5,9 +5,11 @@
   "description": "Accordion live link — a pi extension that streams context to the Accordion GUI and applies the fold plan the GUI returns.",
   "keywords": ["pi-package"],
   "scripts": {
+    "build:app": "npm --prefix ../app run build",
     "build:extension": "node ./build-extension.mjs",
     "build:client": "node ./build-client.mjs",
-    "build": "npm run build:client && npm run build:extension",
+    "build": "npm run build:app && npm run build:client && npm run build:extension",
+    "prepack": "npm run build && npm run smoke",
     "smoke": "node smoke.mjs"
   },
   "pi": {


### PR DESCRIPTION
## Summary
- add a package `prepack` guard that builds the app, vendors the browser bundle, bundles the extension, and runs smoke before npm creates a tarball
- make `extension`'s top-level build script build `../app` first so `dist/client` is fresh
- update the `build-client` comment to document direct-use prerequisites

## Verification
- `cd extension && npm pack --dry-run` (ran `prepack`: app build, client copy, extension bundle, smoke; tarball included `accordion.js`, `dist/client`, skills, and README)