### PR TITLE
fix(map): remove flicker when resizing the window

### DIFF
--- a/app/src/lib/ui/map/ContextMap.svelte
+++ b/app/src/lib/ui/map/ContextMap.svelte
@@ -297,19 +297,35 @@
 		cols = Math.max(4, Math.floor((W + GAP) / (c + GAP)));
 		cell = c;
 	}
+	// Coalesce fit() into a single rAF. A window-drag fires the ResizeObserver
+	// dozens of times per second; each direct fit() re-reads layout (forced
+	// reflow) and rewrites `cell`/`cols`, which resizes + clears every canvas.
+	// Batching to one fit per animation frame removes the reflow storm and the
+	// intermediate-size jitter that reads as flicker.
+	let fitRaf: ReturnType<typeof requestAnimationFrame> | null = null;
+	function scheduleFit() {
+		if (fitRaf !== null) return;
+		fitRaf = requestAnimationFrame(() => {
+			fitRaf = null;
+			fit();
+		});
+	}
 	$effect(() => {
 		if (!stage) return;
-		const ro = new ResizeObserver(() => fit());
+		const ro = new ResizeObserver(() => scheduleFit());
 		ro.observe(stage);
-		fit();
-		return () => ro.disconnect();
+		fit(); // first paint: immediate so the grid is sized before the first frame
+		return () => {
+			ro.disconnect();
+			if (fitRaf !== null) cancelAnimationFrame(fitRaf);
+		};
 	});
 	$effect(() => {
 		// refit when these change
 		void view;
 		void nudge;
 		void count;
-		fit();
+		scheduleFit();
 	});
 
 	// Track the protected boundary so a departing block leaves a hole instead of

--- a/app/src/lib/ui/map/TileCanvas.svelte
+++ b/app/src/lib/ui/map/TileCanvas.svelte
@@ -486,7 +486,15 @@
 		void geo; // depend on geometry changes
 		if (canvas) {
 			resizeCanvas();
-			scheduleRedraw();
+			// Redraw SYNCHRONOUSLY, not via scheduleRedraw(). Setting
+			// canvas.width/height (in resizeCanvas) clears the backing store to
+			// transparent; deferring the repaint to the next animation frame leaves
+			// a blank frame on every resize tick -- visible as flicker while the
+			// window is being dragged. Drawing right now keeps the old -> new
+			// transition atomic. A pending scheduled/partial rAF is harmless: the
+			// scheduled full redraw just re-paints identically, and a pending
+			// partial snapshots an already-empty dirty set.
+			redraw();
 		}
 	});
 


### PR DESCRIPTION
Closes #9.

## Problem

Dragging the window caused visible flicker across the context-map grid.

Two root causes:

1. **Reflow storm.** `ContextMap.fit()` ran synchronously inside the `ResizeObserver` callback. A window drag fires that observer dozens of times per second; each call force-reads layout (reflow), rewrites `cell`/`cols`, and resizes + clears every canvas — producing intermediate-size jitter.
2. **Blank-frame flicker.** In `TileCanvas`, the geometry-change effect called `resizeCanvas()` (which sets `canvas.width`/`canvas.height`, clearing the backing store to transparent) and then deferred the repaint to the next animation frame via `scheduleRedraw()`. That left one blank frame on every resize tick.

## Fix

- **`ContextMap.svelte`** — coalesce `fit()` into a single `requestAnimationFrame` (`scheduleFit()`). The `ResizeObserver` and the view/nudge/count refit effect now route through it, so at most one re-layout happens per frame. The first paint still calls `fit()` immediately so the grid is sized before the first frame; the pending rAF is cancelled on teardown.
- **`TileCanvas.svelte`** — in the geometry-change effect, redraw synchronously (`redraw()`) right after `resizeCanvas()` instead of scheduling. The old → new size transition is now atomic, so the canvas is never left cleared between backing-store resize and repaint. A pending scheduled/partial rAF is harmless (a scheduled full redraw just re-paints identically; a partial snapshots an already-empty dirty set).

## Verification

- `npx svelte-check` — 0 errors / 0 warnings
- `npm run test` — 797 passed (40 files)
- UI verified by resizing the window: grid stays painted throughout the drag with no blank frames.

## Follow-up

A third source of flicker — the per-canvas ResizeObserver in `TileCanvas` firing dozens of times per second and triggering a stack of sync redraws — is addressed separately in [#39](https://github.com/a-Fig/Accordion/pull/39).
