### PR TITLE
docs(readme): fix Part 2 desktop-app setup (duplicate-extension conflict + tauri dev vs build)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,32 +154,81 @@ The desktop app adds **multi-session discovery** (switch between running pi sess
 a sidebar), conductors that require local model resources, and the `/accordion` command
 that foregrounds the right session automatically. It requires Node 20+ and Rust.
 
+> **Don't double-register the extension.** Part 1's `pi install npm:@a-fig/accordion`
+> already registered the extension (the `/accordion` command, the `unfold`/`recall`
+> tools, and the skills all come from the npm package). That same extension is what the
+> local `extension/accordion.ts` builds into. **Adding `extension/accordion.ts` to
+> `extensions` while the npm package is still installed loads it twice** — a duplicate
+> `/accordion` command, duplicate tool registration, and a duplicate context hook. Pick
+> **one** of the two paths below; don't do both.
+
 **Prerequisites:** install [Node 20 LTS](https://nodejs.org) and
 [Rust via rustup](https://rustup.rs), then follow the one-time platform setup at
 **https://v2.tauri.app/start/prerequisites/** (WebView2 + MSVC on Windows, Xcode CLT on
 macOS).
 
-**1. Clone and install:**
+#### Path A — Place a built binary (recommended; keeps the npm package)
+
+`/accordion` launches a **pre-built binary** from disk — it does not connect to a dev
+server. So all you need is a built `app` binary in one of the locations the extension
+scans. If you already ran Part 1, this is the only step: no `settings.json` edit, no
+duplicate extension.
 
 ```bash
 git clone https://github.com/a-Fig/accordion.git
 cd accordion/app && npm install
+npm run tauri build -- --no-bundle   # builds target/release/app(.exe); --no-bundle
+                                     # skips the slower MSI/NSIS/.dmg installers
 ```
 
-**2. Register the extension with pi** — add to `~/.pi/agent/settings.json`:
+Then drop the binary where the extension looks for an installed bundle:
+
+| OS | Path |
+|---|---|
+| **Windows** | `%LOCALAPPDATA%\Programs\Accordion\Accordion.exe` |
+| **macOS** | `/Applications/Accordion.app` |
+| **Linux** | `~/.local/share/Accordion/accordion` |
+
+(Without an installed bundle, `/accordion` falls back to the repo build outputs
+`app/src-tauri/target/release/app` then `…/debug/app`.) Run `/accordion` in any pi
+session and it launches (or focuses, via single-instance) the desktop app on that session.
+
+#### Path B — Register the local extension (for extension development)
+
+Only choose this if you'll edit the extension itself. Remove the npm package first, then
+point pi at your checkout instead. From `~/.pi/agent/settings.json`, drop
+`"npm:@a-fig/accordion"` from `packages` and add to `extensions`:
 
 ```json
 { "extensions": ["<absolute-path-to-repo>/extension/accordion.ts"] }
 ```
 
-**3. Launch the desktop app:**
+The extension has its own runtime deps, so install them too:
+
+```bash
+cd accordion/extension && npm install
+```
+
+#### Run the app + live session
 
 ```bash
 npm run tauri dev   # opens the native window; hot-reloads on save
 ```
 
-**4. Run pi in any project.** It appears in Accordion's **Sessions** sidebar within ~1s.
-Click it (or run `/accordion` in that terminal) and its context populates live.
+> `npm run tauri dev` is a Vite dev server for UI iteration. It is **not** what
+> `/accordion` connects to — `/accordion` always launches a built binary
+> (`target/release/app`). To produce that binary, run
+> `npm run tauri build -- --no-bundle`. Both `npm run dev` and `npm run tauri dev` want
+> **port 1420**; run only one at a time.
+
+Run pi in any project. It advertises itself in `~/.accordion/sessions/` and appears in
+Accordion's **Sessions** sidebar within ~1s. Click it (or run `/accordion` in that
+terminal) and its context populates live. Folding is preview-only by default; use the
+header's **Folding** toggle to opt in to steering the live agent's context.
+
+To refresh the binary after `main` moves (close any open Accordion window first so the
+file isn't locked, then `git pull`, `npm install`, and rebuild): see
+**[CONTRIBUTING.md](CONTRIBUTING.md)**.
 
 ## Contributing
 


### PR DESCRIPTION
## Problem

The Quick Start **Part 2 — Desktop app** instructions are incorrect for anyone who already ran Part 1 (`pi install npm:@a-fig/accordion`). Following them verbatim caused real breakage in a fresh setup:

1. **Duplicate-extension conflict (the main one).** Part 1 already registers the extension via the npm package manifest (`\"pi\": { \"extensions\": [\"./accordion.js\"] }`). The published `accordion.js` *is* the built form of `extension/accordion.ts` — it registers the same `/accordion` command, the same `unfold`/`recall` tools, and the same skills. Part 2 step 2 unconditionally told users to add `extension/accordion.ts` to `extensions`, **loading the extension twice** → duplicate `/accordion` command, duplicate tool registration, duplicate context hook. No warning that the two are mutually exclusive.

2. **`npm run tauri dev` isn't what `/accordion` launches.** `/accordion` launches a **pre-built binary** from disk (`resolveAccordionApp` scans installed bundles then repo `target/{release,debug}/app`); it never connects to the dev server. The old step 3 implied `tauri dev` was how you get the app for `/accordion`. This contradicts CONTRIBUTING.md §5, which already states *"`/accordion` does not run a dev server — it launches a pre-built binary."*

3. **Missing `npm install` in `extension/`.** The extension has runtime deps (`ws`, `typebox`); registering `extension/accordion.ts` without installing them fails to load. CONTRIBUTING §2 notes this; README omitted it.

## Fix

Rewrites the Part 2 section:

- **Callout** up front: don't double-register; the npm-package extension and the local `extension/accordion.ts` are mutually exclusive.
- **Path A (recommended, keeps the npm package):** `npm run tauri build -- --no-bundle`, then drop the binary at the install path the extension already scans (`%LOCALAPPDATA%\Programs\Accordion\Accordion.exe` on Windows, `/Applications/Accordion.app` on macOS, `~/.local/share/Accordion/accordion` on Linux). No `settings.json` edit, no duplicate. This placement option was already supported by `resolveAccordionApp` but undocumented.
- **Path B (extension development):** remove the npm package, register `extension/accordion.ts`, and `npm install` in `extension/` too.
- **Clarifies** `npm run tauri dev` is a Vite dev server for UI iteration; `/accordion` launches a built binary — run `npm run tauri build -- --no-bundle` to produce it. Notes the port-1420 constraint.
- Points to CONTRIBUTING.md for the binary-refresh workflow.

Docs-only change; no code touched.

## Verification

Cross-checked the published `@a-fig/accordion@0.1.2` `accordion.js` (registers `/accordion` at the command hook, `unfold`/`recall` tools, and `resolveAccordionApp` with `windowsInstallCandidates`/`repoAppCandidates`) against `extension/accordion.ts`. Reproduced the duplicate-load conflict during a real setup; the placement path in Path A is the one that resolved it.