### PR TITLE
feat(extension): allow binding 0.0.0.0 + custom port (#42)

### DIFF
--- a/app/src/lib/live/liveClient.svelte.ts
+++ b/app/src/lib/live/liveClient.svelte.ts
@@ -179,19 +179,26 @@ async function sendCompletion(req: CompletionRequest): Promise<CompletionResult>
 	});
 }
 
-export function connectLive(port: number = DEFAULT_PORT): void {
+export function connectLive(port: number = DEFAULT_PORT, opts: { host?: string; token?: string } = {}): void {
 	if (typeof window === "undefined" || typeof WebSocket === "undefined") return;
 	cancelPendingLoad(); // invalidate any pending file/CC load that would otherwise clobber the live store
 	disconnectLive(); // drop any prior socket
 	manualClose = false;
+	// Host defaults to loopback (the desktop app is always co-located with pi). In
+	// browser-served mode the caller passes window.location.hostname so a remote
+	// browser reaches a 0.0.0.0-bound session. The token — only needed when dialing
+	// off-loopback — is forwarded on the WS URL; the browser-served page already has
+	// it in its own URL (?token=…), so the user never types it.
+	const host = opts.host ?? "127.0.0.1";
+	const tokenQs = opts.token ? `/?token=${encodeURIComponent(opts.token)}` : "";
 	live.status = "connecting";
-	live.detail = `ws://127.0.0.1:${port}`;
+	live.detail = `ws://${host}:${port}`;
 	live.sessionId = null;
 	session.error = "";
 
 	let ws: WebSocket;
 	try {
-		ws = new WebSocket(`ws://127.0.0.1:${port}`);
+		ws = new WebSocket(`ws://${host}:${port}${tokenQs}`);
 	} catch (e) {
 		live.status = "error";
 		live.detail = e instanceof Error ? e.message : String(e);

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -138,15 +138,17 @@
 	// Browser-served mode is single-session: the extension that served this page hosts the
 	// live WS on the SAME origin port. This is the "way back" to the live session — e.g.
 	// after viewing the Demo — since the browser has no multi-session discovery to pick from.
-	// The per-session token the browser-served page carries (?token=… or the
-	// accordion_token cookie). Forwarded on the WS upgrade so an off-loopback
-	// (0.0.0.0-bound) session can be steered from a remote browser safely.
+	// Forward the per-session token (when present in the page URL ?token=…) on the
+	// WS upgrade so an off-loopback (0.0.0.0-bound) session can be steered from a
+	// remote browser. NOTE: the accordion_token cookie is HttpOnly, so JS cannot read
+	// it here — that is deliberate. On a reload without ?token=…, readServedToken()
+	// returns null and the WS URL carries no token, but the browser still sends the
+	// HttpOnly cookie on the same-origin WS upgrade and the extension's verifyWsUpgrade
+	// accepts that cookie (mirroring isWebAuthed). So the cookie fallback lives on the
+	// server side of the upgrade, not in JS.
 	function readServedToken(): string | null {
 		if (typeof window === "undefined") return null;
-		const q = new URLSearchParams(window.location.search).get("token");
-		if (q) return q;
-		const m = typeof document.cookie === "string" ? document.cookie.match(/accordion_token=([0-9a-f]+)/) : null;
-		return m ? m[1] : null;
+		return new URLSearchParams(window.location.search).get("token");
 	}
 
 	function reconnectServed(): void {

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -138,10 +138,21 @@
 	// Browser-served mode is single-session: the extension that served this page hosts the
 	// live WS on the SAME origin port. This is the "way back" to the live session — e.g.
 	// after viewing the Demo — since the browser has no multi-session discovery to pick from.
+	// The per-session token the browser-served page carries (?token=… or the
+	// accordion_token cookie). Forwarded on the WS upgrade so an off-loopback
+	// (0.0.0.0-bound) session can be steered from a remote browser safely.
+	function readServedToken(): string | null {
+		if (typeof window === "undefined") return null;
+		const q = new URLSearchParams(window.location.search).get("token");
+		if (q) return q;
+		const m = typeof document.cookie === "string" ? document.cookie.match(/accordion_token=([0-9a-f]+)/) : null;
+		return m ? m[1] : null;
+	}
+
 	function reconnectServed(): void {
 		discovery.selected = null;
 		claudeDiscovery.selected = null;
-		connectLive(Number(window.location.port) || DEFAULT_PORT);
+		connectLive(Number(window.location.port) || DEFAULT_PORT, { host: window.location.hostname, token: readServedToken() ?? undefined });
 	}
 
 	// A Claude Code transcript: load it read-only and tail it for appends. There is
@@ -178,7 +189,7 @@
 					browserServed = true;
 					servedSessionId = body.sessionId ?? null;
 					const port = Number(window.location.port) || DEFAULT_PORT;
-					connectLive(port);
+					connectLive(port, { host: window.location.hostname, token: readServedToken() ?? undefined });
 				} catch {
 					// 404, network error, non-JSON — leave browserServed false; manual UI stays.
 				}
@@ -376,7 +387,7 @@
 								<input class="port" type="number" min="1" max="65535" bind:value={manualPort} aria-label="pi port" />
 								<button
 									class="btn-primary"
-									onclick={() => connectLive(manualPort)}
+									onclick={() => connectLive(manualPort, !isTauriEnv ? { host: window.location.hostname, token: readServedToken() ?? undefined } : {})}
 									disabled={live.status === "connecting"}
 								>
 									<Icon name="activity" size={14} />

--- a/extension/README.md
+++ b/extension/README.md
@@ -45,6 +45,23 @@ sees.
 > resources, and the native window, build the
 > [desktop app](https://github.com/a-Fig/Accordion) from source.
 
+### Remote / custom-port binding
+
+By default the live link binds `127.0.0.1` on an OS-assigned ephemeral port, so it is
+only reachable from the same machine. To steer a session running on a remote box (a
+dev server, a container, a GPU host) from your laptop browser, bind a reachable
+interface and optionally a fixed port:
+
+```bash
+ACCORDION_HOST=0.0.0.0 ACCORDION_PORT=8080 pi
+```
+
+or as flags: `--accordion-host=0.0.0.0 --accordion-port=8080`. The `/accordion` status
+line prints the tokenized browser URL (and a remote-friendly hint). Off-loopback
+connections require the per-session token that the browser URL already carries, so a
+port-scanner on the network cannot steer the agent; loopback connections stay
+tokenless, so the desktop app and a same-machine browser are unchanged.
+
 ## How it works
 
 The **context Map** is the whole window at a glance: one square per block, sized by token

--- a/extension/accordion.ts
+++ b/extension/accordion.ts
@@ -649,13 +649,27 @@ export default function accordionLive(pi: ExtensionAPI): void {
 	 * remote reachability safe by default: the token the user already has unlocks
 	 * steering for them, while a port-scanner on the network is refused.
 	 */
+	// The static-file surface (isWebAuthed) accepts the token via query OR the
+	// accordion_token cookie. The WS upgrade must accept the SAME cookie too: the cookie
+	// is HttpOnly (so JS can't read it to forward it on a reconnect without ?token=…),
+	// but the browser auto-sends it on a same-origin WS upgrade, which is the only path
+	// that lets a bookmarked/reloaded browser-served session re-steer off-loopback.
+	function hasAccordionCookie(req: http.IncomingMessage): boolean {
+		const cookie = req.headers["cookie"];
+		return typeof cookie === "string"
+			&& cookie.split(";").some((c) => c.trim() === `accordion_token=${webToken}`);
+	}
+
 	function verifyWsUpgrade(info: { req: http.IncomingMessage }, cb: (res: boolean, code?: number, message?: string) => void): void {
 		const peer = info.req.socket.remoteAddress;
 		if (isLoopbackPeer(peer)) { cb(true); return; }
-		// Off-loopback peer: require the session token on the upgrade URL (?token=…).
+		// Off-loopback peer: require the per-session token. The browser-served page
+		// forwards it on the upgrade URL (?token=…) on first load; on a later reload
+		// without ?token=… the browser still sends the HttpOnly accordion_token cookie,
+		// which we accept here so the same source of truth authorizes both halves.
 		const u = new URL(info.req.url || "/", "http://accordion.local");
 		const token = u.searchParams.get("token");
-		if (webToken && token === webToken) { cb(true); return; }
+		if (webToken && (token === webToken || hasAccordionCookie(info.req))) { cb(true); return; }
 		cb(false, 401, "unauthorized — open Accordion via the /accordion Browser link (it carries the session token)");
 	}
 

--- a/extension/accordion.ts
+++ b/extension/accordion.ts
@@ -73,6 +73,64 @@ const FOCUS_PATH = path.join(REGISTRY_ROOT, FOCUS_FILE);
 const ACCORDION_APP_FLAG = "accordion-app";
 const ACCORDION_APP_ENV = "ACCORDION_APP_PATH";
 
+// Bind knobs (issue #42): the host/interface and port the live link listens on.
+// Defaults keep the original loopback + OS-assigned-ephemeral behavior; setting
+// the host to 0.0.0.0 (or a specific interface) lets a remote browser reach the
+// session. Flag wins over env, which wins over the default — same precedence as
+// the ACCORDION_APP path knob above.
+const ACCORDION_HOST_FLAG = "accordion-host";
+const ACCORDION_HOST_ENV = "ACCORDION_HOST";
+const ACCORDION_PORT_FLAG = "accordion-port";
+const ACCORDION_PORT_ENV = "ACCORDION_PORT";
+
+/** Resolve the bind host: flag -> env -> 127.0.0.1 (loopback, the safe default). */
+function resolveBindHost(pi: ExtensionAPI): string {
+	const flagVal = pi.getFlag(ACCORDION_HOST_FLAG);
+	if (typeof flagVal === "string" && flagVal.trim()) return flagVal.trim();
+	const envVal = process.env[ACCORDION_HOST_ENV];
+	if (typeof envVal === "string" && envVal.trim()) return envVal.trim();
+	return "127.0.0.1";
+}
+
+/** Resolve the bind port: flag -> env -> 0 (OS-assigned ephemeral). Invalid/empty -> 0. */
+function resolveBindPort(pi: ExtensionAPI): number {
+	const flagVal = pi.getFlag(ACCORDION_PORT_FLAG);
+	const raw = (typeof flagVal === "string" ? flagVal : "") || process.env[ACCORDION_PORT_ENV] || "";
+	const n = Number.parseInt(String(raw).trim(), 10);
+	return Number.isFinite(n) && n >= 0 && n <= 65535 ? n : 0;
+}
+
+/** True if a BIND HOST string names only loopback (so off-loopback peers can't reach). */
+function isLoopbackHost(host: string): boolean {
+	const h = host.toLowerCase();
+	return h === "127.0.0.1" || h === "::1" || h === "localhost";
+}
+
+/** True if a socket peer address is loopback (127.0.0.1 / ::1, incl. IPv4-mapped IPv6). */
+function isLoopbackPeer(addr: string | undefined | null): boolean {
+	if (!addr) return false;
+	const a = addr.toLowerCase();
+	// Strip the IPv4-mapped IPv6 prefix so 127.0.0.1 is recognized under dual-stack.
+	const v4 = a.startsWith("::ffff:") ? a.slice(7) : a;
+	return v4 === "127.0.0.1" || v4 === "::1" || v4 === "localhost";
+}
+
+/** Best-effort first non-internal IPv4 from the network interfaces, for the remote hint. */
+function firstLanIp(): string | null {
+	try {
+		const ifaces = os.networkInterfaces();
+		for (const list of Object.values(ifaces)) {
+			if (!list) continue;
+			for (const i of list) {
+				if (i.family === "IPv4" && !i.internal) return i.address;
+			}
+		}
+	} catch {
+		/* best-effort */
+	}
+	return null;
+}
+
 type LaunchSource = "cli" | "env" | "default";
 type LaunchResult =
 	| { ok: true; path: string; source: LaunchSource }
@@ -205,16 +263,27 @@ export default function accordionLive(pi: ExtensionAPI): void {
 		description: "Path to the Accordion desktop app executable for /accordion launch/focus",
 		type: "string",
 	});
+	pi.registerFlag(ACCORDION_HOST_FLAG, {
+		description: "Host/interface the Accordion live link binds (default 127.0.0.1; use 0.0.0.0 to allow remote browsers)",
+		type: "string",
+	});
+	pi.registerFlag(ACCORDION_PORT_FLAG, {
+		description: "Fixed port for the Accordion live link (default 0 = OS-assigned ephemeral)",
+		type: "string",
+	});
 
 	let wss: WebSocketServer | null = null;
 	// The HTTP server that BOTH hosts the WebSocket upgrade AND serves the browser
 	// build of the Accordion app on the same ephemeral port (feat/browser-served-extension).
 	// One server per pi session; closed alongside `wss` at shutdown.
 	let httpServer: http.Server | null = null;
-	// Per-session token gating the HTTP static-file serving ONLY. Generated once when
-	// the server starts. The WS upgrade path stays UNAUTHENTICATED (see startServer's
-	// banner): the desktop Tauri app dials ws://127.0.0.1:<port> with no token and must
-	// keep working unchanged, so the token never guards the WebSocket — only file serving.
+	// Per-session token gating the HTTP static-file surface AND (when bound off-loopback)
+	// the WS upgrade for non-loopback peers. Generated once when the server starts.
+	// A loopback peer (the desktop Tauri app, or a same-machine browser) dials tokenless
+	// and keeps working unchanged; a NON-loopback peer — only reachable when the bind host
+	// is 0.0.0.0 or a specific interface — must present this token on the upgrade. The
+	// browser-served page already carries it in its URL (?token=…), so the real user never
+	// types it; the gate keeps a network port-scanner from steering the agent's context.
 	let webToken = "";
 	let client: WebSocket | null = null; // the GUI (one driver at a time in M1)
 	let sessionId = "";
@@ -571,28 +640,54 @@ export default function accordionLive(pi: ExtensionAPI): void {
 		}
 	}
 
+	/**
+	 * Gate the WS upgrade by peer address. A loopback peer (the desktop app, or a
+	 * same-machine browser) connects tokenless — unchanged from the original design.
+	 * A NON-loopback peer — only reachable when the bind host is 0.0.0.0 or a specific
+	 * interface — must present the per-session `webToken`, which the browser-served page
+	 * already carries in its URL (?token=…) and forwards on the upgrade. This keeps
+	 * remote reachability safe by default: the token the user already has unlocks
+	 * steering for them, while a port-scanner on the network is refused.
+	 */
+	function verifyWsUpgrade(info: { req: http.IncomingMessage }, cb: (res: boolean, code?: number, message?: string) => void): void {
+		const peer = info.req.socket.remoteAddress;
+		if (isLoopbackPeer(peer)) { cb(true); return; }
+		// Off-loopback peer: require the session token on the upgrade URL (?token=…).
+		const u = new URL(info.req.url || "/", "http://accordion.local");
+		const token = u.searchParams.get("token");
+		if (webToken && token === webToken) { cb(true); return; }
+		cb(false, 401, "unauthorized — open Accordion via the /accordion Browser link (it carries the session token)");
+	}
+
 	function startServer(): void {
 		if (wss || httpServer) return;
-		// Per-session token for the HTTP static surface. The WS upgrade is NEVER gated by
-		// it (see the file banner + handleHttp): the desktop app dials the WS tokenless and
-		// must keep working, so authentication lives only on file serving, not the socket.
+		// Per-session token for the HTTP static surface AND (when bound off-loopback) the
+		// WS upgrade for non-loopback peers — see verifyWsUpgrade for the auth split: a
+		// loopback peer (the desktop app, or a same-machine browser) dials tokenless and
+		// must keep working; a NON-loopback peer — only reachable when the bind host is
+		// 0.0.0.0 or a specific interface — must present this token, which the browser-
+		// served page already carries in its URL (?token=…). Without it anyone on the
+		// network could connect to the steering WS and fold/unfold/pin the agent's context.
 		webToken = crypto.randomBytes(16).toString("hex");
+		const bindHost = resolveBindHost(pi);
+		const bindPort = resolveBindPort(pi);
 		try {
-			// One HTTP server hosts BOTH halves on the SAME ephemeral port:
+			// One HTTP server hosts BOTH halves on the SAME port:
 			//   • HTTP GETs → handleHttp (the browser build, token-gated)
-			//   • WS upgrades → the WebSocketServer below (UNAUTHENTICATED, unchanged)
+			//   • WS upgrades → the WebSocketServer below (loopback tokenless;
+			//     off-loopback token-gated via verifyWsUpgrade)
 			// port 0 ⇒ OS assigns a free ephemeral port (one server per pi session).
 			httpServer = http.createServer(handleHttp);
 			// Attach the WS server to the HTTP server (NOT { port: 0 }) so the upgrade
-			// shares the port. `wss.on("connection")` below is byte-for-byte unchanged.
-			wss = new WebSocketServer({ server: httpServer });
+			// shares the port. verifyWsUpgrade gates non-loopback peers (see above).
+			wss = new WebSocketServer({ server: httpServer, verifyClient: verifyWsUpgrade });
 			httpServer.on("error", () => {
 				// e.g. unexpected bind failure — run headless (passthrough).
 				try { httpServer?.close(); } catch { /* ignore */ }
 				httpServer = null;
 				wss = null;
 			});
-			httpServer.listen(0, "127.0.0.1", () => {
+			httpServer.listen(bindPort, bindHost, () => {
 				const addr = httpServer?.address();
 				if (addr && typeof addr === "object") {
 					port = addr.port;
@@ -1105,8 +1200,17 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			// Browser entry point: the extension also serves the web build of Accordion on
 			// the same ephemeral port, gated by a per-session token. Surface the tokenized
 			// URL so the user can open the UI in a browser instead of the desktop app.
-			if (port && webToken) lines.push(`Browser: http://127.0.0.1:${port}/?token=${webToken}`);
-			else lines.push("Browser: starting…");
+			if (port && webToken) {
+				const bh = resolveBindHost(pi);
+				const displayHost = isLoopbackHost(bh) ? "127.0.0.1" : bh;
+				// Keep the token-bearing line FIRST so the smoke regex (token=…) still matches.
+				lines.push(`Browser: http://${displayHost}:${port}/?token=${webToken}`);
+				// When bound off-loopback, surface a remote-friendly hint using the machine's LAN IP.
+				if (!isLoopbackHost(bh)) {
+					const lan = firstLanIp();
+					if (lan) lines.push(`Remote:  http://${lan}:${port}/?token=${webToken}`);
+				}
+			} else lines.push("Browser: starting…");
 			ctx.ui.notify(lines.join("\n"), action.type);
 		},
 	});


### PR DESCRIPTION
Closes #42.

## What

The live link hard-coded `httpServer.listen(0, "127.0.0.1")`, so a pi session running on a remote box (GPU server, dev box, WSL, container) was unreachable from a laptop browser — and the ephemeral port couldn't be pinned. Added two config knobs — `accordion-host`/`ACCORDION_HOST` and `accordion-port`/`ACCORDION_PORT` (flag wins over env) — mirroring the existing `ACCORDION_APP` pattern. Defaults are `127.0.0.1` + `0` (OS-assigned ephemeral): no opt-in, no behavior change.

## Security model (decided upfront)

Binding `0.0.0.0` makes the steering WebSocket reachable off-loopback. Without auth that would let anyone on the network connect and fold/unfold/pin the agent's context — steering isn't a harmless peek, it actively changes what the model sees. So:

- **Loopback peers** (`127.0.0.1` / `::1` / `::ffff:127.0.0.1`) connect **tokenless**, unchanged — the desktop Tauri app and a same-machine browser keep working exactly as today.
- **Non-loopback peers** must present the per-session `webToken` on the WS upgrade URL (`?token=…`). The browser-served page already loads with that token in its URL (and mints an `accordion_token` cookie); the app-side WS client now forwards it on the upgrade, so the real user never types it. The token already gated static-file serving; this extends it to the WS only for off-loopback peers.
- Auth runs in `verifyClient` on the HTTP upgrade path — never on the pi `context`/model-call hook.

Default config (no flags/env set) is byte-for-byte today's behavior. Loopback users hear nothing new; the auth code is dormant since off-loopback peers can't reach a loopback bind.

## Changes

| file | change |
|------|--------|
| `extension/accordion.ts` | +`resolveBindHost`/`resolveBindPort`/`isLoopbackHost`/`isLoopbackPeer`/`firstLanIp`; +2 `registerFlag`; `verifyWsUpgrade` gates non-loopback peers; `listen(bindPort, bindHost)`; refined `webToken` comment; status line reflects real bind host + optional `Remote:` LAN-IP hint (token-bearing line stays first so `/accordion`'s smoke regex still matches) |
| `app/src/lib/live/liveClient.svelte.ts` | `connectLive(port, opts?)` builds `ws://\${host}:\${port}\${tokenQs}`; `live.detail` shows real host (no token leaked) |
| `app/src/routes/+page.svelte` | +`readServedToken()` (URL query → cookie); `reconnectServed`, `onMount` auto-connect, manual-port connect pass `{ host: window.location.hostname, token }` in browser-served mode; desktop discovery stays tokenless loopback |
| `extension/README.md` | +Remote / custom-port binding subsection (factual) |

No registry / `SessionEntry` changes (desktop app is always co-located → loopback; off-loopback is browser-served, host from `window.location.hostname`). No Rust, no brand/CSS.

## Notes / follow-ups

- **No automated test for the off-loopback auth rejection.** The smoke test connects over loopback (tokenless), so it proves the default path is unchanged but does not exercise `verifyWsUpgrade`'s rejection branch. The logic is a small pure function reviewed by reading; a follow-up test binding `0.0.0.0` and dialing a non-loopback peer would harden it.
- The token is forwarded on the WS URL query string. For a future `wss://` (TLS terminator) the token would travel in the URL; acceptable for the current plaintext loopback/VPN model, worth revisiting if TLS is added.
- `Remote:` LAN-IP hint is best-effort and skipped if no non-internal IPv4 is found.

## Verification

- `cd extension && node smoke.mjs` → **SMOKE PASS**
- `cd extension && npm pack --dry-run` → tarball contains `accordion.js`, `dist/client/index.html`, both skill SKILL.md, `README.md`, `package.json`
- `cd app && npm run check` → 0 errors / 0 warnings
- `cd app && npm run test` → 40 files, 797 tests passed