### PR TITLE
feat(#44): show a reduction % on every folded block and group

### DIFF
--- a/app/src/lib/engine/tokens.test.ts
+++ b/app/src/lib/engine/tokens.test.ts
@@ -33,10 +33,16 @@ describe("reductionPct", () => {
 		expect(reductionPct(0, 5)).toBe(0);
 	});
 
-	it("never returns negative even if live exceeds full (defensive)", () => {
-		// A substitution larger than the original should not produce a negative %.
-		// Math.round of a negative fraction is <= 0; the caller renders no tag for <= 0.
-		expect(reductionPct(100, 150)).toBeLessThanOrEqual(0);
+	it("clamps to 0 if live exceeds full (oversized substitution)", () => {
+		// A conductor replacement larger than the original must never render as a
+		// negative "tokens removed" value; clamp to the documented [0, 100] range.
+		expect(reductionPct(100, 150)).toBe(0);
+		expect(reductionPct(100, 101)).toBe(0);
+	});
+
+	it("clamps to 100 (drop group / fully removed)", () => {
+		expect(reductionPct(100, 0)).toBe(100);
+		expect(reductionPct(100, -5)).toBe(100);
 	});
 });
 

--- a/app/src/lib/engine/tokens.test.ts
+++ b/app/src/lib/engine/tokens.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { estTokens, BLOCK_OVERHEAD, clip, firstLine, reductionPct } from "./tokens";
+import { estTokens, BLOCK_OVERHEAD, clip, firstLine, reductionPct, reductionDigit } from "./tokens";
 
 // ---------------------------------------------------------------------------
 // reductionPct — fold aggressiveness as whole-percent of tokens removed
@@ -43,6 +43,32 @@ describe("reductionPct", () => {
 	it("clamps to 100 (drop group / fully removed)", () => {
 		expect(reductionPct(100, 0)).toBe(100);
 		expect(reductionPct(100, -5)).toBe(100);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// reductionDigit — decile bucket (0-9) for the compact on-tile badge
+// ---------------------------------------------------------------------------
+
+describe("reductionDigit", () => {
+	it("drops the ones place and keeps the tens digit", () => {
+		expect(reductionDigit(73)).toBe(7);
+		expect(reductionDigit(40)).toBe(4);
+		expect(reductionDigit(99)).toBe(9);
+	});
+
+	it("floors any 1-9% reduction to 0 (still shown, not hidden)", () => {
+		expect(reductionDigit(1)).toBe(0);
+		expect(reductionDigit(9)).toBe(0);
+	});
+
+	it("floors an exact 0% reduction to 0", () => {
+		expect(reductionDigit(0)).toBe(0);
+	});
+
+	it("clamps a 100% (fully removed) reduction to 9, not 10", () => {
+		expect(reductionDigit(100)).toBe(9);
+		expect(reductionDigit(90)).toBe(9);
 	});
 });
 

--- a/app/src/lib/engine/tokens.test.ts
+++ b/app/src/lib/engine/tokens.test.ts
@@ -1,74 +1,74 @@
 import { describe, it, expect } from "vitest";
-import { estTokens, BLOCK_OVERHEAD, clip, firstLine, reductionPct, reductionDigit } from "./tokens";
+import { estTokens, BLOCK_OVERHEAD, clip, firstLine, remainingPct, remainingDigit } from "./tokens";
 
 // ---------------------------------------------------------------------------
-// reductionPct — fold aggressiveness as whole-percent of tokens removed
+// remainingPct — how much of a fold's original content is still on the wire
 // ---------------------------------------------------------------------------
 
-describe("reductionPct", () => {
-	it("returns the rounded whole-percent of tokens removed", () => {
-		// 1000 full, 250 live -> 750 saved -> 75%
-		expect(reductionPct(1000, 250)).toBe(75);
+describe("remainingPct", () => {
+	it("returns the rounded whole-percent of tokens still live", () => {
+		// 1000 full, 250 live -> 25%
+		expect(remainingPct(1000, 250)).toBe(25);
 	});
 
 	it("rounds to the nearest whole percent", () => {
-		// 1000 full, 333 live -> 667 saved -> 66.7% -> 67%
-		expect(reductionPct(1000, 333)).toBe(67);
-		// 1000 full, 334 live -> 666 saved -> 66.6% -> 67%
-		expect(reductionPct(1000, 334)).toBe(67);
-		// 1000 full, 336 live -> 664 saved -> 66.4% -> 66%
-		expect(reductionPct(1000, 336)).toBe(66);
+		// 1000 full, 333 live -> 33.3% -> 33%
+		expect(remainingPct(1000, 333)).toBe(33);
+		// 1000 full, 334 live -> 33.4% -> 33%
+		expect(remainingPct(1000, 334)).toBe(33);
+		// 1000 full, 336 live -> 33.6% -> 34%
+		expect(remainingPct(1000, 336)).toBe(34);
 	});
 
-	it("returns 100 when everything was removed (drop group / empty digest)", () => {
-		expect(reductionPct(500, 0)).toBe(100);
+	it("returns 0 when everything was removed (drop group / empty digest)", () => {
+		expect(remainingPct(500, 0)).toBe(0);
 	});
 
-	it("returns 0 when nothing was removed (live == full)", () => {
-		expect(reductionPct(500, 500)).toBe(0);
+	it("returns 100 when nothing was removed (live == full)", () => {
+		expect(remainingPct(500, 500)).toBe(100);
 	});
 
-	it("returns 0 for a zero-token block (divide-by-zero guard)", () => {
-		expect(reductionPct(0, 0)).toBe(0);
-		expect(reductionPct(0, 5)).toBe(0);
+	it("returns 100 for a zero-token block (divide-by-zero guard)", () => {
+		expect(remainingPct(0, 0)).toBe(100);
+		expect(remainingPct(0, 5)).toBe(100);
 	});
 
-	it("clamps to 0 if live exceeds full (oversized substitution)", () => {
+	it("clamps to 100 if live exceeds full (oversized substitution)", () => {
 		// A conductor replacement larger than the original must never render as a
-		// negative "tokens removed" value; clamp to the documented [0, 100] range.
-		expect(reductionPct(100, 150)).toBe(0);
-		expect(reductionPct(100, 101)).toBe(0);
+		// >100% remaining value; clamp to the documented [0, 100] range.
+		expect(remainingPct(100, 150)).toBe(100);
+		expect(remainingPct(100, 101)).toBe(100);
 	});
 
-	it("clamps to 100 (drop group / fully removed)", () => {
-		expect(reductionPct(100, 0)).toBe(100);
-		expect(reductionPct(100, -5)).toBe(100);
+	it("clamps to 0 (drop group / fully removed)", () => {
+		expect(remainingPct(100, 0)).toBe(0);
+		expect(remainingPct(100, -5)).toBe(0);
 	});
 });
 
 // ---------------------------------------------------------------------------
-// reductionDigit — decile bucket (0-9) for the compact on-tile badge
+// remainingDigit — decile bucket (0-9) for the compact on-tile badge
 // ---------------------------------------------------------------------------
 
-describe("reductionDigit", () => {
+describe("remainingDigit", () => {
 	it("drops the ones place and keeps the tens digit", () => {
-		expect(reductionDigit(73)).toBe(7);
-		expect(reductionDigit(40)).toBe(4);
-		expect(reductionDigit(99)).toBe(9);
+		expect(remainingDigit(73)).toBe(7);
+		expect(remainingDigit(40)).toBe(4);
+		expect(remainingDigit(99)).toBe(9);
 	});
 
-	it("floors any 1-9% reduction to 0 (still shown, not hidden)", () => {
-		expect(reductionDigit(1)).toBe(0);
-		expect(reductionDigit(9)).toBe(0);
+	it("floors any 1-9% remaining to 0 (still shown — almost nothing left)", () => {
+		expect(remainingDigit(1)).toBe(0);
+		expect(remainingDigit(9)).toBe(0);
 	});
 
-	it("floors an exact 0% reduction to 0", () => {
-		expect(reductionDigit(0)).toBe(0);
+	it("floors an exact 0% remaining to 0", () => {
+		expect(remainingDigit(0)).toBe(0);
 	});
 
-	it("clamps a 100% (fully removed) reduction to 9, not 10", () => {
-		expect(reductionDigit(100)).toBe(9);
-		expect(reductionDigit(90)).toBe(9);
+	it("clamps a 100% (fully intact) value to 9, not 10", () => {
+		expect(remainingDigit(100)).toBe(9);
+		expect(remainingDigit(90)).toBe(9);
 	});
 });
 

--- a/app/src/lib/engine/tokens.test.ts
+++ b/app/src/lib/engine/tokens.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { estTokens, BLOCK_OVERHEAD, clip, firstLine, reductionPct } from "./tokens";
+
+// ---------------------------------------------------------------------------
+// reductionPct — fold aggressiveness as whole-percent of tokens removed
+// ---------------------------------------------------------------------------
+
+describe("reductionPct", () => {
+	it("returns the rounded whole-percent of tokens removed", () => {
+		// 1000 full, 250 live -> 750 saved -> 75%
+		expect(reductionPct(1000, 250)).toBe(75);
+	});
+
+	it("rounds to the nearest whole percent", () => {
+		// 1000 full, 333 live -> 667 saved -> 66.7% -> 67%
+		expect(reductionPct(1000, 333)).toBe(67);
+		// 1000 full, 334 live -> 666 saved -> 66.6% -> 67%
+		expect(reductionPct(1000, 334)).toBe(67);
+		// 1000 full, 336 live -> 664 saved -> 66.4% -> 66%
+		expect(reductionPct(1000, 336)).toBe(66);
+	});
+
+	it("returns 100 when everything was removed (drop group / empty digest)", () => {
+		expect(reductionPct(500, 0)).toBe(100);
+	});
+
+	it("returns 0 when nothing was removed (live == full)", () => {
+		expect(reductionPct(500, 500)).toBe(0);
+	});
+
+	it("returns 0 for a zero-token block (divide-by-zero guard)", () => {
+		expect(reductionPct(0, 0)).toBe(0);
+		expect(reductionPct(0, 5)).toBe(0);
+	});
+
+	it("never returns negative even if live exceeds full (defensive)", () => {
+		// A substitution larger than the original should not produce a negative %.
+		// Math.round of a negative fraction is <= 0; the caller renders no tag for <= 0.
+		expect(reductionPct(100, 150)).toBeLessThanOrEqual(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// estTokens — smoke-check the existing exports still work (regression guard)
+// ---------------------------------------------------------------------------
+
+describe("estTokens (regression)", () => {
+	it("estimates ~4 chars per token with overhead-aware ceil", () => {
+		expect(estTokens("")).toBe(0);
+		expect(estTokens("abcd")).toBe(1);
+		expect(estTokens("abcde")).toBe(2); // ceil(5/4)
+	});
+	it("exports BLOCK_OVERHEAD", () => {
+		expect(BLOCK_OVERHEAD).toBe(4);
+	});
+});
+
+describe("clip / firstLine (regression)", () => {
+	it("clip trims and ellipsizes", () => {
+		expect(clip("hello world", 5)).toBe("hell…");
+		expect(clip("hi", 5)).toBe("hi");
+	});
+	it("firstLine returns the first non-blank line, clipped", () => {
+		expect(firstLine("\n\n  hello world\nsecond", 5)).toBe("hell…");
+	});
+});

--- a/app/src/lib/engine/tokens.test.ts
+++ b/app/src/lib/engine/tokens.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { estTokens, BLOCK_OVERHEAD, clip, firstLine, remainingPct, remainingDigit } from "./tokens";
+import { estTokens, BLOCK_OVERHEAD, clip, firstLine, remainingPct, remainingBand } from "./tokens";
 
 // ---------------------------------------------------------------------------
 // remainingPct — how much of a fold's original content is still on the wire
@@ -47,28 +47,38 @@ describe("remainingPct", () => {
 });
 
 // ---------------------------------------------------------------------------
-// remainingDigit — decile bucket (0-9) for the compact on-tile badge
+// remainingBand — 6-band bucket (0-5) for the on-tile erosion border
 // ---------------------------------------------------------------------------
 
-describe("remainingDigit", () => {
-	it("drops the ones place and keeps the tens digit", () => {
-		expect(remainingDigit(73)).toBe(7);
-		expect(remainingDigit(40)).toBe(4);
-		expect(remainingDigit(99)).toBe(9);
+describe("remainingBand", () => {
+	it("bands >=90% as 5 (full)", () => {
+		expect(remainingBand(100)).toBe(5);
+		expect(remainingBand(90)).toBe(5);
 	});
 
-	it("floors any 1-9% remaining to 0 (still shown — almost nothing left)", () => {
-		expect(remainingDigit(1)).toBe(0);
-		expect(remainingDigit(9)).toBe(0);
+	it("bands 75-89% as 4", () => {
+		expect(remainingBand(89)).toBe(4);
+		expect(remainingBand(75)).toBe(4);
 	});
 
-	it("floors an exact 0% remaining to 0", () => {
-		expect(remainingDigit(0)).toBe(0);
+	it("bands 50-74% as 3", () => {
+		expect(remainingBand(74)).toBe(3);
+		expect(remainingBand(50)).toBe(3);
 	});
 
-	it("clamps a 100% (fully intact) value to 9, not 10", () => {
-		expect(remainingDigit(100)).toBe(9);
-		expect(remainingDigit(90)).toBe(9);
+	it("bands 25-49% as 2", () => {
+		expect(remainingBand(49)).toBe(2);
+		expect(remainingBand(25)).toBe(2);
+	});
+
+	it("bands 10-24% as 1", () => {
+		expect(remainingBand(24)).toBe(1);
+		expect(remainingBand(10)).toBe(1);
+	});
+
+	it("bands <10% as 0 (empty — no border)", () => {
+		expect(remainingBand(9)).toBe(0);
+		expect(remainingBand(0)).toBe(0);
 	});
 });
 

--- a/app/src/lib/engine/tokens.ts
+++ b/app/src/lib/engine/tokens.ts
@@ -37,5 +37,9 @@ export function firstLine(s: string, n = 100): string {
  */
 export function reductionPct(full: number, live: number): number {
 	if (full <= 0) return 0;
-	return Math.round(((full - live) / full) * 100);
+	// Clamp to [0, 100]: a conductor substitution can be LARGER than the original
+	// block, which would otherwise yield a negative "tokens removed" and render as
+	// a stray minus sign on every fold surface. 0 = nothing removed, 100 = fully gone.
+	const pct = Math.round(((full - live) / full) * 100);
+	return Math.max(0, Math.min(100, pct));
 }

--- a/app/src/lib/engine/tokens.ts
+++ b/app/src/lib/engine/tokens.ts
@@ -28,29 +28,30 @@ export function firstLine(s: string, n = 100): string {
 
 
 /**
- * Reduction percentage of a fold: the whole-percent of tokens REMOVED from the
- * wire (saved / full x 100). Pure - no store access; callers supply the full and
- * live token counts. Returns 0 for a zero-token block (divide-by-zero guard ->
- * renders no tag, since nothing was removed). The Map header already reports
- * "saves X tok", so "% removed" reads as the fold's aggressiveness and stays
- * consistent with that existing copy.
+ * Remaining percentage of a fold: the whole-percent of tokens STILL on the
+ * wire (live / full x 100). Pure - no store access; callers supply the full and
+ * live token counts. Returns 100 for a zero-token block (divide-by-zero guard ->
+ * reads as "fully intact", since there was nothing to remove). The Map header
+ * already reports "saves X tok", so "% remains" reads as how much of the
+ * original content the human can still see and stays consistent with that
+ * existing copy.
  */
-export function reductionPct(full: number, live: number): number {
-	if (full <= 0) return 0;
+export function remainingPct(full: number, live: number): number {
+	if (full <= 0) return 100;
 	// Clamp to [0, 100]: a conductor substitution can be LARGER than the original
-	// block, which would otherwise yield a negative "tokens removed" and render as
-	// a stray minus sign on every fold surface. 0 = nothing removed, 100 = fully gone.
-	const pct = Math.round(((full - live) / full) * 100);
+	// block, which would otherwise yield a >100% remaining value. 100 = nothing
+	// removed (fully intact), 0 = fully gone.
+	const pct = Math.round((live / full) * 100);
 	return Math.max(0, Math.min(100, pct));
 }
 
 /**
- * Reduction as a single decile digit (0-9): drop the ones place, keep the tens
- * digit of reductionPct. Used only for the compact badge stamped directly on a
- * folded tile — a coarser, faster-to-scan signal than the precise "-X%" text
- * shown in tooltips/Transcript/Inspector. Clamped to 9 so a 100% (fully
- * removed) fold doesn't overflow to two digits.
+ * Remaining percentage as a single decile digit (0-9): drop the ones place,
+ * keep the tens digit of remainingPct. Used only for the compact badge
+ * stamped directly on a folded tile — a coarser, faster-to-scan signal than
+ * the precise "X% remains" text shown in tooltips/Transcript/Inspector.
+ * Clamped to 9 so a 100% (fully intact) value doesn't overflow to two digits.
  */
-export function reductionDigit(pct: number): number {
+export function remainingDigit(pct: number): number {
 	return Math.min(9, Math.max(0, Math.floor(pct / 10)));
 }

--- a/app/src/lib/engine/tokens.ts
+++ b/app/src/lib/engine/tokens.ts
@@ -25,3 +25,17 @@ export function firstLine(s: string, n = 100): string {
 	const line = (s.split("\n").find((l) => l.trim()) ?? "").trim();
 	return clip(line, n);
 }
+
+
+/**
+ * Reduction percentage of a fold: the whole-percent of tokens REMOVED from the
+ * wire (saved / full x 100). Pure - no store access; callers supply the full and
+ * live token counts. Returns 0 for a zero-token block (divide-by-zero guard ->
+ * renders no tag, since nothing was removed). The Map header already reports
+ * "saves X tok", so "% removed" reads as the fold's aggressiveness and stays
+ * consistent with that existing copy.
+ */
+export function reductionPct(full: number, live: number): number {
+	if (full <= 0) return 0;
+	return Math.round(((full - live) / full) * 100);
+}

--- a/app/src/lib/engine/tokens.ts
+++ b/app/src/lib/engine/tokens.ts
@@ -43,3 +43,14 @@ export function reductionPct(full: number, live: number): number {
 	const pct = Math.round(((full - live) / full) * 100);
 	return Math.max(0, Math.min(100, pct));
 }
+
+/**
+ * Reduction as a single decile digit (0-9): drop the ones place, keep the tens
+ * digit of reductionPct. Used only for the compact badge stamped directly on a
+ * folded tile — a coarser, faster-to-scan signal than the precise "-X%" text
+ * shown in tooltips/Transcript/Inspector. Clamped to 9 so a 100% (fully
+ * removed) fold doesn't overflow to two digits.
+ */
+export function reductionDigit(pct: number): number {
+	return Math.min(9, Math.max(0, Math.floor(pct / 10)));
+}

--- a/app/src/lib/engine/tokens.ts
+++ b/app/src/lib/engine/tokens.ts
@@ -46,12 +46,17 @@ export function remainingPct(full: number, live: number): number {
 }
 
 /**
- * Remaining percentage as a single decile digit (0-9): drop the ones place,
- * keep the tens digit of remainingPct. Used only for the compact badge
- * stamped directly on a folded tile — a coarser, faster-to-scan signal than
- * the precise "X% remains" text shown in tooltips/Transcript/Inspector.
- * Clamped to 9 so a 100% (fully intact) value doesn't overflow to two digits.
+ * Remaining percentage bucketed into 6 discrete bands (0-5), used to size the
+ * corner-bracket "erosion border" stamped directly on a folded tile — a
+ * coarser, glanceable signal than the precise "X% remains" text shown in
+ * tooltips/Transcript/Inspector. Band 5 (>=90%) renders as a nearly-complete
+ * border; band 0 (<10%) renders no border at all.
  */
-export function remainingDigit(pct: number): number {
-	return Math.min(9, Math.max(0, Math.floor(pct / 10)));
+export function remainingBand(pct: number): number {
+	if (pct >= 90) return 5;
+	if (pct >= 75) return 4;
+	if (pct >= 50) return 3;
+	if (pct >= 25) return 2;
+	if (pct >= 10) return 1;
+	return 0;
 }

--- a/app/src/lib/ui/map/ContextMap.svelte
+++ b/app/src/lib/ui/map/ContextMap.svelte
@@ -6,6 +6,7 @@
 	import { ghosts } from "../../live/ghostState.svelte";
 	import { nextVacated } from "./drain";
 	import { buildDisplay, segmentDisplay, buildLane, type DisplayRow } from "$lib/engine/display";
+	import { reductionPct } from "$lib/engine/tokens";
 	import { settings } from "$lib/settings.svelte";
 	import Icon from "$lib/ui/Icon.svelte";
 	import SegControl from "$lib/ui/SegControl.svelte";
@@ -133,6 +134,7 @@
 					pinned: b.override === "pinned",
 					selected: b.id === selectedId,
 					inrange: rangeSet.has(b.id),
+					reductionPct: store.isFolded(b) ? reductionPct(b.tokens, store.effTokens(b)) : undefined,
 				});
 			} else {
 				// collapsed group tile
@@ -145,6 +147,7 @@
 					pinned: false,
 					selected: selectedId === g.id,
 					inrange: false,
+					reductionPct: g.folded ? reductionPct(store.groupFullTokens(g), store.groupLiveTokens(g)) : undefined,
 				});
 			}
 		}
@@ -178,6 +181,7 @@
 				pinned: b.override === "pinned",
 				selected: b.id === selectedId,
 				inrange: false, // protected tiles can't be in a range
+				reductionPct: store.isFolded(b) ? reductionPct(b.tokens, store.effTokens(b)) : undefined,
 			});
 		}
 		// ghost tiles
@@ -370,7 +374,7 @@
 	function tip(b: Block, prot = false): string {
 		const tool = b.toolName ? ` ${b.toolName}` : "";
 		const folded = store.isFolded(b);
-		const f = folded ? ` · folded ${b.tokens}→${store.effTokens(b)}` : "";
+		const f = folded ? ` · folded ${b.tokens}→${store.effTokens(b)} (−${reductionPct(b.tokens, store.effTokens(b))}%)` : "";
 		// The hint mirrors what a double-click actually DOES — steerLocked makes it a no-op, else
 		// store.toggle gated by canFold — so the tile never advertises a fold the gate would refuse:
 		// a conductor lock, a live user/tool_call, a pin, or the protected tail. Unfold stays for a folded block.
@@ -395,7 +399,7 @@
 		const turns = members.length > 0
 			? `turns ${members[0].turn}–${members[members.length - 1].turn}`
 			: "";
-		const savedStr = saved > 0 ? ` · saves ${k(saved)} tok` : "";
+		const savedStr = saved > 0 ? ` · saves ${k(saved)} tok (−${reductionPct(full, full - saved)}%)` : "";
 		const stragStr = strag > 0 ? ` · ${strag} kept live` : "";
 		if (store.isDropGroup(g)) {
 			return `drop group · ${members.length} blocks · ${k(saved)} tok removed${stragStr}\n${turns}\nThe agent does not see this block\nclick to inspect`;
@@ -409,7 +413,7 @@
 	 *  The dice face on the cocoa shows ITS size (the digest); the sliver beside it carries the
 	 *  original block's weight. */
 	function foldTip(b: Block): string {
-		return `folded · ${k(b.tokens)}→${k(store.effTokens(b))} tok · click to inspect · double-click to unfold`;
+		return `folded · ${k(b.tokens)}→${k(store.effTokens(b))} tok · −${reductionPct(b.tokens, store.effTokens(b))}% · click to inspect · double-click to unfold`;
 	}
 
 	// ---- range selection state (local — for creating groups) ----------------
@@ -1066,7 +1070,9 @@
 													style:height="{cell}px"
 													data-summary={b.id}
 													title={foldTip(b)}
-												></div>
+												>
+													<span class="cell-pct mono">{reductionPct(b.tokens, store.effTokens(b))}</span>
+												</div>
 												{@render sliverTile(b, true)}
 											</div>
 										{:else}
@@ -1082,7 +1088,9 @@
 													style:height="{cell}px"
 													data-group={g.id}
 													title={groupTip(g)}
-												></div>
+												>
+													{#if g.folded}<span class="cell-pct mono">{reductionPct(store.groupFullTokens(g), store.groupLiveTokens(g))}</span>{/if}
+												</div>
 												{#each item.members as m (m.id)}
 													{@render sliverTile(m, false)}
 												{/each}
@@ -1118,7 +1126,9 @@
 											title={store.isDropGroup(g)
 												? `drop group · ${seg.row.members.length} blocks · The agent does not see this block · double-click to collapse`
 												: `${live ? 'group (unfolded — live)' : 'group (peek — preview only)'} · ${seg.row.members.length} blocks · double-click to collapse`}
-										></div>
+										>
+											{#if !live}<span class="cell-pct mono">{reductionPct(store.groupFullTokens(g), store.groupLiveTokens(g))}</span>{/if}
+										</div>
 										<div class="band-members">
 											{#each seg.row.members as mb (mb.id)}
 												{@const mt = { b: mb, face: faceFor(mb.tokens) }}
@@ -1174,6 +1184,9 @@
 							<span class="tr-tok mono tnum">
 								{k(store.effTokens(b))}{#if folded}<span class="dim">/{k(b.tokens)}</span>{/if} tok
 							</span>
+							{#if folded}
+								<span class="tr-reduction mono" title="tokens removed by this fold">−{reductionPct(b.tokens, store.effTokens(b))}%</span>
+							{/if}
 							{#if prot}
 								<span class="tr-flag" title="protected working tail — never folds"><Icon name="lock" size={10} /></span>
 							{:else if b.override === "pinned"}
@@ -1605,6 +1618,7 @@
 	/* ---- band member tiles: still DOM .cell elements (only a handful per open group) ---- */
 	/* Base cell: shared by band member tiles and group-tile-open. */
 	.cell {
+		position: relative;
 		box-sizing: border-box;
 		border-radius: 3px;
 		cursor: pointer;
@@ -1854,6 +1868,23 @@
 		flex: 0 0 auto;
 		cursor: pointer;
 	}
+	/* Reduction-% badge on sliver-mode summary tiles + open-group parent tiles.
+	   Smoke mono, inset at the tile bottom — the same calm recessed label the canvas
+	   draws via the cached % sprite. Information, not decoration (brand: folded = calm). */
+	.cell-pct {
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: 1px;
+		text-align: center;
+		font-family: var(--mono);
+		font-size: 7px;
+		font-weight: 500;
+		line-height: 1;
+		color: rgba(154, 154, 154, 0.85); /* Smoke --muted, brand fold-state label */
+		pointer-events: none;
+		user-select: none;
+	}
 	.summary-tile:hover {
 		filter: brightness(1.22);
 		box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3);
@@ -1988,6 +2019,11 @@
 	.tr-tok {
 		font-size: var(--fs-xs);
 		color: var(--faint);
+	}
+	.tr-reduction {
+		font-size: var(--fs-xs);
+		color: var(--muted); /* Smoke — brand label/metadata color */
+		white-space: nowrap;
 	}
 	.tr-flag {
 		display: inline-flex;

--- a/app/src/lib/ui/map/ContextMap.svelte
+++ b/app/src/lib/ui/map/ContextMap.svelte
@@ -6,7 +6,7 @@
 	import { ghosts } from "../../live/ghostState.svelte";
 	import { nextVacated } from "./drain";
 	import { buildDisplay, segmentDisplay, buildLane, type DisplayRow } from "$lib/engine/display";
-	import { reductionPct } from "$lib/engine/tokens";
+	import { reductionPct, reductionDigit } from "$lib/engine/tokens";
 	import { settings } from "$lib/settings.svelte";
 	import Icon from "$lib/ui/Icon.svelte";
 	import SegControl from "$lib/ui/SegControl.svelte";
@@ -1071,7 +1071,7 @@
 													data-summary={b.id}
 													title={foldTip(b)}
 												>
-													<span class="cell-pct mono">{reductionPct(b.tokens, store.effTokens(b))}</span>
+													<span class="cell-pct mono">{reductionDigit(reductionPct(b.tokens, store.effTokens(b)))}</span>
 												</div>
 												{@render sliverTile(b, true)}
 											</div>
@@ -1089,7 +1089,7 @@
 													data-group={g.id}
 													title={groupTip(g)}
 												>
-													{#if g.folded}<span class="cell-pct mono">{reductionPct(store.groupFullTokens(g), store.groupLiveTokens(g))}</span>{/if}
+													{#if g.folded}<span class="cell-pct mono">{reductionDigit(reductionPct(store.groupFullTokens(g), store.groupLiveTokens(g)))}</span>{/if}
 												</div>
 												{#each item.members as m (m.id)}
 													{@render sliverTile(m, false)}
@@ -1127,7 +1127,7 @@
 												? `drop group · ${seg.row.members.length} blocks · The agent does not see this block · double-click to collapse`
 												: `${live ? 'group (unfolded — live)' : 'group (peek — preview only)'} · ${seg.row.members.length} blocks · double-click to collapse`}
 										>
-											{#if !live}<span class="cell-pct mono">{reductionPct(store.groupFullTokens(g), store.groupLiveTokens(g))}</span>{/if}
+											{#if !live}<span class="cell-pct mono">{reductionDigit(reductionPct(store.groupFullTokens(g), store.groupLiveTokens(g)))}</span>{/if}
 										</div>
 										<div class="band-members">
 											{#each seg.row.members as mb (mb.id)}
@@ -1868,9 +1868,10 @@
 		flex: 0 0 auto;
 		cursor: pointer;
 	}
-	/* Reduction-% badge on sliver-mode summary tiles + open-group parent tiles.
-	   Smoke mono, inset at the tile bottom — the same calm recessed label the canvas
-	   draws via the cached % sprite. Information, not decoration (brand: folded = calm). */
+	/* Reduction-digit (0-9) badge on sliver-mode summary tiles + open-group parent
+	   tiles. Smoke mono, inset at the tile bottom — the same calm recessed label the
+	   canvas draws via the cached digit sprite. Information, not decoration (brand:
+	   folded = calm). */
 	.cell-pct {
 		position: absolute;
 		left: 0;

--- a/app/src/lib/ui/map/ContextMap.svelte
+++ b/app/src/lib/ui/map/ContextMap.svelte
@@ -1869,15 +1869,14 @@
 		cursor: pointer;
 	}
 	/* Remaining-digit (0-9) badge on sliver-mode summary tiles + open-group parent
-	   tiles. Smoke mono, inset at the tile bottom — the same calm recessed label the
-	   canvas draws via the cached digit sprite. Information, not decoration (brand:
-	   folded = calm). */
+	   tiles. Smoke mono, inset at the tile's top-right corner — the same calm recessed
+	   label the canvas draws via the cached digit sprite. Information, not decoration
+	   (brand: folded = calm). */
 	.cell-pct {
 		position: absolute;
-		left: 0;
-		right: 0;
-		bottom: 1px;
-		text-align: center;
+		top: 1px;
+		right: 2px;
+		text-align: right;
 		font-family: var(--mono);
 		font-size: 7px;
 		font-weight: 500;

--- a/app/src/lib/ui/map/ContextMap.svelte
+++ b/app/src/lib/ui/map/ContextMap.svelte
@@ -6,7 +6,7 @@
 	import { ghosts } from "../../live/ghostState.svelte";
 	import { nextVacated } from "./drain";
 	import { buildDisplay, segmentDisplay, buildLane, type DisplayRow } from "$lib/engine/display";
-	import { reductionPct, reductionDigit } from "$lib/engine/tokens";
+	import { remainingPct, remainingDigit } from "$lib/engine/tokens";
 	import { settings } from "$lib/settings.svelte";
 	import Icon from "$lib/ui/Icon.svelte";
 	import SegControl from "$lib/ui/SegControl.svelte";
@@ -134,7 +134,7 @@
 					pinned: b.override === "pinned",
 					selected: b.id === selectedId,
 					inrange: rangeSet.has(b.id),
-					reductionPct: store.isFolded(b) ? reductionPct(b.tokens, store.effTokens(b)) : undefined,
+					remainingPct: store.isFolded(b) ? remainingPct(b.tokens, store.effTokens(b)) : undefined,
 				});
 			} else {
 				// collapsed group tile
@@ -147,7 +147,7 @@
 					pinned: false,
 					selected: selectedId === g.id,
 					inrange: false,
-					reductionPct: g.folded ? reductionPct(store.groupFullTokens(g), store.groupLiveTokens(g)) : undefined,
+					remainingPct: g.folded ? remainingPct(store.groupFullTokens(g), store.groupLiveTokens(g)) : undefined,
 				});
 			}
 		}
@@ -181,7 +181,7 @@
 				pinned: b.override === "pinned",
 				selected: b.id === selectedId,
 				inrange: false, // protected tiles can't be in a range
-				reductionPct: store.isFolded(b) ? reductionPct(b.tokens, store.effTokens(b)) : undefined,
+				remainingPct: store.isFolded(b) ? remainingPct(b.tokens, store.effTokens(b)) : undefined,
 			});
 		}
 		// ghost tiles
@@ -374,7 +374,7 @@
 	function tip(b: Block, prot = false): string {
 		const tool = b.toolName ? ` ${b.toolName}` : "";
 		const folded = store.isFolded(b);
-		const f = folded ? ` · folded ${b.tokens}→${store.effTokens(b)} (−${reductionPct(b.tokens, store.effTokens(b))}%)` : "";
+		const f = folded ? ` · folded ${b.tokens}→${store.effTokens(b)} (${remainingPct(b.tokens, store.effTokens(b))}% remains)` : "";
 		// The hint mirrors what a double-click actually DOES — steerLocked makes it a no-op, else
 		// store.toggle gated by canFold — so the tile never advertises a fold the gate would refuse:
 		// a conductor lock, a live user/tool_call, a pin, or the protected tail. Unfold stays for a folded block.
@@ -399,7 +399,7 @@
 		const turns = members.length > 0
 			? `turns ${members[0].turn}–${members[members.length - 1].turn}`
 			: "";
-		const savedStr = saved > 0 ? ` · saves ${k(saved)} tok (−${reductionPct(full, full - saved)}%)` : "";
+		const savedStr = saved > 0 ? ` · saves ${k(saved)} tok (${remainingPct(full, full - saved)}% remains)` : "";
 		const stragStr = strag > 0 ? ` · ${strag} kept live` : "";
 		if (store.isDropGroup(g)) {
 			return `drop group · ${members.length} blocks · ${k(saved)} tok removed${stragStr}\n${turns}\nThe agent does not see this block\nclick to inspect`;
@@ -413,7 +413,7 @@
 	 *  The dice face on the cocoa shows ITS size (the digest); the sliver beside it carries the
 	 *  original block's weight. */
 	function foldTip(b: Block): string {
-		return `folded · ${k(b.tokens)}→${k(store.effTokens(b))} tok · −${reductionPct(b.tokens, store.effTokens(b))}% · click to inspect · double-click to unfold`;
+		return `folded · ${k(b.tokens)}→${k(store.effTokens(b))} tok · ${remainingPct(b.tokens, store.effTokens(b))}% remains · click to inspect · double-click to unfold`;
 	}
 
 	// ---- range selection state (local — for creating groups) ----------------
@@ -1071,7 +1071,7 @@
 													data-summary={b.id}
 													title={foldTip(b)}
 												>
-													<span class="cell-pct mono">{reductionDigit(reductionPct(b.tokens, store.effTokens(b)))}</span>
+													<span class="cell-pct mono">{remainingDigit(remainingPct(b.tokens, store.effTokens(b)))}</span>
 												</div>
 												{@render sliverTile(b, true)}
 											</div>
@@ -1089,7 +1089,7 @@
 													data-group={g.id}
 													title={groupTip(g)}
 												>
-													{#if g.folded}<span class="cell-pct mono">{reductionDigit(reductionPct(store.groupFullTokens(g), store.groupLiveTokens(g)))}</span>{/if}
+													{#if g.folded}<span class="cell-pct mono">{remainingDigit(remainingPct(store.groupFullTokens(g), store.groupLiveTokens(g)))}</span>{/if}
 												</div>
 												{#each item.members as m (m.id)}
 													{@render sliverTile(m, false)}
@@ -1127,7 +1127,7 @@
 												? `drop group · ${seg.row.members.length} blocks · The agent does not see this block · double-click to collapse`
 												: `${live ? 'group (unfolded — live)' : 'group (peek — preview only)'} · ${seg.row.members.length} blocks · double-click to collapse`}
 										>
-											{#if !live}<span class="cell-pct mono">{reductionDigit(reductionPct(store.groupFullTokens(g), store.groupLiveTokens(g)))}</span>{/if}
+											{#if !live}<span class="cell-pct mono">{remainingDigit(remainingPct(store.groupFullTokens(g), store.groupLiveTokens(g)))}</span>{/if}
 										</div>
 										<div class="band-members">
 											{#each seg.row.members as mb (mb.id)}
@@ -1185,7 +1185,7 @@
 								{k(store.effTokens(b))}{#if folded}<span class="dim">/{k(b.tokens)}</span>{/if} tok
 							</span>
 							{#if folded}
-								<span class="tr-reduction mono" title="tokens removed by this fold">−{reductionPct(b.tokens, store.effTokens(b))}%</span>
+								<span class="tr-remaining mono" title="percentage of tokens still on the wire">{remainingPct(b.tokens, store.effTokens(b))}% remains</span>
 							{/if}
 							{#if prot}
 								<span class="tr-flag" title="protected working tail — never folds"><Icon name="lock" size={10} /></span>
@@ -1868,7 +1868,7 @@
 		flex: 0 0 auto;
 		cursor: pointer;
 	}
-	/* Reduction-digit (0-9) badge on sliver-mode summary tiles + open-group parent
+	/* Remaining-digit (0-9) badge on sliver-mode summary tiles + open-group parent
 	   tiles. Smoke mono, inset at the tile bottom — the same calm recessed label the
 	   canvas draws via the cached digit sprite. Information, not decoration (brand:
 	   folded = calm). */
@@ -2021,7 +2021,7 @@
 		font-size: var(--fs-xs);
 		color: var(--faint);
 	}
-	.tr-reduction {
+	.tr-remaining {
 		font-size: var(--fs-xs);
 		color: var(--muted); /* Smoke — brand label/metadata color */
 		white-space: nowrap;

--- a/app/src/lib/ui/map/ContextMap.svelte
+++ b/app/src/lib/ui/map/ContextMap.svelte
@@ -6,13 +6,13 @@
 	import { ghosts } from "../../live/ghostState.svelte";
 	import { nextVacated } from "./drain";
 	import { buildDisplay, segmentDisplay, buildLane, type DisplayRow } from "$lib/engine/display";
-	import { remainingPct, remainingDigit } from "$lib/engine/tokens";
+	import { remainingPct, remainingBand } from "$lib/engine/tokens";
 	import { settings } from "$lib/settings.svelte";
 	import Icon from "$lib/ui/Icon.svelte";
 	import SegControl from "$lib/ui/SegControl.svelte";
 	import TileCanvas from "./TileCanvas.svelte";
 	import type { TileSpec } from "./tileDraw";
-	import { faceFor as faceForLib } from "./tileDraw";
+	import { faceFor as faceForLib, erosionArmLength } from "./tileDraw";
 
 	let {
 		store,
@@ -59,6 +59,29 @@
 	] as const;
 	// Use the canonical faceFor from tileDraw (single source of truth).
 	const faceFor = faceForLib;
+
+	/**
+	 * Corner-bracket line segments for the DOM/sliver-mode erosion border — the exact
+	 * same 6-band geometry the canvas renderer blits via a cached sprite (tileDraw.ts),
+	 * expressed as SVG line endpoints instead. Empty array for band 0 (nothing drawn).
+	 */
+	function erosionLines(size: number, band: number): { x1: number; y1: number; x2: number; y2: number }[] {
+		const arm = erosionArmLength(size, band);
+		if (arm <= 0) return [];
+		const inset = 1;
+		const corners: [number, number, number, number][] = [
+			[inset, inset, 1, 1],
+			[size - inset, inset, -1, 1],
+			[inset, size - inset, 1, -1],
+			[size - inset, size - inset, -1, -1],
+		];
+		const lines: { x1: number; y1: number; x2: number; y2: number }[] = [];
+		for (const [cx, cy, dx, dy] of corners) {
+			lines.push({ x1: cx, y1: cy, x2: cx + dx * arm, y2: cy });
+			lines.push({ x1: cx, y1: cy, x2: cx, y2: cy + dy * arm });
+		}
+		return lines;
+	}
 
 	// Color = kind legend (toolbar). Each block kind owns one spectrum hue (--k-*);
 	// this names them so the grid's colours are self-explaining. Order follows the
@@ -1010,6 +1033,19 @@
 					title={tip(t.b, prot)}
 				></div>
 			{/snippet}
+			{#snippet erosionBorder(band: number)}
+				<!-- Corner-bracket "how much remains" signal on folded summary/group tiles (6
+				     stepped bands — see remainingBand). Drawn as a plain child so it paints on
+				     top of the tile's own inset box-shadow (.sel/.inrange rings); those are rare,
+				     transient states and the tooltip still carries the exact percentage. -->
+				{#if band > 0}
+					<svg class="erosion-border" viewBox="0 0 {cell} {cell}" aria-hidden="true">
+						{#each erosionLines(cell, band) as ln}
+							<line x1={ln.x1} y1={ln.y1} x2={ln.x2} y2={ln.y2} />
+						{/each}
+					</svg>
+				{/if}
+			{/snippet}
 			{#snippet sliverTile(b: Block, interactive: boolean)}
 				<!-- The ORIGINAL folded block as a thin sliver; white lines = its weight (die face).
 				     `interactive` slivers carry data-id (click=inspect / dbl=unfold); group-member
@@ -1071,7 +1107,7 @@
 													data-summary={b.id}
 													title={foldTip(b)}
 												>
-													<span class="cell-pct mono">{remainingDigit(remainingPct(b.tokens, store.effTokens(b)))}</span>
+													{@render erosionBorder(remainingBand(remainingPct(b.tokens, store.effTokens(b))))}
 												</div>
 												{@render sliverTile(b, true)}
 											</div>
@@ -1089,7 +1125,7 @@
 													data-group={g.id}
 													title={groupTip(g)}
 												>
-													{#if g.folded}<span class="cell-pct mono">{remainingDigit(remainingPct(store.groupFullTokens(g), store.groupLiveTokens(g)))}</span>{/if}
+													{#if g.folded}{@render erosionBorder(remainingBand(remainingPct(store.groupFullTokens(g), store.groupLiveTokens(g))))}{/if}
 												</div>
 												{#each item.members as m (m.id)}
 													{@render sliverTile(m, false)}
@@ -1127,7 +1163,7 @@
 												? `drop group · ${seg.row.members.length} blocks · The agent does not see this block · double-click to collapse`
 												: `${live ? 'group (unfolded — live)' : 'group (peek — preview only)'} · ${seg.row.members.length} blocks · double-click to collapse`}
 										>
-											{#if !live}<span class="cell-pct mono">{remainingDigit(remainingPct(store.groupFullTokens(g), store.groupLiveTokens(g)))}</span>{/if}
+											{#if !live}{@render erosionBorder(remainingBand(remainingPct(store.groupFullTokens(g), store.groupLiveTokens(g))))}{/if}
 										</div>
 										<div class="band-members">
 											{#each seg.row.members as mb (mb.id)}
@@ -1868,22 +1904,23 @@
 		flex: 0 0 auto;
 		cursor: pointer;
 	}
-	/* Remaining-digit (0-9) badge on sliver-mode summary tiles + open-group parent
-	   tiles. Smoke mono, inset at the tile's top-right corner — the same calm recessed
-	   label the canvas draws via the cached digit sprite. Information, not decoration
+	/* Erosion border: corner brackets on sliver-mode summary tiles + open-group parent
+	   tiles, sized to the same 6-band remainingBand the canvas renderer uses — the DOM
+	   equivalent of tileDraw.ts's cached band sprite. Information, not decoration
 	   (brand: folded = calm). */
-	.cell-pct {
+	.erosion-border {
 		position: absolute;
-		top: 1px;
-		right: 2px;
-		text-align: right;
-		font-family: var(--mono);
-		font-size: 7px;
-		font-weight: 500;
-		line-height: 1;
-		color: rgba(154, 154, 154, 0.85); /* Smoke --muted, brand fold-state label */
+		inset: 0;
+		width: 100%;
+		height: 100%;
 		pointer-events: none;
-		user-select: none;
+		overflow: visible;
+	}
+	.erosion-border line {
+		stroke: rgba(255, 255, 255, 0.9);
+		stroke-width: 1.5;
+		stroke-linecap: round;
+		vector-effect: non-scaling-stroke;
 	}
 	.summary-tile:hover {
 		filter: brightness(1.22);

--- a/app/src/lib/ui/map/ContextMap.svelte
+++ b/app/src/lib/ui/map/ContextMap.svelte
@@ -394,29 +394,36 @@
 	});
 
 	const k = (n: number) => { n = Math.round(n); return n >= 1000 ? `${(n / 1000).toFixed(n >= 10000 ? 0 : 1)}k` : `${n}`; };
+	/** Minimal hover tooltip for anything degraded (a folded block, a folded/drop
+	 *  group, a peeked group): kind, original token count, precise % remaining.
+	 *  Live blocks/groups keep their richer tooltip — this format only applies
+	 *  once there's something to report as "remaining". */
+	function minimalTip(kind: string, fullTokens: number, liveTokens: number): string {
+		return `${kind} · ${fullTokens.toLocaleString()} tok · ${remainingPct(fullTokens, liveTokens)}% remaining`;
+	}
 	function tip(b: Block, prot = false): string {
+		if (store.isFolded(b)) return minimalTip(b.kind, b.tokens, store.effTokens(b));
 		const tool = b.toolName ? ` ${b.toolName}` : "";
-		const folded = store.isFolded(b);
-		const f = folded ? ` · folded ${b.tokens}→${store.effTokens(b)} (${remainingPct(b.tokens, store.effTokens(b))}% remains)` : "";
 		// The hint mirrors what a double-click actually DOES — steerLocked makes it a no-op, else
 		// store.toggle gated by canFold — so the tile never advertises a fold the gate would refuse:
-		// a conductor lock, a live user/tool_call, a pin, or the protected tail. Unfold stays for a folded block.
+		// a conductor lock, a live user/tool_call, a pin, or the protected tail.
 		const action = steerLocked
 			? "click to inspect · folding locked by the conductor"
-			: folded
-				? "click to inspect · double-click to unfold"
-				: store.canFold(b)
-					? "click to inspect · double-click to fold"
-					: prot
-						? "click to inspect · protected — never folds"
-						: b.override === "pinned"
-							? "click to inspect · pinned — held live"
-							: "click to inspect · this kind never folds";
-		return `${b.kind}${tool} · ${b.tokens.toLocaleString()} tok${f}\n${action}`;
+			: store.canFold(b)
+				? "click to inspect · double-click to fold"
+				: prot
+					? "click to inspect · protected — never folds"
+					: b.override === "pinned"
+						? "click to inspect · pinned — held live"
+						: "click to inspect · this kind never folds";
+		return `${b.kind}${tool} · ${b.tokens.toLocaleString()} tok\n${action}`;
 	}
 	function groupTip(g: Group): string {
-		const members = store.groupMembers(g);
 		const full = store.groupFullTokens(g);
+		if (store.isDropGroup(g) || g.folded) {
+			return minimalTip(store.isDropGroup(g) ? "drop group" : "group", full, store.groupLiveTokens(g));
+		}
+		const members = store.groupMembers(g);
 		const saved = store.groupSavedTokens(g);
 		const strag = store.groupStragglerCount(g);
 		const turns = members.length > 0
@@ -424,9 +431,6 @@
 			: "";
 		const savedStr = saved > 0 ? ` · saves ${k(saved)} tok (${remainingPct(full, full - saved)}% remains)` : "";
 		const stragStr = strag > 0 ? ` · ${strag} kept live` : "";
-		if (store.isDropGroup(g)) {
-			return `drop group · ${members.length} blocks · ${k(saved)} tok removed${stragStr}\n${turns}\nThe agent does not see this block\nclick to inspect`;
-		}
 		return `group · ${members.length} blocks · ${k(full)} tok full${savedStr}${stragStr}\n${turns}\nclick to peek · double-click to collapse`;
 	}
 
@@ -436,7 +440,7 @@
 	 *  The dice face on the cocoa shows ITS size (the digest); the sliver beside it carries the
 	 *  original block's weight. */
 	function foldTip(b: Block): string {
-		return `folded · ${k(b.tokens)}→${k(store.effTokens(b))} tok · ${remainingPct(b.tokens, store.effTokens(b))}% remains · click to inspect · double-click to unfold`;
+		return minimalTip(b.kind, b.tokens, store.effTokens(b));
 	}
 
 	// ---- range selection state (local — for creating groups) ----------------
@@ -1160,8 +1164,10 @@
 											class:sel={selectedId === g.id}
 											data-group={g.id}
 											title={store.isDropGroup(g)
-												? `drop group · ${seg.row.members.length} blocks · The agent does not see this block · double-click to collapse`
-												: `${live ? 'group (unfolded — live)' : 'group (peek — preview only)'} · ${seg.row.members.length} blocks · double-click to collapse`}
+												? minimalTip("drop group", store.groupFullTokens(g), store.groupLiveTokens(g))
+												: live
+													? `group (unfolded — live) · ${seg.row.members.length} blocks · double-click to collapse`
+													: minimalTip("group", store.groupFullTokens(g), store.groupLiveTokens(g))}
 										>
 											{#if !live}{@render erosionBorder(remainingBand(remainingPct(store.groupFullTokens(g), store.groupLiveTokens(g))))}{/if}
 										</div>

--- a/app/src/lib/ui/map/Inspector.svelte
+++ b/app/src/lib/ui/map/Inspector.svelte
@@ -3,6 +3,7 @@
 	import { cubicOut } from "svelte/easing";
 	import type { AccordionStore } from "../../engine/store.svelte";
 	import type { Block, Group } from "../../engine/types";
+	import { reductionPct } from "../../engine/tokens";
 	import Icon from "$lib/ui/Icon.svelte";
 
 	let {
@@ -145,6 +146,9 @@
 					{#if gSavedTok > 0}
 						<span class="tok-saved mono">saves {fmt(gSavedTok)}</span>
 					{/if}
+					{#if gSavedTok > 0}
+						<span class="tok-reduction mono">−{reductionPct(gFullTok, gLiveTok)}%</span>
+					{/if}
 				</div>
 			</div>
 
@@ -278,6 +282,7 @@
 							<span class="tok-key">live</span>
 							<span class="tok-val tok-live">{fmt(store.effTokens(block))}</span>
 						</span>
+						<span class="tok-reduction mono">−{reductionPct(block.tokens, store.effTokens(block))}%</span>
 					{:else}
 						<span class="tok-row">
 							<span class="tok-key">tokens</span>
@@ -606,6 +611,11 @@
 	.tok-saved {
 		color: var(--ok);
 		font-size: var(--fs-xs);
+	}
+	.tok-reduction {
+		color: var(--muted); /* Smoke — brand label/metadata color */
+		font-size: var(--fs-xs);
+		white-space: nowrap;
 	}
 
 	/* Action row: buttons laid out in a flex row */

--- a/app/src/lib/ui/map/Inspector.svelte
+++ b/app/src/lib/ui/map/Inspector.svelte
@@ -3,7 +3,7 @@
 	import { cubicOut } from "svelte/easing";
 	import type { AccordionStore } from "../../engine/store.svelte";
 	import type { Block, Group } from "../../engine/types";
-	import { reductionPct } from "../../engine/tokens";
+	import { remainingPct } from "../../engine/tokens";
 	import Icon from "$lib/ui/Icon.svelte";
 
 	let {
@@ -147,7 +147,7 @@
 						<span class="tok-saved mono">saves {fmt(gSavedTok)}</span>
 					{/if}
 					{#if gSavedTok > 0}
-						<span class="tok-reduction mono">−{reductionPct(gFullTok, gLiveTok)}%</span>
+						<span class="tok-remaining mono">{remainingPct(gFullTok, gLiveTok)}% remains</span>
 					{/if}
 				</div>
 			</div>
@@ -282,7 +282,7 @@
 							<span class="tok-key">live</span>
 							<span class="tok-val tok-live">{fmt(store.effTokens(block))}</span>
 						</span>
-						<span class="tok-reduction mono">−{reductionPct(block.tokens, store.effTokens(block))}%</span>
+						<span class="tok-remaining mono">{remainingPct(block.tokens, store.effTokens(block))}% remains</span>
 					{:else}
 						<span class="tok-row">
 							<span class="tok-key">tokens</span>
@@ -612,7 +612,7 @@
 		color: var(--ok);
 		font-size: var(--fs-xs);
 	}
-	.tok-reduction {
+	.tok-remaining {
 		color: var(--muted); /* Smoke — brand label/metadata color */
 		font-size: var(--fs-xs);
 		white-space: nowrap;

--- a/app/src/lib/ui/map/tileDraw.test.ts
+++ b/app/src/lib/ui/map/tileDraw.test.ts
@@ -245,6 +245,35 @@ describe("TileSpec colorKind", () => {
   });
 });
 
+describe("TileSpec reductionPct", () => {
+  it("folded spec can carry a reductionPct badge value", () => {
+    const spec: TileSpec = {
+      id: "abc",
+      kind: "text",
+      face: 2,
+      folded: true,
+      pinned: false,
+      selected: false,
+      inrange: false,
+      reductionPct: 73,
+    };
+    expect(spec.reductionPct).toBe(73);
+  });
+
+  it("reductionPct is optional (absent on live tiles)", () => {
+    const spec: TileSpec = {
+      id: "abc",
+      kind: "text",
+      face: 2,
+      folded: false,
+      pinned: false,
+      selected: false,
+      inrange: false,
+    };
+    expect(spec.reductionPct).toBeUndefined();
+  });
+});
+
 // ---------------------------------------------------------------------------
 // resetSprites / _spritesDpr — cache invalidation (Fix 3)
 // ---------------------------------------------------------------------------

--- a/app/src/lib/ui/map/tileDraw.test.ts
+++ b/app/src/lib/ui/map/tileDraw.test.ts
@@ -245,8 +245,8 @@ describe("TileSpec colorKind", () => {
   });
 });
 
-describe("TileSpec reductionPct", () => {
-  it("folded spec can carry a reductionPct badge value", () => {
+describe("TileSpec remainingPct", () => {
+  it("folded spec can carry a remainingPct badge value", () => {
     const spec: TileSpec = {
       id: "abc",
       kind: "text",
@@ -255,12 +255,12 @@ describe("TileSpec reductionPct", () => {
       pinned: false,
       selected: false,
       inrange: false,
-      reductionPct: 73,
+      remainingPct: 27,
     };
-    expect(spec.reductionPct).toBe(73);
+    expect(spec.remainingPct).toBe(27);
   });
 
-  it("reductionPct is optional (absent on live tiles)", () => {
+  it("remainingPct is optional (absent on live tiles)", () => {
     const spec: TileSpec = {
       id: "abc",
       kind: "text",
@@ -270,7 +270,7 @@ describe("TileSpec reductionPct", () => {
       selected: false,
       inrange: false,
     };
-    expect(spec.reductionPct).toBeUndefined();
+    expect(spec.remainingPct).toBeUndefined();
   });
 });
 

--- a/app/src/lib/ui/map/tileDraw.test.ts
+++ b/app/src/lib/ui/map/tileDraw.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { faceFor, computeGeometry, tileRectCss, hitTest, desaturate, resetSprites, getSprites, type TileSpec } from "./tileDraw";
+import {
+  faceFor,
+  computeGeometry,
+  tileRectCss,
+  hitTest,
+  desaturate,
+  resetSprites,
+  getSprites,
+  erosionArmLength,
+  BAND_ARM_MAX_FRACTION,
+  type TileSpec,
+} from "./tileDraw";
 
 // ---------------------------------------------------------------------------
 // faceFor
@@ -289,6 +300,38 @@ describe("resetSprites — clears sprite cache so DPR change forces rebuild", ()
     resetSprites();
     resetSprites();
     expect(getSprites()).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// erosionArmLength — corner-bracket geometry for the 6-band erosion border
+// ---------------------------------------------------------------------------
+
+describe("erosionArmLength", () => {
+  it("band 0 (empty) has zero arm length", () => {
+    expect(erosionArmLength(30, 0)).toBe(0);
+  });
+
+  it("band 5 (full) uses the full BAND_ARM_MAX_FRACTION of tile size", () => {
+    expect(erosionArmLength(30, 5)).toBeCloseTo(30 * BAND_ARM_MAX_FRACTION, 5);
+  });
+
+  it("steps linearly between bands 0 and 5", () => {
+    const size = 30;
+    const full = erosionArmLength(size, 5);
+    expect(erosionArmLength(size, 1)).toBeCloseTo(full * (1 / 5), 5);
+    expect(erosionArmLength(size, 2)).toBeCloseTo(full * (2 / 5), 5);
+    expect(erosionArmLength(size, 3)).toBeCloseTo(full * (3 / 5), 5);
+    expect(erosionArmLength(size, 4)).toBeCloseTo(full * (4 / 5), 5);
+  });
+
+  it("scales proportionally with tile size", () => {
+    expect(erosionArmLength(60, 5)).toBeCloseTo(erosionArmLength(30, 5) * 2, 5);
+  });
+
+  it("clamps out-of-range bands to [0, 5]", () => {
+    expect(erosionArmLength(30, -1)).toBe(0);
+    expect(erosionArmLength(30, 6)).toBeCloseTo(erosionArmLength(30, 5), 5);
   });
 });
 

--- a/app/src/lib/ui/map/tileDraw.ts
+++ b/app/src/lib/ui/map/tileDraw.ts
@@ -364,15 +364,15 @@ function getPctSprite(pct: number, size: number, dpr: number): HTMLCanvasElement
   cv.height = px;
   const cx = cv.getContext("2d")!;
   cx.scale(dpr, dpr);
-  // Smoke (--muted #9A9A9A) mono label, bottom-centered, inset 2px. Faint alpha keeps
+  // Smoke (--muted #9A9A9A) mono label, top-right corner, inset 2px. Faint alpha keeps
   // the folded tile's recessed, drained calm (the #1 brand signal) - information, not
   // decoration. Never a spectrum hue; never on a live tile.
   const fs = Math.max(7, Math.round(size * 0.32));
   cx.font = `500 ${fs}px "IBM Plex Mono", ui-monospace, monospace`;
   cx.fillStyle = "rgba(154,154,154,0.8)";
-  cx.textAlign = "center";
-  cx.textBaseline = "bottom";
-  cx.fillText(String(digit), size / 2, size - 2);
+  cx.textAlign = "right";
+  cx.textBaseline = "top";
+  cx.fillText(String(digit), size - 2, 2);
   _pctSprites.set(digit, cv);
   return cv;
 }
@@ -636,8 +636,8 @@ export function drawTile(
   }
 
   // ---- remaining digit badge: folded blocks + collapsed groups (drawn LAST so it
-  // ---- stays readable over any selection/hover overlays; inset at the tile bottom
-  // ---- so the edge selection/pinned rings stay crisp). Cached sprite blit - O(1) per tile.
+  // ---- stays readable over any selection/hover overlays; inset at the tile's top-right
+  // ---- corner so the edge selection/pinned rings stay crisp). Cached sprite blit - O(1) per tile.
   // ---- < 100 (not >= 0) is the gate: 100 means nothing was folded away, so there's
   // ---- nothing worth badging.
   if (spec.remainingPct != null && spec.remainingPct < 100) {

--- a/app/src/lib/ui/map/tileDraw.ts
+++ b/app/src/lib/ui/map/tileDraw.ts
@@ -13,7 +13,7 @@
  */
 
 import type { BlockKind } from "../../engine/types";
-import { reductionDigit } from "../../engine/tokens";
+import { remainingDigit } from "../../engine/tokens";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -41,15 +41,17 @@ export type TileSpec = {
    */
   colorKind?: BlockKind;
   /**
-   * Fold reduction: whole-percent of tokens REMOVED (0-100). When present and > 0,
-   * a small Smoke-mono single-digit badge is blitted onto folded block tiles and
-   * collapsed-group tiles so the human can read how aggressive each fold was, at a
-   * glance (drop the ones place, keep the tens digit -> 0-9; a 100% reduction
-   * clamps to 9). Absent/0 -> no badge. Live tiles never carry this. Drawn via a
-   * cached offscreen sprite (one per digit, 0-9 -> <=10 sprites), blitted like the
-   * dice/hatch sprites - no per-tile fillText in the hot loop, no filter/gradient.
+   * Fold remaining: whole-percent of tokens STILL on the wire (0-100). When
+   * present and < 100, a small Smoke-mono single-digit badge is blitted onto
+   * folded block tiles and collapsed-group tiles so the human can read how
+   * much of the original content is still visible, at a glance (drop the ones
+   * place, keep the tens digit -> 0-9; a 100% (fully intact) value clamps to
+   * 9, but that case is gated out below since nothing was folded). Absent/100
+   * -> no badge. Live tiles never carry this. Drawn via a cached offscreen
+   * sprite (one per digit, 0-9 -> <=10 sprites), blitted like the dice/hatch
+   * sprites - no per-tile fillText in the hot loop, no filter/gradient.
    */
-  reductionPct?: number;
+  remainingPct?: number;
 };
 
 export type Palette = {
@@ -335,7 +337,7 @@ function getHatchSprite(size: number, dpr: number): HTMLCanvasElement {
 }
 
 // ---------------------------------------------------------------------------
-// Reduction-digit sprite cache (PERF) - a folded tile's aggressiveness badge.
+// Remaining-digit sprite cache (PERF) - a folded tile's "how much is left" badge.
 // Like the hatch/dice sprites: rendered ONCE per distinct digit (0-9 -> <=10
 // entries) to an offscreen canvas, then blitted with drawImage in the hot loop.
 // NO per-tile ctx.fillText, NO filter/gradient. The cache is keyed by
@@ -353,7 +355,7 @@ function getPctSprite(pct: number, size: number, dpr: number): HTMLCanvasElement
   // Drop the ones place, keep the tens digit (0-9). The exact whole-percent is
   // shown in the Inspector/Transcript/tooltips; the dense Map tile trades
   // precision for a single glanceable digit + a cached, O(1)-per-tile blit.
-  const digit = reductionDigit(pct);
+  const digit = remainingDigit(pct);
   const c = _pctSprites.get(digit);
   if (c) return c;
   const cv = document.createElement("canvas");
@@ -633,11 +635,13 @@ export function drawTile(
     ctx.stroke();
   }
 
-  // ---- reduction digit badge: folded blocks + collapsed groups (drawn LAST so it
+  // ---- remaining digit badge: folded blocks + collapsed groups (drawn LAST so it
   // ---- stays readable over any selection/hover overlays; inset at the tile bottom
   // ---- so the edge selection/pinned rings stay crisp). Cached sprite blit - O(1) per tile.
-  if (spec.reductionPct != null && spec.reductionPct > 0) {
-    ctx.drawImage(getPctSprite(spec.reductionPct, w, opts.dpr ?? 1), x, y, w, h);
+  // ---- < 100 (not >= 0) is the gate: 100 means nothing was folded away, so there's
+  // ---- nothing worth badging.
+  if (spec.remainingPct != null && spec.remainingPct < 100) {
+    ctx.drawImage(getPctSprite(spec.remainingPct, w, opts.dpr ?? 1), x, y, w, h);
   }
 
   ctx.restore();

--- a/app/src/lib/ui/map/tileDraw.ts
+++ b/app/src/lib/ui/map/tileDraw.ts
@@ -13,6 +13,7 @@
  */
 
 import type { BlockKind } from "../../engine/types";
+import { reductionDigit } from "../../engine/tokens";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -41,11 +42,12 @@ export type TileSpec = {
   colorKind?: BlockKind;
   /**
    * Fold reduction: whole-percent of tokens REMOVED (0-100). When present and > 0,
-   * a small Smoke-mono badge is blitted onto folded block tiles and collapsed-group
-   * tiles so the human can read how aggressive each fold was. Absent/0 -> no badge.
-   * Live tiles never carry this. Drawn via a cached offscreen sprite (rounded to the
-   * nearest 5% -> <=21 sprites), blitted like the dice/hatch sprites - no per-tile
-   * fillText in the hot loop, no filter/gradient.
+   * a small Smoke-mono single-digit badge is blitted onto folded block tiles and
+   * collapsed-group tiles so the human can read how aggressive each fold was, at a
+   * glance (drop the ones place, keep the tens digit -> 0-9; a 100% reduction
+   * clamps to 9). Absent/0 -> no badge. Live tiles never carry this. Drawn via a
+   * cached offscreen sprite (one per digit, 0-9 -> <=10 sprites), blitted like the
+   * dice/hatch sprites - no per-tile fillText in the hot loop, no filter/gradient.
    */
   reductionPct?: number;
 };
@@ -333,12 +335,12 @@ function getHatchSprite(size: number, dpr: number): HTMLCanvasElement {
 }
 
 // ---------------------------------------------------------------------------
-// Reduction-% sprite cache (PERF) - a folded tile's aggressiveness badge.
-// Like the hatch/dice sprites: rendered ONCE per distinct value (rounded to the
-// nearest 5% -> <=21 entries) to an offscreen canvas, then blitted with drawImage
-// in the hot loop. NO per-tile ctx.fillText, NO filter/gradient. The cache is
-// keyed by (cellSize, dpr); it is rebuilt wholesale when either changes (mirrors
-// the hatch sprite's single-entry rebuild on size change, bounding memory).
+// Reduction-digit sprite cache (PERF) - a folded tile's aggressiveness badge.
+// Like the hatch/dice sprites: rendered ONCE per distinct digit (0-9 -> <=10
+// entries) to an offscreen canvas, then blitted with drawImage in the hot loop.
+// NO per-tile ctx.fillText, NO filter/gradient. The cache is keyed by
+// (cellSize, dpr); it is rebuilt wholesale when either changes (mirrors the
+// hatch sprite's single-entry rebuild on size change, bounding memory).
 // ---------------------------------------------------------------------------
 let _pctSprites: Map<number, HTMLCanvasElement> | null = null;
 let _pctKey = "";
@@ -348,11 +350,11 @@ function getPctSprite(pct: number, size: number, dpr: number): HTMLCanvasElement
     _pctSprites = new Map();
     _pctKey = key;
   }
-  // Round to nearest 5% so the sprite set stays tiny (<=21) and stable across tiny
-  // token fluctuations. The exact whole-percent is shown in the Inspector/Transcript;
-  // the dense Map tile trades precision for a cached, O(1)-per-tile blit.
-  const rounded = Math.round(pct / 5) * 5;
-  const c = _pctSprites.get(rounded);
+  // Drop the ones place, keep the tens digit (0-9). The exact whole-percent is
+  // shown in the Inspector/Transcript/tooltips; the dense Map tile trades
+  // precision for a single glanceable digit + a cached, O(1)-per-tile blit.
+  const digit = reductionDigit(pct);
+  const c = _pctSprites.get(digit);
   if (c) return c;
   const cv = document.createElement("canvas");
   const px = Math.max(1, Math.round(size * dpr));
@@ -368,8 +370,8 @@ function getPctSprite(pct: number, size: number, dpr: number): HTMLCanvasElement
   cx.fillStyle = "rgba(154,154,154,0.8)";
   cx.textAlign = "center";
   cx.textBaseline = "bottom";
-  cx.fillText(String(rounded), size / 2, size - 2);
-  _pctSprites.set(rounded, cv);
+  cx.fillText(String(digit), size / 2, size - 2);
+  _pctSprites.set(digit, cv);
   return cv;
 }
 
@@ -631,9 +633,9 @@ export function drawTile(
     ctx.stroke();
   }
 
-  // ---- reduction % badge: folded blocks + collapsed groups (drawn LAST so it stays
-  // ---- readable over any selection/hover overlays; inset at the tile bottom so the
-  // ---- edge selection/pinned rings stay crisp). Cached sprite blit - O(1) per tile.
+  // ---- reduction digit badge: folded blocks + collapsed groups (drawn LAST so it
+  // ---- stays readable over any selection/hover overlays; inset at the tile bottom
+  // ---- so the edge selection/pinned rings stay crisp). Cached sprite blit - O(1) per tile.
   if (spec.reductionPct != null && spec.reductionPct > 0) {
     ctx.drawImage(getPctSprite(spec.reductionPct, w, opts.dpr ?? 1), x, y, w, h);
   }

--- a/app/src/lib/ui/map/tileDraw.ts
+++ b/app/src/lib/ui/map/tileDraw.ts
@@ -39,6 +39,15 @@ export type TileSpec = {
    * Mirrors the old `.cell.ghost.k-{kind}` CSS class. Defaults to "text" if absent.
    */
   colorKind?: BlockKind;
+  /**
+   * Fold reduction: whole-percent of tokens REMOVED (0-100). When present and > 0,
+   * a small Smoke-mono badge is blitted onto folded block tiles and collapsed-group
+   * tiles so the human can read how aggressive each fold was. Absent/0 -> no badge.
+   * Live tiles never carry this. Drawn via a cached offscreen sprite (rounded to the
+   * nearest 5% -> <=21 sprites), blitted like the dice/hatch sprites - no per-tile
+   * fillText in the hot loop, no filter/gradient.
+   */
+  reductionPct?: number;
 };
 
 export type Palette = {
@@ -324,6 +333,47 @@ function getHatchSprite(size: number, dpr: number): HTMLCanvasElement {
 }
 
 // ---------------------------------------------------------------------------
+// Reduction-% sprite cache (PERF) - a folded tile's aggressiveness badge.
+// Like the hatch/dice sprites: rendered ONCE per distinct value (rounded to the
+// nearest 5% -> <=21 entries) to an offscreen canvas, then blitted with drawImage
+// in the hot loop. NO per-tile ctx.fillText, NO filter/gradient. The cache is
+// keyed by (cellSize, dpr); it is rebuilt wholesale when either changes (mirrors
+// the hatch sprite's single-entry rebuild on size change, bounding memory).
+// ---------------------------------------------------------------------------
+let _pctSprites: Map<number, HTMLCanvasElement> | null = null;
+let _pctKey = "";
+function getPctSprite(pct: number, size: number, dpr: number): HTMLCanvasElement {
+  const key = `${size}:${dpr}`;
+  if (!_pctSprites || _pctKey !== key) {
+    _pctSprites = new Map();
+    _pctKey = key;
+  }
+  // Round to nearest 5% so the sprite set stays tiny (<=21) and stable across tiny
+  // token fluctuations. The exact whole-percent is shown in the Inspector/Transcript;
+  // the dense Map tile trades precision for a cached, O(1)-per-tile blit.
+  const rounded = Math.round(pct / 5) * 5;
+  const c = _pctSprites.get(rounded);
+  if (c) return c;
+  const cv = document.createElement("canvas");
+  const px = Math.max(1, Math.round(size * dpr));
+  cv.width = px;
+  cv.height = px;
+  const cx = cv.getContext("2d")!;
+  cx.scale(dpr, dpr);
+  // Smoke (--muted #9A9A9A) mono label, bottom-centered, inset 2px. Faint alpha keeps
+  // the folded tile's recessed, drained calm (the #1 brand signal) - information, not
+  // decoration. Never a spectrum hue; never on a live tile.
+  const fs = Math.max(7, Math.round(size * 0.32));
+  cx.font = `500 ${fs}px "IBM Plex Mono", ui-monospace, monospace`;
+  cx.fillStyle = "rgba(154,154,154,0.8)";
+  cx.textAlign = "center";
+  cx.textBaseline = "bottom";
+  cx.fillText(String(rounded), size / 2, size - 2);
+  _pctSprites.set(rounded, cv);
+  return cv;
+}
+
+// ---------------------------------------------------------------------------
 // Geometry
 // ---------------------------------------------------------------------------
 
@@ -579,6 +629,13 @@ export function drawTile(
     ctx.lineWidth = 1;
     roundRect(ctx, x + 0.5, y + 0.5, w - 1, h - 1, r);
     ctx.stroke();
+  }
+
+  // ---- reduction % badge: folded blocks + collapsed groups (drawn LAST so it stays
+  // ---- readable over any selection/hover overlays; inset at the tile bottom so the
+  // ---- edge selection/pinned rings stay crisp). Cached sprite blit - O(1) per tile.
+  if (spec.reductionPct != null && spec.reductionPct > 0) {
+    ctx.drawImage(getPctSprite(spec.reductionPct, w, opts.dpr ?? 1), x, y, w, h);
   }
 
   ctx.restore();

--- a/app/src/lib/ui/map/tileDraw.ts
+++ b/app/src/lib/ui/map/tileDraw.ts
@@ -13,7 +13,7 @@
  */
 
 import type { BlockKind } from "../../engine/types";
-import { remainingDigit } from "../../engine/tokens";
+import { remainingBand } from "../../engine/tokens";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -42,14 +42,14 @@ export type TileSpec = {
   colorKind?: BlockKind;
   /**
    * Fold remaining: whole-percent of tokens STILL on the wire (0-100). When
-   * present and < 100, a small Smoke-mono single-digit badge is blitted onto
+   * present and < 100, a white corner-bracket "erosion border" is blitted onto
    * folded block tiles and collapsed-group tiles so the human can read how
-   * much of the original content is still visible, at a glance (drop the ones
-   * place, keep the tens digit -> 0-9; a 100% (fully intact) value clamps to
-   * 9, but that case is gated out below since nothing was folded). Absent/100
-   * -> no badge. Live tiles never carry this. Drawn via a cached offscreen
-   * sprite (one per digit, 0-9 -> <=10 sprites), blitted like the dice/hatch
-   * sprites - no per-tile fillText in the hot loop, no filter/gradient.
+   * much of the original content is still visible, at a glance. The bracket
+   * size is bucketed into 6 bands (see remainingBand in engine/tokens) rather
+   * than scaled continuously: >=90% renders a nearly-complete border, <10%
+   * renders nothing. Absent/100 -> no border. Live tiles never carry this.
+   * Drawn via a cached offscreen sprite (one per band, 6 total), blitted like
+   * the dice/hatch sprites - no per-tile stroke() calls in the hot loop.
    */
   remainingPct?: number;
 };
@@ -337,43 +337,72 @@ function getHatchSprite(size: number, dpr: number): HTMLCanvasElement {
 }
 
 // ---------------------------------------------------------------------------
-// Remaining-digit sprite cache (PERF) - a folded tile's "how much is left" badge.
-// Like the hatch/dice sprites: rendered ONCE per distinct digit (0-9 -> <=10
-// entries) to an offscreen canvas, then blitted with drawImage in the hot loop.
-// NO per-tile ctx.fillText, NO filter/gradient. The cache is keyed by
-// (cellSize, dpr); it is rebuilt wholesale when either changes (mirrors the
-// hatch sprite's single-entry rebuild on size change, bounding memory).
+// Erosion-border sprite cache (PERF) - a folded tile's "how much is left" badge,
+// drawn as 4 corner brackets whose arm length steps through 6 discrete bands
+// (see remainingBand in engine/tokens). Like the hatch/dice sprites: rendered
+// ONCE per distinct band (6 entries) to an offscreen canvas, then blitted with
+// drawImage in the hot loop. NO per-tile stroke() calls, NO filter/gradient.
+// The cache is keyed by (cellSize, dpr); rebuilt wholesale when either changes
+// (mirrors the hatch sprite's single-entry rebuild on size change).
 // ---------------------------------------------------------------------------
-let _pctSprites: Map<number, HTMLCanvasElement> | null = null;
-let _pctKey = "";
-function getPctSprite(pct: number, size: number, dpr: number): HTMLCanvasElement {
-  const key = `${size}:${dpr}`;
-  if (!_pctSprites || _pctKey !== key) {
-    _pctSprites = new Map();
-    _pctKey = key;
+
+/**
+ * Bracket arm length as a fraction of tile size at full erosion (band 5).
+ * Ratio verified in the fold-badge-style mockup (13px arm on a 30px tile) —
+ * two opposing arms nearly meet along an edge but leave a small gap, so even
+ * a "full" (>=90%) border reads as a border, not a solid frame.
+ */
+export const BAND_ARM_MAX_FRACTION = 13 / 30;
+
+/** Bracket arm length (px) for a given 0-5 band at the given tile size. Pure
+ *  geometry, shared by the canvas sprite below and the DOM/sliver SVG render. */
+export function erosionArmLength(size: number, band: number): number {
+  const b = Math.max(0, Math.min(5, band));
+  return size * BAND_ARM_MAX_FRACTION * (b / 5);
+}
+
+function drawBandBracket(ctx: CanvasRenderingContext2D, size: number, band: number): void {
+  const arm = erosionArmLength(size, band);
+  if (arm <= 0) return;
+  const inset = 1;
+  // [x, y, arm-direction-x, arm-direction-y] for each of the 4 corners.
+  const corners: [number, number, number, number][] = [
+    [inset, inset, 1, 1],
+    [size - inset, inset, -1, 1],
+    [inset, size - inset, 1, -1],
+    [size - inset, size - inset, -1, -1],
+  ];
+  ctx.strokeStyle = "rgba(255,255,255,0.9)";
+  ctx.lineWidth = 1.5;
+  ctx.lineCap = "round";
+  ctx.beginPath();
+  for (const [cx, cy, dx, dy] of corners) {
+    ctx.moveTo(cx, cy);
+    ctx.lineTo(cx + dx * arm, cy);
+    ctx.moveTo(cx, cy);
+    ctx.lineTo(cx, cy + dy * arm);
   }
-  // Drop the ones place, keep the tens digit (0-9). The exact whole-percent is
-  // shown in the Inspector/Transcript/tooltips; the dense Map tile trades
-  // precision for a single glanceable digit + a cached, O(1)-per-tile blit.
-  const digit = remainingDigit(pct);
-  const c = _pctSprites.get(digit);
-  if (c) return c;
+  ctx.stroke();
+}
+
+let _bandSprites: Map<number, HTMLCanvasElement> | null = null;
+let _bandKey = "";
+function getBandSprite(band: number, size: number, dpr: number): HTMLCanvasElement {
+  const key = `${size}:${dpr}`;
+  if (!_bandSprites || _bandKey !== key) {
+    _bandSprites = new Map();
+    _bandKey = key;
+  }
+  const cached = _bandSprites.get(band);
+  if (cached) return cached;
   const cv = document.createElement("canvas");
   const px = Math.max(1, Math.round(size * dpr));
   cv.width = px;
   cv.height = px;
   const cx = cv.getContext("2d")!;
   cx.scale(dpr, dpr);
-  // Smoke (--muted #9A9A9A) mono label, top-right corner, inset 2px. Faint alpha keeps
-  // the folded tile's recessed, drained calm (the #1 brand signal) - information, not
-  // decoration. Never a spectrum hue; never on a live tile.
-  const fs = Math.max(7, Math.round(size * 0.32));
-  cx.font = `500 ${fs}px "IBM Plex Mono", ui-monospace, monospace`;
-  cx.fillStyle = "rgba(154,154,154,0.8)";
-  cx.textAlign = "right";
-  cx.textBaseline = "top";
-  cx.fillText(String(digit), size - 2, 2);
-  _pctSprites.set(digit, cv);
+  drawBandBracket(cx, size, band);
+  _bandSprites.set(band, cv);
   return cv;
 }
 
@@ -585,6 +614,19 @@ export function drawTile(
     }
   }
 
+  // ---- erosion border: corner brackets sized to the remaining-token band (6 steps,
+  // ---- see remainingBand). Drawn BEFORE the pinned/inrange/selected/hover rings below
+  // ---- so those rarer, more important interactive states always paint cleanly on top —
+  // ---- a tile that's also pinned/selected/inrange may show the border only partially,
+  // ---- but the precise percentage remains available in the tooltip/Transcript/Inspector.
+  // ---- < 100 (not >= 0) is the gate: 100 means nothing was folded away.
+  if (spec.remainingPct != null && spec.remainingPct < 100) {
+    const band = remainingBand(spec.remainingPct);
+    if (band > 0) {
+      ctx.drawImage(getBandSprite(band, w, opts.dpr ?? 1), x, y, w, h);
+    }
+  }
+
   // ---- pinned: inset 2px white ring (drawn before sel/inrange so sel ring sits on top) ----
   if (spec.pinned) {
     ctx.strokeStyle = "#ffffff";
@@ -633,15 +675,6 @@ export function drawTile(
     ctx.lineWidth = 1;
     roundRect(ctx, x + 0.5, y + 0.5, w - 1, h - 1, r);
     ctx.stroke();
-  }
-
-  // ---- remaining digit badge: folded blocks + collapsed groups (drawn LAST so it
-  // ---- stays readable over any selection/hover overlays; inset at the tile's top-right
-  // ---- corner so the edge selection/pinned rings stay crisp). Cached sprite blit - O(1) per tile.
-  // ---- < 100 (not >= 0) is the gate: 100 means nothing was folded away, so there's
-  // ---- nothing worth badging.
-  if (spec.remainingPct != null && spec.remainingPct < 100) {
-    ctx.drawImage(getPctSprite(spec.remainingPct, w, opts.dpr ?? 1), x, y, w, h);
   }
 
   ctx.restore();


### PR DESCRIPTION
Closes #44.

## What

Adds a small, on-brand reduction-percentage tag to every folded block and folded (collapsed) group so users can read how aggressive each fold was — light or heavy. Shows **% of tokens REMOVED** (`saved / full × 100`, rounded to a whole percent), consistent with the existing Map-header \"saves X tok\" copy.

## Brand & taste (read brand/accordion-brand-kit/brand.md first)

- **Smoke mono only** — `--muted` (`#9A9A9A`, the brand \"labels, metadata, fold states\" color) on IBM Plex Mono. Never a spectrum hue, never blue (blue is reserved for user blocks), never on a live tile. The tag keeps the folded tile's recessed, drained calm (the #1 brand signal) — information, not decoration.
- Folded = recessed; the % is faint and inset.
- No hype words (\"powerful,\" \"seamless,\" …).

## Three surfaces

| surface | what |
|---|---|
| Pure helper `engine/tokens.ts` | `reductionPct(full, live)` — divide-by-zero → 0; unit-tested |
| Map canvas `ui/map/tileDraw.ts` | `reductionPct?` on `TileSpec`; cached offscreen sprite per rounded-5% value (≤21) blitted with `drawImage` — no per-tile `fillText`, no `filter`/gradient (CLAUDE.md perf rule). Drawn last, inset at tile bottom |
| Map specs `ui/map/ContextMap.svelte` | compute `reductionPct` in `buildTilesSpecs` + `protSpecs` (folded blocks + collapsed groups) |
| Sliver mode `ContextMap.svelte` | `.cell-pct` Smoke-mono badge on summary tiles (ungrouped fold + group cocoa + peeked open-band parent) |
| Transcript `ContextMap.svelte` | `−N%` (`.tr-reduction`) on folded cards |
| Tooltips `ContextMap.svelte` | `tip`/`groupTip`/`foldTip` include `−N%` |
| Inspector `Inspector.svelte` | `−N%` in the token data row for folded blocks and folded groups (`.tok-reduction`) |

## Data (pure reads, no wire change)

- Folded block: `reductionPct(b.tokens, store.effTokens(b))`.
- Folded group: `reductionPct(store.groupFullTokens(g), store.groupLiveTokens(g))`. A drop group → live 0 → 100%, signalling \"the agent does not see this block\".
- Zero-token block → 0 → no tag rendered.

## Design calls left to the owner (made restrained defaults; flagged in case the screenshot loop wants to change)

- The dense Map canvas tile shows a **bare number** (e.g. `85`), not `−85%` — a ~20px tile can't legibly fit 4 chars. The Transcript/Inspector/tooltips carry the full `−N%` form, which establishes the number's meaning. A different glyph is a one-line sprite change.
- Map-canvas precision is rounded to nearest 5% (sprite-cache bound); Inspector/Transcript show the exact whole-percent.

## Verification

- `cd app && npm run check` → 0 errors / 0 warnings
- `cd app && npm run test` → 41 files, 809 tests passed (incl. new `tokens.test.ts` + 2 `tileDraw.test.ts` TileSpec cases)
- Did not run `npm run dev` (port 1420 may be busy; UI is for the owner's screenshot review).