### PR TITLE
fix(sidebar): mark loopback-only sessions in remote browser-served mode

### DIFF
--- a/app/src/lib/ui/live/SessionsSidebar.svelte
+++ b/app/src/lib/ui/live/SessionsSidebar.svelte
@@ -22,6 +22,8 @@
 		claudeSelected = null,
 		onselectclaude = () => {},
 		browserServed = false,
+		crossSessionRemote = false,
+		servedSessionId = null,
 	}: {
 		source?: "pi" | "claude";
 		onsource?: (s: "pi" | "claude") => void;
@@ -40,6 +42,13 @@
 		// the source switcher: browsing read-only Claude Code transcripts reads ~/.claude
 		// straight off disk, which still requires the Tauri Rust layer.
 		browserServed?: boolean;
+		// Browser-served over a non-loopback origin: only `servedSessionId` carries a token the
+		// extension accepts off-loopback, so every OTHER session row is un-steerable from here.
+		// We render those rows as loopback-only (dimmed, lock badge, non-clickable) so the rail
+		// never lists a session it cannot actually open. Both false/null in the common (desktop
+		// or same-machine) case, where every session is dialable.
+		crossSessionRemote?: boolean;
+		servedSessionId?: string | null;
 	} = $props();
 
 	const STORE_KEY = "accordion.sidebar.collapsed";
@@ -90,6 +99,13 @@
 	function label(s: SessionEntry): string {
 		return baseName(s.cwd) || s.title || "session";
 	}
+	// A session this rail can actually open. Off-loopback (crossSessionRemote) only the served
+	// session's token is valid, so every other row is loopback-only. Always true otherwise.
+	function steerable(s: SessionEntry): boolean {
+		return !crossSessionRemote || s.sessionId === servedSessionId;
+	}
+	const LOCKED_TIP =
+		"Loopback-only — served by a different pi session, so it can't be steered from this remote browser. Open it from that session's own /accordion URL.";
 
 	// browserServed forces the pi source (no CC transcript browsing without Tauri fs access).
 	const effectiveSource = $derived(browserServed ? "pi" : source);
@@ -124,14 +140,21 @@
 			<div class="icon-list">
 				{#each sessions as s (s.sessionId)}
 					{@const isSel = s.sessionId === selected}
+					{@const canSteer = steerable(s)}
 					<button
 						class="rail-btn dot-btn"
 						class:sel={isSel}
-						title={label(s)}
-						aria-label={label(s)}
-						onclick={() => onselect(s)}
+						class:locked={!canSteer}
+						title={canSteer ? label(s) : `${label(s)} — ${LOCKED_TIP}`}
+						aria-label={canSteer ? label(s) : `${label(s)} (loopback-only)`}
+						onclick={() => { if (canSteer) onselect(s); }}
+						aria-disabled={!canSteer}
 					>
-						<span class="status-dot" class:on={isSel && connected} class:steering={isSel && connected && folding.enabled}></span>
+						{#if canSteer}
+							<span class="status-dot" class:on={isSel && connected} class:steering={isSel && connected && folding.enabled}></span>
+						{:else}
+							<Icon name="lock" size={12} />
+						{/if}
 					</button>
 				{/each}
 			</div>
@@ -240,14 +263,24 @@
 						{#each sessions as s (s.sessionId)}
 							{@const p = pct(s)}
 							{@const isSel = s.sessionId === selected}
+							{@const canSteer = steerable(s)}
 							<li>
-								<button class="row" class:sel={isSel} onclick={() => onselect(s)} title={s.cwd}>
+								<button
+									class="row"
+									class:sel={isSel}
+									class:locked={!canSteer}
+									onclick={() => { if (canSteer) onselect(s); }}
+									aria-disabled={!canSteer}
+									title={canSteer ? s.cwd : LOCKED_TIP}
+								>
 									<span class="status-dot" class:on={isSel && connected} class:steering={isSel && connected && folding.enabled}></span>
 									<span class="body">
 										<span class="t1">{label(s)}</span>
 										<span class="t2 mono">{shortModel(s.model)}</span>
 									</span>
-									{#if p !== null}
+									{#if !canSteer}
+										<span class="lock-badge mono" title={LOCKED_TIP}><Icon name="lock" size={10} />local</span>
+									{:else if p !== null}
 										<span class="usage" title={`${s.tokens} / ${s.contextWindow} tokens`}>
 											<span class="bar"><span class="fill" class:hot={p >= 80} style:width={`${p}%`}></span></span>
 											<span class="pct mono"><AnimatedNumber value={s.tokens ?? 0} format={fmtTokens} /></span>
@@ -789,6 +822,35 @@
 		border: 1px solid var(--line);
 		border-radius: var(--radius-sm);
 		padding: 1px var(--sp-1);
+	}
+
+	/* ===== Loopback-only (un-steerable from a remote browser) rows ===== */
+	.row.locked {
+		cursor: default;
+		opacity: 0.5;
+	}
+	.row.locked:hover {
+		background: transparent; /* no hover affordance — it isn't clickable */
+	}
+	.dot-btn.locked {
+		cursor: default;
+		opacity: 0.5;
+		color: var(--faint);
+	}
+	.dot-btn.locked:hover {
+		background: transparent;
+		border-color: transparent;
+		color: var(--faint);
+	}
+	.lock-badge {
+		flex: 0 0 auto;
+		display: flex;
+		align-items: center;
+		gap: 3px;
+		font-size: var(--fs-2xs);
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--faint);
 	}
 
 	/* ===== CC footer note ===== */

--- a/app/src/lib/ui/live/SessionsSidebar.svelte
+++ b/app/src/lib/ui/live/SessionsSidebar.svelte
@@ -149,6 +149,7 @@
 						aria-label={canSteer ? label(s) : `${label(s)} (loopback-only)`}
 						onclick={() => { if (canSteer) onselect(s); }}
 						aria-disabled={!canSteer}
+						tabindex={canSteer ? undefined : -1}
 					>
 						{#if canSteer}
 							<span class="status-dot" class:on={isSel && connected} class:steering={isSel && connected && folding.enabled}></span>
@@ -271,6 +272,7 @@
 									class:locked={!canSteer}
 									onclick={() => { if (canSteer) onselect(s); }}
 									aria-disabled={!canSteer}
+									tabindex={canSteer ? undefined : -1}
 									title={canSteer ? s.cwd : LOCKED_TIP}
 								>
 									<span class="status-dot" class:on={isSel && connected} class:steering={isSel && connected && folding.enabled}></span>

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -26,6 +26,10 @@
 	let manualPort = $state(DEFAULT_PORT);
 	let activityOpen = $state(false);
 	let browserServed = $state(false);
+	// The sessionId that SERVED this page (from /__accordion/meta). In browser-served mode
+	// its per-session token is the one carried in our URL, so off-loopback it is the ONLY
+	// session we can actually steer — see crossSessionRemote / selectAndConnect.
+	let servedSessionId = $state<string | null>(null);
 
 	// Which session source the sidebar lists: live pi vs read-only Claude Code.
 	const SRC_KEY = "accordion.sidebar.source";
@@ -131,8 +135,34 @@
 		return new URLSearchParams(window.location.search).get("token");
 	}
 
+	// A page origin the extension's verifyWsUpgrade treats as loopback — dialed tokenless,
+	// so cross-session switching Just Works. Anything else (a LAN IP or a real hostname) is
+	// off-loopback: the WS upgrade then requires each session's OWN token, and we only hold
+	// the served session's. Mirrors isLoopbackPeer in extension/accordion.ts.
+	function isLoopbackHost(host: string): boolean {
+		return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
+	}
+
+	// True when this browser-served page was reached over a NON-loopback origin. In that case
+	// only the served session is steerable (its token is in our URL); every OTHER discovered
+	// session carries a different token the extension would reject, so we mark those rows as
+	// loopback-only rather than let a click fail with a generic "could not reach pi" error.
+	// Gated on knowing the served id: without it we can't tell WHICH row is the steerable one,
+	// so we fail open (mark nothing) rather than risk locking the connected session too.
+	const crossSessionRemote = $derived(
+		browserServed &&
+			typeof window !== "undefined" &&
+			!isLoopbackHost(window.location.hostname) &&
+			servedSessionId !== null,
+	);
+
 	function selectAndConnect(s: SessionEntry): void {
 		if (discovery.selected === s.sessionId && live.status === "connected") return;
+		// Off-loopback, only the served session's token is valid (see crossSessionRemote). The
+		// sidebar already renders these rows as loopback-only/non-clickable; guard here too so
+		// no path (e.g. an /accordion focus request) can dial a session that would just be
+		// token-rejected and surface a misleading "could not reach pi" error.
+		if (crossSessionRemote && s.sessionId !== servedSessionId) return;
 		session.readOnly = false; // a live pi session is steerable, not read-only
 		claudeDiscovery.selected = null;
 		discovery.selected = s.sessionId;
@@ -193,6 +223,7 @@
 					const body = await res.json() as { served?: boolean; sessionId?: string; protocolVersion?: number };
 					if (body.served !== true) return;
 					browserServed = true;
+					servedSessionId = body.sessionId ?? null;
 					// This session's own port is dialed immediately so the view doesn't wait on
 					// the first discovery poll; the sidebar itself (below) is populated by
 					// startBrowserDiscovery, which lists every OTHER live session too.
@@ -259,6 +290,8 @@
 			claudeSelected={claudeDiscovery.selected}
 			onselectclaude={selectClaudeSession}
 			{browserServed}
+			{crossSessionRemote}
+			{servedSessionId}
 		/>
 	{/if}
 

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -138,9 +138,20 @@
 	// A page origin the extension's verifyWsUpgrade treats as loopback — dialed tokenless,
 	// so cross-session switching Just Works. Anything else (a LAN IP or a real hostname) is
 	// off-loopback: the WS upgrade then requires each session's OWN token, and we only hold
-	// the served session's. Mirrors isLoopbackPeer in extension/accordion.ts.
+	// the served session's. Mirrors isLoopbackPeer in extension/accordion.ts — including the
+	// IPv4-mapped prefix strip — but also unwraps the `[…]` brackets that location.hostname
+	// puts around an IPv6 literal and accepts the fully-expanded ::1 spelling, so an
+	// IPv6-loopback URL isn't mistaken for remote (which would falsely lock every sibling).
 	function isLoopbackHost(host: string): boolean {
-		return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
+		let h = host.toLowerCase();
+		if (h.startsWith("[") && h.endsWith("]")) h = h.slice(1, -1); // [::1] → ::1
+		if (h.startsWith("::ffff:")) h = h.slice(7); // IPv4-mapped IPv6 → bare IPv4
+		return (
+			h === "localhost" ||
+			h === "127.0.0.1" ||
+			h === "::1" ||
+			h === "0:0:0:0:0:0:0:1"
+		);
 	}
 
 	// True when this browser-served page was reached over a NON-loopback origin. In that case
@@ -159,9 +170,9 @@
 	function selectAndConnect(s: SessionEntry): void {
 		if (discovery.selected === s.sessionId && live.status === "connected") return;
 		// Off-loopback, only the served session's token is valid (see crossSessionRemote). The
-		// sidebar already renders these rows as loopback-only/non-clickable; guard here too so
-		// no path (e.g. an /accordion focus request) can dial a session that would just be
-		// token-rejected and surface a misleading "could not reach pi" error.
+		// sidebar already renders these rows as loopback-only/non-clickable, so this is
+		// defense-in-depth for the click path: refuse the dial rather than let it fail with a
+		// misleading "could not reach pi" error if a locked row is ever activated anyway.
 		if (crossSessionRemote && s.sessionId !== servedSessionId) return;
 		session.readOnly = false; // a live pi session is steerable, not read-only
 		claudeDiscovery.selected = null;


### PR DESCRIPTION
## What

In browser-served multi-session mode (PR #50), the sidebar lists every live pi session, but `selectAndConnect` reuses **this page's own** per-session token for every discovered sibling. On loopback that's fine — `verifyWsUpgrade` ignores the token for loopback peers. But from a genuinely remote / `0.0.0.0`-bound origin, a sibling session rejects that token (each session mints its own), so the click failed with the generic **"could not reach pi on :port — is a pi session running?"** error. The rail advertised sessions it could not actually open.

## Fix

Make the state honest (option **b** from the task — visually mark un-dialable rows):

- When the page was reached over a **non-loopback** origin, only the **served** session (whose token is in our URL) is steerable. Every other row renders **loopback-only**: dimmed, a lock badge (expanded) / lock icon (collapsed rail), non-clickable, with a tooltip pointing the user at that session's own `/accordion` URL.
- `selectAndConnect` guards the same condition, so no path (including `/accordion` focus requests) dials a session that would just be token-rejected and surface the misleading error.
- **Fails open** — marks nothing — when the served session id is unknown, and is fully inert on desktop / same-machine (loopback) where every session is dialable.

Detection mirrors the extension's `isLoopbackPeer` split in `extension/accordion.ts`: loopback origin ⇒ tokenless WS upgrade ⇒ every sibling dialable; otherwise only the served session's token is accepted off-loopback.

Non-blocking UX polish, not a correctness bug — no wire/protocol change.

## Verification

- `npm run check` — 0 errors / 0 warnings
- `npm run test` — 797 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)