### PR TITLE
feat(conductors): portEnv launch.json convention for host-assigned ports

### DIFF
--- a/conductors/README.md
+++ b/conductors/README.md
@@ -145,6 +145,14 @@ endpoint that Accordion dials as a client; the `context/update` frame carries th
 heartbeat file at `~/.accordion/conductors/<id>.json` so the desktop app auto-discovers them;
 off-box ones are added by `ws://` URL in the header dropdown.
 
+Each out-of-process conductor also ships a `launch.json` manifest — `{ id, label, command,
+args, portEnv? }` — that lets a host spawn it directly (the desktop app's "launch" button and
+headless harnesses like bellows both use it). The optional `portEnv` names the environment
+variable the conductor reads its listen port from (e.g. `"THERMO_PORT"`); declaring it lets a
+harness assign a free port per run so several instances can coexist. A conductor without
+`portEnv` can only run one instance at a time. Conductors should also honor `ACCORDION_HOME`
+for the heartbeat directory — every conductor in this repo already does.
+
 The runnable wire example is [`recency-folder/`](recency-folder/) (Node.js). The full
 lifecycle and message reference is the second half of
 [`docs/conductor-protocol.md`](../docs/conductor-protocol.md).

--- a/conductors/attention-folder/launch.json
+++ b/conductors/attention-folder/launch.json
@@ -2,5 +2,6 @@
   "id": "attention-folder",
   "label": "Attention folder",
   "command": "node",
-  "args": ["attention-folder.mjs"]
+  "args": ["attention-folder.mjs"],
+  "portEnv": "ATTN_PORT"
 }

--- a/conductors/recency-folder/launch.json
+++ b/conductors/recency-folder/launch.json
@@ -2,5 +2,6 @@
   "id": "recency-folder",
   "label": "Recency folder",
   "command": "node",
-  "args": ["recency-folder.js"]
+  "args": ["recency-folder.js"],
+  "portEnv": "RECENCY_PORT"
 }

--- a/conductors/recency-folder/recency-folder.js
+++ b/conductors/recency-folder/recency-folder.js
@@ -20,7 +20,7 @@ import { join } from "node:path";
 
 const ID = "recency-folder";
 const LABEL = "Recency folder";
-const PORT = 7700;
+const PORT = Number(process.env.RECENCY_PORT) || 7700;
 const URL = `ws://127.0.0.1:${PORT}`;
 
 // ── Auto-discovery: advertise a heartbeat file under ~/.accordion/conductors/ ──

--- a/conductors/the-conductor-v2/launch.json
+++ b/conductors/the-conductor-v2/launch.json
@@ -2,5 +2,6 @@
   "id": "the-conductor-v2",
   "label": "The Conductor v2",
   "command": "node",
-  "args": ["the-conductor.ts"]
+  "args": ["the-conductor.ts"],
+  "portEnv": "CONDUCTOR_PORT"
 }

--- a/conductors/the-conductor/launch.json
+++ b/conductors/the-conductor/launch.json
@@ -2,5 +2,6 @@
   "id": "the-conductor",
   "label": "The Conductor",
   "command": "node",
-  "args": ["the-conductor.ts"]
+  "args": ["the-conductor.ts"],
+  "portEnv": "CONDUCTOR_PORT"
 }

--- a/conductors/thermocline/README.md
+++ b/conductors/thermocline/README.md
@@ -119,7 +119,7 @@ The port and all tuning knobs can be overridden via environment variables. Defau
 - `scorer.mjs` — thin re-export shim: delegates to `../attention-folder/scorer.mjs` so the probe path is always correct regardless of invocation cwd.
 - `policy.test.mjs` — unit tests for the pure policy (`node --test`, no GPU, no Python, no WS).
 - `package.json` — `start` / `test` scripts; single dep: `ws`.
-- `launch.json` — VS Code launch config.
+- `launch.json` — launcher manifest (`{ id, label, command, args, portEnv }`) used by hosts to spawn thermocline directly.
 
 ## Governance
 

--- a/conductors/thermocline/launch.json
+++ b/conductors/thermocline/launch.json
@@ -2,5 +2,6 @@
   "id": "thermocline",
   "label": "Thermocline",
   "command": "node",
-  "args": ["thermocline.mjs"]
+  "args": ["thermocline.mjs"],
+  "portEnv": "THERMO_PORT"
 }

--- a/conductors/tiered-relevance/launch.json
+++ b/conductors/tiered-relevance/launch.json
@@ -2,5 +2,6 @@
   "id": "tiered-relevance",
   "label": "Tiered relevance",
   "command": "node",
-  "args": ["tiered-relevance.mjs"]
+  "args": ["tiered-relevance.mjs"],
+  "portEnv": "TIERS_PORT"
 }


### PR DESCRIPTION
## Why

External-conductor benchmarking (bellows Track A) needs to spawn out-of-process conductors with a **host-assigned port** so parallel arms don't collide on each conductor's default port. Nothing in the manifest previously declared *which* env var controls the port.

## What

- `launch.json` gains an optional `portEnv` field naming the env var the conductor reads its listen port from. Added to all six out-of-process conductors (`THERMO_PORT`, `ATTN_PORT`, `TIERS_PORT`, `CONDUCTOR_PORT` ×2, `RECENCY_PORT`).
- `recency-folder` learns `RECENCY_PORT` (port was hardcoded 7700) — one line.
- Convention documented in the escape-hatch section of `conductors/README.md`.
- Fixed thermocline README mislabeling `launch.json` as a VS Code config.

## Safety

The Tauri launcher parses the manifest as loose `serde_json::Value` and reads only `command`/`args` — the extra field is inert for the desktop app. Additive, no behavior change for any existing flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)