### PR TITLE
fix(extension): stale-plan fallback + steering mode + plan RTT (#58)

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -72,6 +72,23 @@ reasons over at full fidelity.
 <img src="https://raw.githubusercontent.com/a-Fig/Accordion/main/docs/assets/attention-conductor.png" alt="Attention conductor view — each block tinted by how much the working tail still attends back to it" width="600">
 </div>
 
+## Configuration
+
+Advanced knobs, read from the environment once when the extension loads. Defaults are
+tuned for interactive use; the steering knobs matter mainly for benchmark harnesses that
+must enforce a hard context budget.
+
+| Env var | Default | Effect |
+|---|---|---|
+| `ACCORDION_PLAN_TIMEOUT_MS` | `250` | How long a model request waits for the GUI's fold plan before falling back. On a miss the extension re-applies the **last known plan** rather than shipping the conversation unfolded (a one-turn-stale plan is strictly better than none), and logs the fallback — it is never silent. |
+| `ACCORDION_STEERING` | off | Truthy (`1`/`true`) switches the wait to a hard **deadline** (`ACCORDION_PLAN_DEADLINE_MS`) instead of the short timeout, so a run whose cap must hold actually holds it. A missed deadline is logged loudly and still falls back to the last known plan. It never blocks when no GUI is attached, and a mid-wait disconnect resolves immediately. |
+| `ACCORDION_PLAN_DEADLINE_MS` | `10000` | Steering-mode deadline. Ignored unless `ACCORDION_STEERING` is on. |
+
+Invalid values (non-numeric, `NaN`, `≤0`) fall back to the default.
+
+Each request also records the plan round-trip time it waited, stamped onto the assistant
+message it produced as `usage.rttMs` (integer milliseconds) in the session file.
+
 ## Skills included
 
 This package registers two pi skills the agent uses to interact with folded context:

--- a/extension/README.md
+++ b/extension/README.md
@@ -81,10 +81,12 @@ must enforce a hard context budget.
 | Env var | Default | Effect |
 |---|---|---|
 | `ACCORDION_PLAN_TIMEOUT_MS` | `250` | How long a model request waits for the GUI's fold plan before falling back. On a miss the extension re-applies the **last known plan** rather than shipping the conversation unfolded (a one-turn-stale plan is strictly better than none), and logs the fallback — it is never silent. |
-| `ACCORDION_STEERING` | off | Truthy (`1`/`true`) switches the wait to a hard **deadline** (`ACCORDION_PLAN_DEADLINE_MS`) instead of the short timeout, so a run whose cap must hold actually holds it. A missed deadline is logged loudly and still falls back to the last known plan. It never blocks when no GUI is attached, and a mid-wait disconnect resolves immediately. |
+| `ACCORDION_STEERING` | off | Truthy (`1`/`true`) switches the wait to a hard **deadline** (`ACCORDION_PLAN_DEADLINE_MS`) instead of the short timeout, so a run whose cap must hold actually holds it. A missed deadline is logged loudly and still falls back to the last known plan. It never blocks when no GUI is attached, and a mid-wait disconnect resolves immediately. **Caution:** a hung-but-connected GUI (socket open, not replying) stalls *every* model request by the full deadline (10s by default) — there is deliberately no circuit breaker yet; a consecutive-miss breaker is tracked as follow-up work. |
 | `ACCORDION_PLAN_DEADLINE_MS` | `10000` | Steering-mode deadline. Ignored unless `ACCORDION_STEERING` is on. |
 
-Invalid values (non-numeric, `NaN`, `≤0`) fall back to the default.
+Invalid values (non-numeric, `NaN`, `≤0`, or non-integer such as `"250.5"`) fall back to
+the default. Values are parsed with `Number()`, so scientific notation (`"1e3"`) and hex
+(`"0x10"`) are also accepted as long as they resolve to a positive integer.
 
 Each request also records the plan round-trip time it waited, stamped onto the assistant
 message it produced as `usage.rttMs` (integer milliseconds) in the session file.

--- a/extension/accordion.ts
+++ b/extension/accordion.ts
@@ -20,7 +20,12 @@
  *   • The plan reply times out → apply the LAST KNOWN plan instead of silently
  *     passing through unfolded (issue #58: a stale one-turn plan is strictly better
  *     than shipping the whole conversation past budget). If there is no cached plan
- *     yet, pass through as before — but always log the timeout (never silent).
+ *     yet, pass through as before — but always log the timeout (never silent). Note:
+ *     on a timeout-with-stale-fallback turn, what the GUI is showing can diverge for
+ *     that one turn from what the extension actually sent the model (the stale plan
+ *     may be missing folds/unfolds the GUI has since queued) — the fold alarm has no
+ *     visibility into this, since it never receives the applied plan back. The next
+ *     plan the GUI delivers resyncs both sides.
  *   • pi's native /compact is suppressed ONLY while the GUI is attached.
  *   • The shared mapping (linearize/applyPlan) carries the provider-safety rules
  *     (durable-id + kind checks); the engine is the single foldability gate and
@@ -35,7 +40,10 @@
  *     logged loudly and still falls back to the last known plan (or passthrough). It
  *     never blocks when no GUI is attached, and a mid-wait disconnect resolves at once.
  *   • ACCORDION_PLAN_DEADLINE_MS — steering-mode deadline (positive int, default 10000).
- *   Invalid values (NaN / ≤0) fall back to the default.
+ *   Parsed with `Number()`, then required to be a positive integer. Invalid values
+ *   (missing / NaN / ≤0 / non-integer, e.g. "250.5") fall back to the default. Note
+ *   `Number()` accepts more than plain decimal — scientific notation ("1e3") and hex
+ *   ("0x10") are both valid positive integers and will be honored, not rejected.
  *
  * Plan round-trip time (RTT): each `context` hook measures how long it waited on the
  * plan and stamps it onto the assistant message it produced as `usage.rttMs` (integer
@@ -906,6 +914,14 @@ export default function accordionLive(pi: ExtensionAPI): void {
 
 	// ── lifecycle ──────────────────────────────────────────────────────────────
 	pi.on("session_start", (_event, ctx: ExtensionContext) => {
+		// Invalidate any `context` await still in flight from the OLD session BEFORE resetting
+		// the cursor below — mirrors the GUI-reconnect path (flushPending() then epoch++).
+		// Without this, a plan for the old session that lands after this switch still passes
+		// the epoch guard (`epoch !== myEpoch`) and applies against the NEW session: it
+		// re-inflates `sentCount` with the old session's block count (delta-cursor corruption)
+		// and overwrites `lastPlan` with the old session's plan.
+		flushPending();
+		epoch++;
 		latestCtx = ctx;
 		sessionId = `s-${process.pid}-${Date.now()}`;
 		sentCount = 0;
@@ -988,6 +1004,11 @@ export default function accordionLive(pi: ExtensionAPI): void {
 	// only an explicit `{ messages }` replaces them. Every passthrough path below
 	// returns undefined, so we never alter a model call without a plan.
 	pi.on("context", async (event, ctx: ExtensionContext) => {
+		// Clear any stash from a previous request FIRST, before the no-GUI early return below.
+		// Otherwise an aborted turn (no assistant message_end to consume it) followed by a GUI
+		// detach leaves the old RTT sitting in the stash, and the next message_end — for an
+		// unrelated message — stamps it on the wrong reply.
+		lastPlanRttMs = null;
 		latestCtx = ctx;
 		const myEpoch = epoch;
 		// Refresh model/usage in memory only — NO disk I/O on the model-call critical
@@ -1024,9 +1045,15 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			sentCount = Math.max(sentCount, all.length);
 			const elapsed = lastPlanRttMs;
 			const hasStale = !!lastPlan && (lastPlan.ops.length > 0 || lastPlan.groups.length > 0);
+			// Three distinct outcomes, not two: a cached EMPTY plan (lastPlan set, 0 ops/groups —
+			// the conductor explicitly asked for no folds) still passes through unfolded, same as
+			// genuinely having no cached plan at all — but the two causes are worth telling apart
+			// in the log rather than both reading as "no cached plan".
 			const detail = hasStale
 				? `applying last known plan (${lastPlan!.ops.length} ops, ${lastPlan!.groups.length} groups)`
-				: "no cached plan — passing through unfolded";
+				: lastPlan
+					? "cached plan is empty (no folds) — passing through unfolded"
+					: "no cached plan — passing through unfolded";
 			if (STEERING) {
 				// Steering promised to hold the budget and didn't: shout, don't whisper.
 				console.error(`[accordion] STEERING deadline missed: plan reqId=${reqId} did not arrive within ${PLAN_WAIT_MS}ms (waited ${elapsed}ms) — ${detail}`);
@@ -1118,8 +1145,13 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			replacement = { ...(event.message as object), usage: { ...(finished.usage ?? {}), rttMs } } as unknown as AgentMessage;
 		}
 
+		// pi's MessageEndEventResult requires `{ message }` — emitMessageEnd does
+		// `if (!handlerResult?.message) continue;`, so a bare message is silently
+		// dropped and the RTT stamp never reaches the session file. Wrap every exit.
+		const finish = () => (replacement ? { message: replacement } : undefined);
+
 		const ws = client;
-		if (!ws || ws.readyState !== 1) return replacement; // no GUI → nothing to push (still stamp RTT)
+		if (!ws || ws.readyState !== 1) return finish(); // no GUI → nothing to push (still stamp RTT)
 
 		// Guaranteed teardown (invariant #2, ADR 0003): sweep all active ghosts as a
 		// backstop. Any ghost not already resolved by its own *_end frame is cleared
@@ -1146,12 +1178,12 @@ export default function accordionLive(pi: ExtensionAPI): void {
 		if (msgIds.size > 0 && !alreadySeen) pendingSince.push(msg);
 
 		const all = linearize([...lastMessages, ...pendingSince]);
-		if (all.length <= sentCount) return replacement; // nothing new to push (RTT stamp still returned)
+		if (all.length <= sentCount) return finish(); // nothing new to push (RTT stamp still returned)
 		const reqId = ++reqSeq;
 		const full = sentCount === 0;
 		send(ws, { type: "sync", reqId, full, blocks: all.slice(sentCount) });
 		sentCount = all.length; // advance cursor; agent_end and next context will dedup
-		return replacement; // hand the RTT-stamped assistant message back to pi (undefined = unchanged)
+		return finish(); // hand the RTT-stamped assistant message back to pi, wrapped per MessageEndEventResult (undefined = unchanged)
 	});
 
 	// ── live view: push the assistant's reply the moment the loop ends ──────────

--- a/extension/accordion.ts
+++ b/extension/accordion.ts
@@ -16,12 +16,30 @@
  * becoming duplicate windows).
  *
  * Safety:
- *   • No GUI connected, or the plan reply times out → pass messages through
- *     UNMODIFIED. We never corrupt context.
+ *   • No GUI connected → pass messages through UNMODIFIED. We never corrupt context.
+ *   • The plan reply times out → apply the LAST KNOWN plan instead of silently
+ *     passing through unfolded (issue #58: a stale one-turn plan is strictly better
+ *     than shipping the whole conversation past budget). If there is no cached plan
+ *     yet, pass through as before — but always log the timeout (never silent).
  *   • pi's native /compact is suppressed ONLY while the GUI is attached.
  *   • The shared mapping (linearize/applyPlan) carries the provider-safety rules
  *     (durable-id + kind checks); the engine is the single foldability gate and
  *     never folds a protected block, so no wire-side position backstop is needed.
+ *
+ * Env configuration (read once at module init):
+ *   • ACCORDION_PLAN_TIMEOUT_MS  — how long a `context` hook waits on the GUI's plan
+ *     before falling back (positive int, default 250).
+ *   • ACCORDION_STEERING         — truthy ("1"/"true", case-insensitive) switches the
+ *     plan wait to a hard DEADLINE (ACCORDION_PLAN_DEADLINE_MS) instead of the short
+ *     timeout, so a benchmark harness actually enforces its cap. A missed deadline is
+ *     logged loudly and still falls back to the last known plan (or passthrough). It
+ *     never blocks when no GUI is attached, and a mid-wait disconnect resolves at once.
+ *   • ACCORDION_PLAN_DEADLINE_MS — steering-mode deadline (positive int, default 10000).
+ *   Invalid values (NaN / ≤0) fall back to the default.
+ *
+ * Plan round-trip time (RTT): each `context` hook measures how long it waited on the
+ * plan and stamps it onto the assistant message it produced as `usage.rttMs` (integer
+ * ms), so downstream tooling can see per-request wait cost. See the `message_end` hook.
  *
  * Milestone 1: the GUI replies with an empty plan, so this never alters a model
  * call — it only proves the loop and powers the live view.
@@ -46,6 +64,17 @@ import { DEFAULT_PORT, PROTOCOL_VERSION, type FoldOp, type GroupOp, type ServerM
 
 /** The GUI's reply to a sync: in-place fold ops + group-collapse ops (ADR 0006). */
 type Plan = { ops: FoldOp[]; groups: GroupOp[] };
+/**
+ * Outcome of awaiting a plan (issue #58). The old code collapsed all three cases into
+ * a single `{ops:[],groups:[]}`/`null`, so a genuine empty plan (conductor wants no
+ * folds) was indistinguishable from a timeout (GUI too slow) — the timeout then passed
+ * through UNFOLDED and silently. This discriminates them:
+ *   • "plan"    — the GUI delivered a plan (possibly genuinely empty).
+ *   • "timeout" — the wait elapsed with no reply → fall back to the last known plan.
+ *   • "unsent"  — nothing was delivered (no GUI at call time, or the socket dropped /
+ *                 was superseded mid-wait via flushPending) → passthrough, don't advance.
+ */
+type PlanResult = { kind: "plan"; plan: Plan } | { kind: "timeout" } | { kind: "unsent" };
 import {
 	REGISTRY_PROTOCOL,
 	REGISTRY_DIR,
@@ -56,7 +85,33 @@ import {
 	type FocusRequest,
 } from "../app/src/lib/live/registry";
 
-const REQUEST_TIMEOUT_MS = 250; // how long pi waits on the GUI before passing through
+// Env-config helpers. Parse defensively: a positive integer only, anything else
+// (missing / non-numeric / NaN / ≤0 / non-integer) falls back to the default.
+function envPositiveInt(name: string, fallback: number): number {
+	const raw = process.env[name];
+	if (typeof raw !== "string") return fallback;
+	const n = Number(raw.trim());
+	return Number.isInteger(n) && n > 0 ? n : fallback;
+}
+// Truthy env flag: "1" or "true" (case-insensitive). Everything else is false.
+function envTruthy(name: string): boolean {
+	const raw = process.env[name];
+	if (typeof raw !== "string") return false;
+	const v = raw.trim().toLowerCase();
+	return v === "1" || v === "true";
+}
+
+// How long a `context` hook waits on the GUI before falling back (issue #58). This
+// used to be a silent 250ms passthrough; it is now configurable and the fallback is
+// no longer silent (stale plan + log — see the `context` hook).
+const PLAN_TIMEOUT_MS = envPositiveInt("ACCORDION_PLAN_TIMEOUT_MS", 250);
+// Steering (blocking) mode: enforce the budget by waiting a hard DEADLINE for the plan
+// instead of the short timeout, so a benchmark run whose cap must hold actually holds it.
+const STEERING = envTruthy("ACCORDION_STEERING");
+const PLAN_DEADLINE_MS = envPositiveInt("ACCORDION_PLAN_DEADLINE_MS", 10_000);
+// The wait a `context` plan request actually uses: the long deadline under steering,
+// the short timeout otherwise. Either way a missed wait falls back (stale plan / passthrough).
+const PLAN_WAIT_MS = STEERING ? PLAN_DEADLINE_MS : PLAN_TIMEOUT_MS;
 // Unfold replies arrive during the agent's OWN turn (not on the model-call critical
 // path), so a generous wait is fine — the user's next message isn't blocked.
 const UNFOLD_TIMEOUT_MS = 2000;
@@ -223,7 +278,17 @@ export default function accordionLive(pi: ExtensionAPI): void {
 	let sentCount = 0; // blocks already streamed to the current client
 	let reqSeq = 0;
 	let epoch = 0; // bumped on every new GUI connection; invalidates in-flight requests
-	const pending = new Map<number, (plan: Plan) => void>();
+	const pending = new Map<number, (r: PlanResult) => void>();
+	// Last plan the GUI DELIVERED (issue #58). Cached — including a genuinely empty plan
+	// (empty = "conductor wants no folds", so caching it prevents wrongly re-applying an
+	// older non-empty plan) — so a timed-out `context` can apply it instead of shipping the
+	// whole conversation unfolded. Reset wherever the cursor/epoch resets (session_start +
+	// GUI (re)connect): a plan from a superseded view must never apply to a fresh sync.
+	let lastPlan: Plan | null = null;
+	// Most recent plan round-trip time (ms), stashed by `context` and consumed by
+	// `message_end` to stamp `usage.rttMs` on the assistant message this request produced.
+	// null = no context RTT to attribute (e.g. no GUI attached this turn) → no field stamped.
+	let lastPlanRttMs: number | null = null;
 	// Unfold requests: keyed by reqId, resolved when the GUI replies (or null on flush).
 	// Deliberately NOT reset on reconnect (unlike reqSeq): a late reply from a superseded
 	// GUI can never alias a fresh request's reqId, and flushPending() drains the map anyway.
@@ -267,9 +332,13 @@ export default function accordionLive(pi: ExtensionAPI): void {
 
 	const attached = (): boolean => !!client && client.readyState === 1; /* OPEN */
 
-	/** Resolve every outstanding request as passthrough (used on connect-swap / shutdown). */
+	/** Resolve every outstanding request as passthrough (used on connect-swap / disconnect / shutdown). */
 	function flushPending(): void {
-		for (const resolve of pending.values()) resolve({ ops: [], groups: [] });
+		// "unsent": the GUI is gone (superseded / dropped / shutting down), so the in-flight
+		// `context` awaits pass through WITHOUT advancing the cursor — same meaning as before
+		// (an undeliverable request never alters or claims-as-sent a model call). Distinct from
+		// a timeout, which DID deliver blocks and falls back to the last known plan.
+		for (const resolve of pending.values()) resolve({ kind: "unsent" });
 		pending.clear();
 		// In-flight unfold requests (if any) must also be resolved. null signals "not
 		// attached" — the tool returns a safe "did not respond" message to the agent.
@@ -615,6 +684,7 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			epoch++;
 			sentCount = 0; // re-sync the whole context to the freshly-connected GUI
 			reqSeq = 0;
+			lastPlan = null; // a new view starts with no known plan; never apply the old one to it
 			send(ws, { type: "hello", protocolVersion: PROTOCOL_VERSION, sessionId, meta });
 
 			// Flush existing history IMMEDIATELY on attach. Without this, a session that
@@ -650,7 +720,10 @@ export default function accordionLive(pi: ExtensionAPI): void {
 					const resolve = pending.get(msg.reqId);
 					if (resolve) {
 						pending.delete(msg.reqId);
-						resolve({ ops: Array.isArray(msg.ops) ? msg.ops : [], groups: Array.isArray(msg.groups) ? msg.groups : [] });
+						// A delivered plan — possibly genuinely empty. "plan" (not the "timeout"/"unsent"
+						// sentinels) tells the context hook the GUI actually replied, so an empty reply
+						// is honored as "no folds" and cached, not mistaken for a slow/absent GUI.
+						resolve({ kind: "plan", plan: { ops: Array.isArray(msg.ops) ? msg.ops : [], groups: Array.isArray(msg.groups) ? msg.groups : [] } });
 					}
 				}
 				if (msg?.type === "unfoldResult" && typeof msg.reqId === "number") {
@@ -748,7 +821,14 @@ export default function accordionLive(pi: ExtensionAPI): void {
 				}
 			});
 			const drop = () => {
-				if (client === ws) client = null;
+				if (client === ws) {
+					client = null;
+					// The active GUI dropped mid-flight: resolve any in-flight plan/unfold/recall
+					// waits at once instead of letting them run out their timers. This matters most
+					// in steering mode, where the plan wait is a multi-second deadline — without this
+					// a disconnect would stall the model call until that deadline elapsed.
+					flushPending();
+				}
 			};
 			ws.on("close", drop);
 			ws.on("error", drop);
@@ -762,20 +842,28 @@ export default function accordionLive(pi: ExtensionAPI): void {
 		});
 	}
 
-	/** Send a sync and await the GUI's plan; resolves an empty plan on timeout, null if unsent. */
-	function requestPlan(reqId: number, full: boolean, blocks: ReturnType<typeof linearize>): Promise<Plan | null> {
+	/**
+	 * Send a sync and await the GUI's plan. Resolves a discriminated PlanResult:
+	 *   • "unsent"  — no GUI attached at call time (nothing sent).
+	 *   • "timeout" — sent, but no reply within PLAN_WAIT_MS (the caller falls back to
+	 *                 the last known plan). The wait is PLAN_DEADLINE_MS under steering.
+	 *   • "plan"    — the GUI replied (delivered via the pending resolver / flushPending).
+	 * The pending resolver is also driven by flushPending() (→ "unsent") on a superseded /
+	 * dropped / shutting-down GUI, so a mid-wait disconnect never runs out the full timer.
+	 */
+	function requestPlan(reqId: number, full: boolean, blocks: ReturnType<typeof linearize>): Promise<PlanResult> {
 		return new Promise((resolve) => {
 			const ws = client;
-			if (!ws || ws.readyState !== 1) return resolve(null);
+			if (!ws || ws.readyState !== 1) return resolve({ kind: "unsent" });
 			const timer = setTimeout(() => {
 				if (pending.has(reqId)) {
 					pending.delete(reqId);
-					resolve({ ops: [], groups: [] }); // delivered but no reply in time → passthrough
+					resolve({ kind: "timeout" }); // delivered but no reply in time → caller applies last known plan
 				}
-			}, REQUEST_TIMEOUT_MS);
-			pending.set(reqId, (plan) => {
+			}, PLAN_WAIT_MS);
+			pending.set(reqId, (r) => {
 				clearTimeout(timer);
-				resolve(plan);
+				resolve(r);
 			});
 			send(ws, { type: "sync", reqId, full, blocks, contextWindow });
 		});
@@ -821,6 +909,8 @@ export default function accordionLive(pi: ExtensionAPI): void {
 		latestCtx = ctx;
 		sessionId = `s-${process.pid}-${Date.now()}`;
 		sentCount = 0;
+		lastPlan = null; // fresh session → no known plan yet (cursor also resets here)
+		lastPlanRttMs = null;
 		pendingSince = [];
 		// Seed the cache from the session itself. For a fresh session this is []; for a
 		// RESUMED/loaded session (reason "resume"/"startup"/"fork") it is the full prior
@@ -916,9 +1006,42 @@ export default function accordionLive(pi: ExtensionAPI): void {
 		const fresh = all.slice(sentCount);
 		const reqId = ++reqSeq;
 		const full = sentCount === 0;
-		const plan = await requestPlan(reqId, full, fresh);
-		if (plan === null) return; // couldn't deliver → pass through, don't advance
+		// Measure the plan round-trip (Feature C). Stashed for `message_end` regardless of
+		// outcome — the assistant message this request produces waited this long, whatever
+		// the result (applied / stale-fallback / timeout).
+		const t0 = Date.now();
+		const result = await requestPlan(reqId, full, fresh);
+		lastPlanRttMs = Date.now() - t0;
+
 		if (epoch !== myEpoch) return; // GUI reconnected mid-flight → don't apply/advance
+		if (result.kind === "unsent") return; // couldn't deliver (no GUI / dropped) → pass through, don't advance
+
+		if (result.kind === "timeout") {
+			// Issue #58: the plan missed the wait. Blocks WERE delivered, so advance the cursor
+			// as before — but instead of shipping unfolded, re-apply the LAST KNOWN plan (a
+			// one-turn-stale, id-addressed plan is strictly better than none; applyPlan passes
+			// through ops for ids no longer present). Never silent: log cause + reqId + elapsed.
+			sentCount = Math.max(sentCount, all.length);
+			const elapsed = lastPlanRttMs;
+			const hasStale = !!lastPlan && (lastPlan.ops.length > 0 || lastPlan.groups.length > 0);
+			const detail = hasStale
+				? `applying last known plan (${lastPlan!.ops.length} ops, ${lastPlan!.groups.length} groups)`
+				: "no cached plan — passing through unfolded";
+			if (STEERING) {
+				// Steering promised to hold the budget and didn't: shout, don't whisper.
+				console.error(`[accordion] STEERING deadline missed: plan reqId=${reqId} did not arrive within ${PLAN_WAIT_MS}ms (waited ${elapsed}ms) — ${detail}`);
+			} else {
+				console.warn(`[accordion] plan timeout: reqId=${reqId} after ${elapsed}ms — ${detail}`);
+			}
+			if (hasStale) return { messages: applyPlan(event.messages as unknown as PiMessage[], lastPlan!.ops, lastPlan!.groups) as unknown as AgentMessage[] };
+			return;
+		}
+
+		// result.kind === "plan": the GUI replied. Cache it (even when empty — that is the
+		// conductor explicitly asking for NO folds, and caching it stops a later timeout from
+		// wrongly resurrecting an older non-empty plan).
+		const plan = result.plan;
+		lastPlan = plan;
 		sentCount = Math.max(sentCount, all.length); // advance cursor; never rewind (a message_end during the await may have advanced it further)
 		if (plan.ops.length === 0 && plan.groups.length === 0) return; // empty plan → pass through
 
@@ -968,9 +1091,35 @@ export default function accordionLive(pi: ExtensionAPI): void {
 	// View-only: no reqId registered in `pending`; folding may only happen at `context`.
 	// The `agent_end` handler below remains the loop-end backstop — with dedup it is
 	// harmless; it catches anything missed (e.g. if message_end fired with no GUI).
+	//
+	// This handler ALSO carries the Feature C RTT injection. That is deliberately merged
+	// here rather than split into a second `pi.on("message_end", …)`:
+	//   • The vendored pi SDK composes multiple handlers on one event reliably (loader.js
+	//     pushes each into a per-event array; runner.js emitMessageEnd chains their returned
+	//     messages, so a second handler WOULD work in production) — but smoke.mjs's mock
+	//     `pi.on` overwrites per event (last-wins), so a second handler would silently drop
+	//     one of the two in tests.
+	//   • Injection must run even when no GUI is attached, otherwise a value stashed while a
+	//     GUI was briefly attached could leak onto a later assistant message. Keeping it in
+	//     ONE handler, above the no-GUI guard, guarantees the stash is always consumed+cleared.
+	// So the RTT stamp is computed first (and returned at every exit), then the view-only
+	// sync push runs only when a GUI is attached.
 	pi.on("message_end", (event) => {
+		// ── Feature C: stamp usage.rttMs onto the assistant message this request produced ──
+		// Persisted verbatim: pi applies this replacement in place (agent-session._replace-
+		// MessageInPlace) and SessionManager.appendMessage JSON-serializes the whole message,
+		// so arbitrary `usage` keys survive to the session file. Consume+clear the stash so a
+		// message with no preceding context RTT (null) gets no field.
+		let replacement: AgentMessage | undefined;
+		const finished = event.message as unknown as PiMessage & { role?: string; usage?: Record<string, unknown> };
+		if (finished && finished.role === "assistant" && lastPlanRttMs !== null) {
+			const rttMs = lastPlanRttMs;
+			lastPlanRttMs = null;
+			replacement = { ...(event.message as object), usage: { ...(finished.usage ?? {}), rttMs } } as unknown as AgentMessage;
+		}
+
 		const ws = client;
-		if (!ws || ws.readyState !== 1) return; // no GUI → nothing to push
+		if (!ws || ws.readyState !== 1) return replacement; // no GUI → nothing to push (still stamp RTT)
 
 		// Guaranteed teardown (invariant #2, ADR 0003): sweep all active ghosts as a
 		// backstop. Any ghost not already resolved by its own *_end frame is cleared
@@ -997,11 +1146,12 @@ export default function accordionLive(pi: ExtensionAPI): void {
 		if (msgIds.size > 0 && !alreadySeen) pendingSince.push(msg);
 
 		const all = linearize([...lastMessages, ...pendingSince]);
-		if (all.length <= sentCount) return; // nothing new since the last sync
+		if (all.length <= sentCount) return replacement; // nothing new to push (RTT stamp still returned)
 		const reqId = ++reqSeq;
 		const full = sentCount === 0;
 		send(ws, { type: "sync", reqId, full, blocks: all.slice(sentCount) });
 		sentCount = all.length; // advance cursor; agent_end and next context will dedup
+		return replacement; // hand the RTT-stamped assistant message back to pi (undefined = unchanged)
 	});
 
 	// ── live view: push the assistant's reply the moment the loop ends ──────────

--- a/extension/package.json
+++ b/extension/package.json
@@ -10,7 +10,7 @@
     "build:client": "node ./build-client.mjs",
     "build": "npm run build:app && npm run build:client && npm run build:extension",
     "prepack": "npm run build && npm run smoke",
-    "smoke": "node smoke.mjs"
+    "smoke": "node smoke.mjs && node smoke-config.mjs"
   },
   "pi": {
     "extensions": ["./accordion.js"]

--- a/extension/smoke-config.mjs
+++ b/extension/smoke-config.mjs
@@ -1,0 +1,198 @@
+/*
+ * smoke-config.mjs — Feature B coverage (issue #58): configurable plan timeout,
+ * steering (blocking) mode, and defensive env parsing.
+ *
+ * These knobs are read ONCE at module init (ACCORDION_PLAN_TIMEOUT_MS / ACCORDION_STEERING
+ * / ACCORDION_PLAN_DEADLINE_MS), so each scenario must run in its OWN process with the
+ * env pre-set. This file is both the orchestrator (no ACCORDION_SMOKE_SCENARIO → spawn a
+ * child per scenario) and the driver (ACCORDION_SMOKE_SCENARIO set → run that one scenario
+ * in-process and exit 0/1). It complements smoke.mjs, which covers the default-env paths.
+ *
+ * Run: node smoke-config.mjs
+ */
+import { spawn } from "node:child_process";
+import { createJiti } from "jiti";
+import { WebSocket } from "ws";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCENARIO = process.env.ACCORDION_SMOKE_SCENARIO;
+
+// Each scenario: the env it needs at module init + the timing/log expectations.
+// `band` is the acceptable elapsed-ms range for the plan wait before fallback — wide
+// enough for timer jitter, tight enough to catch a broken parse (NaN → setTimeout fires
+// at ~0ms) or the wrong wait being used (steering ignored / custom value dropped).
+const SCENARIOS = {
+	// Steering uses the long DEADLINE (600ms here), logs LOUDLY via console.error, and
+	// still falls back to the last known plan. 600ms is unmistakably past the 250 default,
+	// so hitting the band proves the deadline (not the short timeout) governed the wait.
+	steering: {
+		env: { ACCORDION_STEERING: "1", ACCORDION_PLAN_DEADLINE_MS: "600" },
+		band: [430, 4000],
+		wantError: true,
+		wantWarn: false,
+		wantStaleFold: true,
+	},
+	// Invalid values must fall back to the 250 default (NOT NaN → immediate fire), and the
+	// non-steering path logs via console.warn.
+	"env-defaults": {
+		env: { ACCORDION_PLAN_TIMEOUT_MS: "not-a-number", ACCORDION_PLAN_DEADLINE_MS: "-5", ACCORDION_STEERING: "nope" },
+		band: [150, 400],
+		wantError: false,
+		wantWarn: true,
+		wantStaleFold: true,
+	},
+	// A valid custom timeout (120ms) is honored — the band excludes the 250 default.
+	"custom-timeout": {
+		env: { ACCORDION_PLAN_TIMEOUT_MS: "120" },
+		band: [50, 230],
+		wantError: false,
+		wantWarn: true,
+		wantStaleFold: true,
+	},
+};
+
+// ── orchestrator ─────────────────────────────────────────────────────────────
+if (!SCENARIO) {
+	const names = Object.keys(SCENARIOS);
+	const results = await Promise.all(
+		names.map(
+			(name) =>
+				new Promise((resolve) => {
+					const home = path.join(os.tmpdir(), `accordion-cfg-${process.pid}-${name}`);
+					const child = spawn(process.execPath, [fileURLToPath(import.meta.url)], {
+						env: {
+							...process.env,
+							ACCORDION_SMOKE_SCENARIO: name,
+							ACCORDION_HOME: home,
+							// A missing explicit app path stops the /accordion launcher fallback (unused here).
+							ACCORDION_APP_PATH: path.join(home, "missing.exe"),
+							...SCENARIOS[name].env,
+						},
+						stdio: ["ignore", "pipe", "pipe"],
+					});
+					let out = "";
+					child.stdout.on("data", (d) => (out += d.toString()));
+					child.stderr.on("data", (d) => (out += d.toString()));
+					child.on("close", (code) => resolve({ name, code, out: out.trim() }));
+				}),
+		),
+	);
+	let failed = false;
+	for (const r of results) {
+		const line = r.out.split("\n").filter(Boolean).at(-1) ?? "(no output)";
+		if (r.code === 0) {
+			console.log(`  ✓ ${r.name}: ${line}`);
+		} else {
+			failed = true;
+			console.error(`  ✗ ${r.name} (exit ${r.code}): ${r.out || "(no output)"}`);
+		}
+	}
+	if (failed) {
+		console.error("SMOKE-CONFIG FAIL");
+		process.exit(1);
+	}
+	console.log("SMOKE-CONFIG PASS — steering deadline ✓  env defaults (invalid → 250) ✓  custom timeout honored ✓");
+	process.exit(0);
+}
+
+// ── driver: run exactly one scenario in-process (env already applied by the parent) ──
+const spec = SCENARIOS[SCENARIO];
+if (!spec) {
+	console.error(`unknown scenario: ${SCENARIO}`);
+	process.exit(1);
+}
+
+const HOME = process.env.ACCORDION_HOME;
+const SESSIONS_DIR = path.join(HOME, ".accordion", "sessions");
+
+async function waitFor(predicate, ms, label) {
+	const start = Date.now();
+	while (Date.now() - start < ms) {
+		if (predicate()) return;
+		await new Promise((r) => setTimeout(r, 25));
+	}
+	throw new Error(`timed out waiting for ${label}`);
+}
+
+// Count (and swallow) the extension's fallback logs so we can assert severity.
+let errN = 0;
+let warnN = 0;
+console.warn = () => warnN++;
+console.error = () => errN++;
+
+const jiti = createJiti(import.meta.url);
+const mod = await jiti.import("./accordion.ts");
+const accordionLive = mod.default;
+
+const handlers = {};
+const pi = {
+	on: (name, fn) => (handlers[name] = fn),
+	registerFlag: () => {},
+	getFlag: () => undefined,
+	registerCommand: () => {},
+	registerTool: () => {},
+	appendEntry: () => {},
+};
+accordionLive(pi);
+const ctx = {
+	ui: { setStatus() {}, notify() {}, theme: { fg: (_c, s) => s } },
+	model: { id: "test/model", contextWindow: 1000 },
+	getContextUsage: () => ({ tokens: 42, contextWindow: 1000 }),
+};
+handlers.session_start({}, ctx);
+
+await waitFor(() => fs.existsSync(SESSIONS_DIR) && fs.readdirSync(SESSIONS_DIR).some((f) => f.endsWith(".json")), 3000, "registry entry");
+const entry = JSON.parse(fs.readFileSync(path.join(SESSIONS_DIR, fs.readdirSync(SESSIONS_DIR).find((f) => f.endsWith(".json"))), "utf8"));
+const PORT = entry.port;
+
+const T0 = Date.now();
+const sample = [
+	{ role: "user", content: "do the thing", timestamp: T0 },
+	{ role: "assistant", content: [{ type: "text", text: "ORIGINAL" }], responseId: "resp-abc", timestamp: T0 + 1 },
+];
+
+const gui = new WebSocket(`ws://127.0.0.1:${PORT}`);
+let mode = "ignore"; // "fold" → reply once to prime the cache; "drop" → withhold (force fallback)
+gui.on("message", (data) => {
+	let m;
+	try { m = JSON.parse(data.toString()); } catch { return; }
+	if (m.type !== "sync") return;
+	if (mode === "fold") gui.send(JSON.stringify({ type: "plan", reqId: m.reqId, ops: [{ id: "a:resp-abc:p0", digestText: "STALEFOLD" }], groups: [] }));
+	// "drop"/"ignore" → no reply
+});
+await new Promise((res, rej) => { gui.on("open", res); gui.on("error", rej); });
+await new Promise((r) => setTimeout(r, 100)); // settle the view-only attach flush
+
+// Prime the cache with a delivered fold, then withhold the next reply to force the
+// timeout/deadline fallback and measure how long the wait took.
+mode = "fold";
+await Promise.resolve(handlers.context({ messages: sample }, ctx));
+mode = "drop";
+const t0 = Date.now();
+const ret = await Promise.resolve(handlers.context({ messages: sample }, ctx));
+const elapsed = Date.now() - t0;
+
+gui.close();
+handlers.session_shutdown({}, ctx);
+try { fs.rmSync(HOME, { recursive: true, force: true }); } catch { /* ignore */ }
+
+const fails = [];
+if (elapsed < spec.band[0] || elapsed > spec.band[1])
+	fails.push(`plan wait ${elapsed}ms outside expected band [${spec.band[0]}, ${spec.band[1]}]`);
+if (spec.wantError && errN < 1) fails.push("expected a console.error (steering deadline miss) but none fired");
+if (!spec.wantError && errN > 0) fails.push(`unexpected console.error fired (${errN}) for a non-steering fallback`);
+if (spec.wantWarn && warnN < 1) fails.push("expected a console.warn (timeout fallback) but none fired");
+if (spec.wantStaleFold) {
+	const folded = ret?.messages?.[1]?.content?.[0]?.text;
+	if (folded !== "STALEFOLD") fails.push(`fallback did not re-apply the cached plan (got ${JSON.stringify(folded)})`);
+}
+
+if (fails.length) {
+	process.stdout.write(`${SCENARIO}: FAIL — ${fails.join("; ")}\n`);
+	process.exit(1);
+}
+process.stdout.write(`${SCENARIO}: waited ${elapsed}ms, errN=${errN} warnN=${warnN}, stale-fold applied\n`);
+process.exit(0);

--- a/extension/smoke.mjs
+++ b/extension/smoke.mjs
@@ -969,6 +969,18 @@ if (!recallTool) {
 // dependent and lives in smoke-config.mjs (spawned children). Here we drive the
 // `context`/`message_end` hooks through a fresh GUI whose reply behavior we switch
 // per scenario: reply-with-fold, reply-with-empty, or withhold (force timeout).
+
+// Mirrors pi's real `message_end` contract (MessageEndEventResult, see
+// node_modules/@earendil-works/pi-coding-agent/dist/core/extensions/types.d.ts): the
+// runner's emitMessageEnd does `if (!handlerResult?.message) continue;` — a handler's
+// return only takes effect wrapped as `{ message }`; a bare message is silently
+// dropped. Applying that same gate to the raw handler return (rather than reading
+// `.usage` straight off it) is what makes rttVal below actually depend on the
+// extension returning the correct `{ message }` shape.
+function unwrapMessageEnd(result) {
+	if (!result?.message) return undefined;
+	return result.message;
+}
 const stale = { primedFold: null, staleFold: null, emptyPass: undefined, afterEmptyPass: undefined, rtt: null, rtt2: null };
 {
 	const gui = new WebSocket(`ws://127.0.0.1:${PORT}`);
@@ -1025,12 +1037,16 @@ if (stale.emptyPass !== undefined) fails.push("stale-fallback: delivered empty p
 if (stale.afterEmptyPass !== undefined)
 	fails.push("stale-fallback: a timeout after a delivered EMPTY plan wrongly resurrected the older non-empty plan");
 // Feature C: rttMs stamped on the assistant message following a context wait.
-const rttVal = stale.rtt?.usage?.rttMs;
+// Unwrapped via the runner's `{ message }` contract (see unwrapMessageEnd above) — a
+// regression to the pre-fix bare-message return makes this undefined, failing the test.
+const rttMessage = unwrapMessageEnd(stale.rtt);
+const rttVal = rttMessage?.usage?.rttMs;
 if (!(typeof rttVal === "number" && Number.isInteger(rttVal) && rttVal >= 0))
 	fails.push(`rttMs: assistant message_end did not carry an integer usage.rttMs (got ${JSON.stringify(rttVal)})`);
-if (stale.rtt?.role !== "assistant") fails.push("rttMs: injected message must keep role assistant");
+if (rttMessage?.role !== "assistant") fails.push("rttMs: injected message must keep role assistant");
 // Feature C: no preceding context wait → the stash was cleared → no rttMs field leaks.
-if (stale.rtt2 && stale.rtt2.usage && typeof stale.rtt2.usage.rttMs === "number")
+const rtt2Message = unwrapMessageEnd(stale.rtt2);
+if (rtt2Message && rtt2Message.usage && typeof rtt2Message.usage.rttMs === "number")
 	fails.push("rttMs: a message with no preceding context RTT wrongly received a rttMs field (stale stash leaked)");
 
 // ── assertions ───────────────────────────────────────────────────────────────

--- a/extension/smoke.mjs
+++ b/extension/smoke.mjs
@@ -963,6 +963,76 @@ if (!recallTool) {
 	await new Promise((resolve) => { wsr.on("close", resolve); wsr.close(); });
 }
 
+// ── issue #58: stale-plan fallback + empty-plan cache + rttMs stamp ───────────
+// Feature A (stale-plan fallback) and Feature C (rttMs) run against the DEFAULT env
+// (250ms timeout). Feature B (steering deadline + env parsing) is module-init env
+// dependent and lives in smoke-config.mjs (spawned children). Here we drive the
+// `context`/`message_end` hooks through a fresh GUI whose reply behavior we switch
+// per scenario: reply-with-fold, reply-with-empty, or withhold (force timeout).
+const stale = { primedFold: null, staleFold: null, emptyPass: undefined, afterEmptyPass: undefined, rtt: null, rtt2: null };
+{
+	const gui = new WebSocket(`ws://127.0.0.1:${PORT}`);
+	let mode = "ignore"; // "fold" | "empty" | "drop" | "ignore"
+	gui.on("message", (data) => {
+		let m;
+		try { m = JSON.parse(data.toString()); } catch { return; }
+		if (m.type !== "sync") return;
+		if (mode === "fold") gui.send(JSON.stringify({ type: "plan", reqId: m.reqId, ops: [{ id: "a:resp-abc:p0", digestText: "STALEFOLD" }], groups: [] }));
+		else if (mode === "empty") gui.send(JSON.stringify({ type: "plan", reqId: m.reqId, ops: [], groups: [] }));
+		// "drop"/"ignore" → deliberately no reply (the attach flush is an "ignore" sync)
+	});
+	await new Promise((res, rej) => { gui.on("open", res); gui.on("error", rej); });
+	await new Promise((r) => setTimeout(r, 100)); // let the view-only attach flush settle
+
+	// 1) Prime the cache: the GUI delivers a NON-EMPTY plan → lastPlan cached + applied.
+	mode = "fold";
+	stale.primedFold = await Promise.resolve(handlers.context({ messages: sample }, ctx));
+
+	// 2) TIMEOUT → the extension must re-apply the LAST KNOWN plan, not pass through
+	//    unfolded. The GUI withholds its reply; after the 250ms default wait the
+	//    context hook falls back to the cached STALEFOLD plan.
+	mode = "drop";
+	stale.staleFold = await Promise.resolve(handlers.context({ messages: sample }, ctx));
+
+	// 3) A delivered EMPTY plan (conductor wants no folds) must REPLACE the cached
+	//    non-empty plan — a later timeout must then pass through unfolded, never
+	//    resurrect the old fold.
+	mode = "empty";
+	stale.emptyPass = await Promise.resolve(handlers.context({ messages: sample }, ctx));
+	mode = "drop";
+	stale.afterEmptyPass = await Promise.resolve(handlers.context({ messages: sample }, ctx));
+
+	// 4) rttMs stamp: a context wait stashes an RTT that the NEXT assistant message_end
+	//    stamps onto usage.rttMs; a following assistant message with no preceding context
+	//    wait gets NO field (the stash was consumed+cleared).
+	mode = "fold";
+	await Promise.resolve(handlers.context({ messages: sample }, ctx)); // stashes an RTT
+	stale.rtt = await Promise.resolve(handlers.message_end({ message: { role: "assistant", content: [{ type: "text", text: "RTT REPLY" }], responseId: "resp-rtt", timestamp: T0 + 5000 } }, ctx));
+	stale.rtt2 = await Promise.resolve(handlers.message_end({ message: { role: "assistant", content: [{ type: "text", text: "SECOND REPLY" }], responseId: "resp-rtt2", timestamp: T0 + 5001 } }, ctx));
+
+	gui.close();
+	await new Promise((r) => setTimeout(r, 50));
+}
+// Feature A: primed non-empty plan applied (resp-abc → STALEFOLD).
+if (stale.primedFold?.messages?.[1]?.content?.[0]?.text !== "STALEFOLD")
+	fails.push(`stale-fallback: primed plan did not fold resp-abc (got ${JSON.stringify(stale.primedFold?.messages?.[1]?.content?.[0]?.text)})`);
+// Feature A: on timeout the STALE plan is re-applied instead of passthrough.
+if (!stale.staleFold?.messages) fails.push("stale-fallback: timeout passed through unfolded instead of applying the last known plan");
+else if (stale.staleFold.messages[1]?.content?.[0]?.text !== "STALEFOLD")
+	fails.push(`stale-fallback: timeout did not re-apply the cached fold (got ${JSON.stringify(stale.staleFold.messages[1]?.content?.[0]?.text)})`);
+// Feature A: a delivered empty plan passes through AND is cached (not overridden by the older plan).
+if (stale.emptyPass !== undefined) fails.push("stale-fallback: delivered empty plan did not pass through");
+if (stale.afterEmptyPass !== undefined)
+	fails.push("stale-fallback: a timeout after a delivered EMPTY plan wrongly resurrected the older non-empty plan");
+// Feature C: rttMs stamped on the assistant message following a context wait.
+const rttVal = stale.rtt?.usage?.rttMs;
+if (!(typeof rttVal === "number" && Number.isInteger(rttVal) && rttVal >= 0))
+	fails.push(`rttMs: assistant message_end did not carry an integer usage.rttMs (got ${JSON.stringify(rttVal)})`);
+if (stale.rtt?.role !== "assistant") fails.push("rttMs: injected message must keep role assistant");
+// Feature C: no preceding context wait → the stash was cleared → no rttMs field leaks.
+if (stale.rtt2 && stale.rtt2.usage && typeof stale.rtt2.usage.rttMs === "number")
+	fails.push("rttMs: a message with no preceding context RTT wrongly received a rttMs field (stale stash leaked)");
+
 // ── assertions ───────────────────────────────────────────────────────────────
 if (!seen.hello) fails.push("never received hello");
 if (!seen.flushOnAttach) fails.push("GUI received no history flush on attach (would stay empty until first message — the bug)");
@@ -1011,6 +1081,7 @@ console.log(
 			`resumed-session attach-flush ✓  getBranch fallback ✓  ` +
 				`anchor-less positional-id round-trip ✓  applyPlan guard (positional + empty-digest refused) ✓  ` +
 					`unfold tool (no-ids / detached guards, attached round-trip) ✓  ` +
-					`recall tool (no-ids / detached guards, content-echo round-trip) ✓  skill discovery ✓`,
+					`recall tool (no-ids / detached guards, content-echo round-trip) ✓  skill discovery ✓  ` +
+					`stale-plan fallback (timeout re-applies last plan, empty plan not overridden) ✓  rttMs stamp ✓`,
 );
 process.exit(0);


### PR DESCRIPTION
## Why

Fixes the silent-unfolded-passthrough failure documented in #58. The pi extension's `context` hook waited 250ms for the GUI's fold plan and, on timeout, resolved the **same** empty plan `{ops:[],groups:[]}` that a genuinely-empty reply produces. So "the plan was slow" was indistinguishable from "the conductor wants no folds" — and every timed-out request went out **unfolded, silently**. In a real bellows run this let context climb to 152k tokens (52% past a 100k cap) while Accordion's own telemetry read ~63k.

This PR implements the issue's **proposed fixes #1 and #2** (steering/blocking mode + apply-last-known-plan-on-timeout) and lays the **RTT groundwork** the report asks for. It does **not** touch the O(session) hot-path memoization (#3) or the ack/telemetry cross-check (#4/#5) — those are tracked separately (issues #59 / #60).

## What changed (all in `extension/accordion.ts`)

**Feature A — stale-plan fallback (always on).**
- `requestPlan` now resolves a discriminated `PlanResult` — `"plan"` (GUI replied, possibly empty) · `"timeout"` (waited, no reply) · `"unsent"` (no GUI / socket dropped). `flushPending()` and the no-GUI path keep their existing passthrough-without-advancing meaning (they resolve `"unsent"`).
- A module-level `lastPlan` caches the last **delivered** plan — **including a genuinely empty one**, because empty = "conductor wants no folds", and caching it stops a later timeout from resurrecting a stale non-empty plan. Reset on `session_start` and every GUI (re)connect (wherever the cursor/epoch resets).
- On timeout the hook re-applies `lastPlan` (id-addressed; `applyPlan` passes through ops for ids no longer present) instead of shipping unfolded, and **logs** the fallback (`cause + reqId + elapsed`). If there's no cached plan it passes through as before — but still logs. Never silent again.

**Feature B — configurable timeout + steering (blocking) mode.**
- `ACCORDION_PLAN_TIMEOUT_MS` (default 250) replaces the hardcoded constant.
- `ACCORDION_STEERING` (truthy `1`/`true`) switches the wait to a hard `ACCORDION_PLAN_DEADLINE_MS` (default 10000). A missed deadline logs **loudly** via `console.error` and still falls back to the stale plan. It never blocks when no GUI is attached (the `!attached()` guard runs first), and a mid-wait disconnect now flushes pending in the socket `drop` handler so the wait resolves immediately rather than stalling the model call for the whole deadline.
- Env values parsed defensively (`NaN` / ≤0 / non-integer → default).

**Feature C — plan RTT surfaced in the session file.**
- `context` measures the wall-clock ms it waited on the plan and stashes it; the assistant `message_end` handler stamps it onto the message as **`usage.rttMs`** (integer ms), then clears the stash (a message with no preceding context wait gets no field). `rttMs` = time awaiting the plan for the request that produced this assistant message, whatever the outcome (applied / stale-fallback / timeout / no-host ≈ none).

## Design notes for reviewers (the two verifications from the task)

- **Timeout sentinel:** rather than a magic `null` + out-of-band flag, `requestPlan` returns a small discriminated union. This is what makes "timed out" cleanly separable from "delivered empty" and "never sent" at the one call site.
- **`message_end` composition (3a):** I verified the vendored SDK — `loader.js` **appends** handlers per event (`list.push`) and `runner.js#emitMessageEnd` **chains** each handler's returned message — so a *second* `pi.on("message_end", …)` would compose fine **in production**. I still **merged** the RTT injection into the existing view-only handler because (1) `smoke.mjs`'s mock `pi.on` overwrites per event (last-wins), so a second handler would silently drop one in tests, and (2) injection must run **even when no GUI is attached**, otherwise a value stashed while a GUI was briefly attached could leak onto a later message — one handler above the no-GUI guard guarantees the stash is always consumed+cleared.
- **`usage.rttMs` persistence (3b):** verified end-to-end. `message_end` replacements are applied in place (`agent-session._replaceMessageInPlace`) and `SessionManager.appendMessage` JSON-serializes the **whole** message, so arbitrary `usage` keys survive to the session file. No `appendEntry` fallback needed — **downstream consumers can read `usage.rttMs` directly off the assistant message** (integer ms; absent when there was no plan wait for that message, e.g. no GUI attached).

## Tests

- `smoke.mjs` (default-env, in-process): timeout → **stale plan re-applied** (not passthrough); a delivered **empty plan is not overridden** by the older plan (a later timeout passes through unfolded); **`usage.rttMs`** injected on the assistant message and **cleared** so the next message gets no field.
- `smoke-config.mjs` (new): module-init env is per-process, so it spawns a child per scenario — **steering deadline** (600ms honored, `console.error` fired, stale plan applied), **invalid env → 250 default** (`console.warn`), **custom timeout honored** (120ms). Wired into `npm run smoke`.

All green:
```
SMOKE PASS — … stale-plan fallback ✓  rttMs stamp ✓
SMOKE-CONFIG PASS — steering deadline ✓  env defaults (invalid → 250) ✓  custom timeout honored ✓
```

Docs: file header + `README.md` gain a Configuration section for the env vars and the `usage.rttMs` semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)