### PR TITLE
Unify steering: armed state over the wire drives plan-wait blocking

### DIFF
--- a/app/src/lib/live/liveClient.svelte.ts
+++ b/app/src/lib/live/liveClient.svelte.ts
@@ -14,9 +14,9 @@ import { session, cancelPendingLoad } from "../session.svelte";
 import { AccordionStore } from "../engine/store.svelte";
 import { wireToBlock } from "./mapping";
 import { computeFoldOps, computeGroupOps, resolveUnfold, resolveRecall } from "./plan";
-import { folding } from "./folding.svelte";
+import { folding, setFolding } from "./folding.svelte";
 import { activeRemoteRunner } from "./conductorClient.svelte";
-import { DEFAULT_PORT, PROTOCOL_VERSION, isServerMessage, type ServerMessage, type PlanMessage, type FoldOp, type GroupOp, type UnfoldResultMessage, type RecallResultMessage, type CompleteRequestMessage } from "./protocol";
+import { DEFAULT_PORT, PROTOCOL_VERSION, isServerMessage, type ServerMessage, type PlanMessage, type FoldOp, type GroupOp, type UnfoldResultMessage, type RecallResultMessage, type CompleteRequestMessage, type ArmedMessage } from "./protocol";
 import { ghostStart, ghostEnd, ghostClearAll } from "./ghostState.svelte";
 import type { CompletionRequest, CompletionResult } from "$conductors/contract";
 
@@ -179,6 +179,36 @@ async function sendCompletion(req: CompletionRequest): Promise<CompletionResult>
 	});
 }
 
+/**
+ * Tell the extension whether this client is ARMED (guarded send). Armed, the extension
+ * blocks each `context` hook on the plan up to the hard deadline instead of racing past it
+ * at the short fast-path timeout (see `ArmedMessage` in protocol.ts). No-op when the socket
+ * is not OPEN — the state is re-synced on every attach from the hello handler, so a send
+ * that can't land now is never lost.
+ */
+function sendArmed(on: boolean): void {
+	const ws = socket;
+	if (!ws || ws.readyState !== WebSocket.OPEN) return;
+	const msg: ArmedMessage = { type: "armed", armed: on };
+	try {
+		ws.send(JSON.stringify(msg));
+	} catch {
+		/* socket gone — the next attach re-syncs armed state */
+	}
+}
+
+/**
+ * Arm / disarm folding for the live session — the SINGLE source of truth behind the GUI's
+ * arm toggle. Flips the local `folding.enabled` (drives the on-screen preview and, armed,
+ * the fold plan actually applied) AND declares the armed state to the extension over the
+ * wire so its plan-wait blocking follows the same switch. Replaces the old benchmark-only
+ * `ACCORDION_STEERING` env flag with one steering concept shared by GUI and headless host.
+ */
+export function setArmed(on: boolean): void {
+	setFolding(on);
+	sendArmed(on);
+}
+
 export function connectLive(port: number = DEFAULT_PORT): void {
 	if (typeof window === "undefined" || typeof WebSocket === "undefined") return;
 	cancelPendingLoad(); // invalidate any pending file/CC load that would otherwise clobber the live store
@@ -231,6 +261,10 @@ export function connectLive(port: number = DEFAULT_PORT): void {
 			// Safety (review Q5b): every new live attach starts DISARMED - folding is
 			// opt-in per session, never silently carried from a previously armed agent.
 			folding.enabled = false;
+			// Explicitly re-sync the disarmed state to the extension on every attach, so a fresh
+			// (or reconnected) extension learns this client's armed state over the wire from turn
+			// zero rather than inferring it. The socket is OPEN here (we are handling its hello).
+			sendArmed(false);
 			// Structural reset: clear all ghosts — no ghost survives a session reconnect.
 			ghostClearAll();
 			budgetLive = false;

--- a/app/src/lib/live/liveClient.test.ts
+++ b/app/src/lib/live/liveClient.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { connectLive, disconnectLive, setArmed, live } from "./liveClient.svelte";
+import { folding } from "./folding.svelte";
+import { PROTOCOL_VERSION } from "./protocol";
+
+/*
+ * liveClient armed-over-wire coverage. The live client is a WebSocket CLIENT, so we drive it
+ * against a fake socket installed on `globalThis.WebSocket` (the same pattern conductorClient.test.ts
+ * uses, and that extension/smoke.mjs uses against a real WS). `connectLive` also guards on
+ * `typeof window` — node is the vitest environment here, so we shim a truthy `window` too.
+ *
+ * Scope: the two things this change adds to the client — `setArmed` puts an `armed` frame on the
+ * wire (guarded on socket state), and the hello handler re-declares armed:false alongside the
+ * folding reset on every attach. Deeper store/plan behavior is covered elsewhere (plan.test.ts,
+ * mapping.test.ts) and by the extension smoke tests.
+ */
+
+class FakeWebSocket {
+	static CONNECTING = 0;
+	static OPEN = 1;
+	static CLOSED = 3;
+	static last: FakeWebSocket | null = null;
+
+	readyState = FakeWebSocket.CONNECTING;
+	onopen: (() => void) | null = null;
+	onmessage: ((ev: { data: string }) => void) | null = null;
+	onerror: (() => void) | null = null;
+	onclose: (() => void) | null = null;
+	sent: string[] = [];
+
+	constructor(public url: string) {
+		FakeWebSocket.last = this;
+	}
+	send(data: string): void {
+		this.sent.push(data);
+	}
+	close(): void {
+		this.readyState = FakeWebSocket.CLOSED;
+		this.onclose?.();
+	}
+	// --- test drivers ---
+	open(): void {
+		this.readyState = FakeWebSocket.OPEN;
+		this.onopen?.();
+	}
+	emit(obj: unknown): void {
+		this.onmessage?.({ data: JSON.stringify(obj) });
+	}
+	frames(): any[] {
+		return this.sent.map((s) => JSON.parse(s));
+	}
+	framesOfType(t: string): any[] {
+		return this.frames().filter((f) => f.type === t);
+	}
+}
+
+function helloFrame() {
+	return {
+		type: "hello",
+		protocolVersion: PROTOCOL_VERSION,
+		sessionId: "s-test",
+		meta: { title: "t", cwd: "/tmp", model: "m", contextWindow: 1000, format: "pi" },
+	};
+}
+
+/** Connect and complete the hello handshake so the socket is OPEN and steerable. */
+function connectAndHello(): FakeWebSocket {
+	connectLive(1234);
+	const ws = FakeWebSocket.last!;
+	ws.open(); // OPEN before hello so a send inside the hello handler can land
+	ws.emit(helloFrame());
+	return ws;
+}
+
+let savedWS: unknown;
+let savedWindow: unknown;
+let hadWindow: boolean;
+
+beforeEach(() => {
+	savedWS = (globalThis as any).WebSocket;
+	hadWindow = "window" in globalThis;
+	savedWindow = (globalThis as any).window;
+	(globalThis as any).WebSocket = FakeWebSocket;
+	(globalThis as any).window = (globalThis as any).window ?? {};
+	FakeWebSocket.last = null;
+	folding.enabled = false;
+});
+
+afterEach(() => {
+	disconnectLive();
+	(globalThis as any).WebSocket = savedWS;
+	if (hadWindow) (globalThis as any).window = savedWindow;
+	else delete (globalThis as any).window;
+});
+
+describe("liveClient — armed over the wire", () => {
+	it("re-declares armed:false alongside the folding reset on every attach (hello)", () => {
+		const ws = connectAndHello();
+		expect(live.status).toBe("connected");
+		// The safety reset: a fresh attach always starts disarmed...
+		expect(folding.enabled).toBe(false);
+		// ...and that disarmed state is explicitly re-synced to the extension.
+		const armedFrames = ws.framesOfType("armed");
+		expect(armedFrames.length).toBeGreaterThanOrEqual(1);
+		expect(armedFrames.at(-1)).toEqual({ type: "armed", armed: false });
+	});
+
+	it("setArmed(true) flips folding AND sends {type:'armed',armed:true} when connected", () => {
+		const ws = connectAndHello();
+		ws.sent.length = 0; // drop the hello-time armed:false so we assert only the toggle's frame
+
+		setArmed(true);
+		expect(folding.enabled).toBe(true);
+		expect(ws.framesOfType("armed")).toEqual([{ type: "armed", armed: true }]);
+
+		ws.sent.length = 0;
+		setArmed(false);
+		expect(folding.enabled).toBe(false);
+		expect(ws.framesOfType("armed")).toEqual([{ type: "armed", armed: false }]);
+	});
+
+	it("setArmed still flips folding but sends nothing on the wire when the socket is closed", () => {
+		const ws = connectAndHello();
+		ws.close(); // readyState → CLOSED; the client's onclose nulls out the active socket
+		ws.sent.length = 0;
+
+		setArmed(true);
+		// Local state (the on-screen preview / arm intent) still flips...
+		expect(folding.enabled).toBe(true);
+		// ...but the guarded send is a no-op: no frame goes out on a non-OPEN socket. The state
+		// is re-synced on the next attach from the hello handler, so nothing is lost.
+		expect(ws.framesOfType("armed")).toHaveLength(0);
+	});
+
+	it("setArmed no-ops the wire send when never connected (folding still flips)", () => {
+		// No connectLive at all → module socket is null.
+		setArmed(true);
+		expect(folding.enabled).toBe(true);
+		// Nothing to assert on a socket; the point is it does not throw and does not require a socket.
+		expect(FakeWebSocket.last).toBeNull();
+	});
+});

--- a/app/src/lib/live/protocol.ts
+++ b/app/src/lib/live/protocol.ts
@@ -30,6 +30,18 @@
  *  - v4: group collapse ops (`GroupOp`, `PlanMessage.groups`).
  *  - v5: recall tool (`recallRequest` / `recallResult`) plus completion relay
  *        (`completeRequest` / `completeResult`) for out-of-band model completions.
+ *  - (still v5, additive) `armed` / `armedAck`: the attached client declares its
+ *    ARMED state over the wire (client→server `armed`), and the extension replies
+ *    `armedAck` whenever it processes one. PROTOCOL_VERSION is DELIBERATELY NOT
+ *    bumped here. Both live peers that carry the pi wire — the GUI (liveClient's
+ *    hello handler) AND the bellows headless host — reject on a STRICT
+ *    `protocolVersion !== PROTOCOL_VERSION` mismatch, not `>=`. A bump would break
+ *    every mixed-version pairing (old GUI/host ↔ new extension, and vice versa) even
+ *    though these two messages are purely additive: an old peer simply drops an
+ *    unknown message type without error, degrading gracefully to the non-blocking
+ *    fast path. Capability is detected out-of-band via `armedAck` — a new client
+ *    that sends `armed` and gets no ack back knows it is talking to an old extension
+ *    (and can scream) — so the version number buys nothing a bump would cost.
  */
 export const PROTOCOL_VERSION = 5;
 
@@ -218,7 +230,22 @@ export interface CompleteResultMessage {
 	error?: string;
 }
 
-export type ServerMessage = HelloMessage | SyncMessage | StreamMessage | UnfoldRequestMessage | RecallRequestMessage | CompleteResultMessage;
+/**
+ * Sent by the extension whenever it processes an `armed` message from the attached client
+ * (additive on protocol v5 — see the PROTOCOL_VERSION history note). It echoes the armed
+ * state the extension now holds. Its whole purpose is capability detection for a headless
+ * client (e.g. the bellows benchmark host): a client that sends `armed` and never receives
+ * an `armedAck` is talking to an OLD extension that silently dropped the unknown type, so it
+ * knows its blocking benchmark would run non-blocking and can fail loudly. The GUI may ignore
+ * acks entirely — `isServerMessage` recognizes the type, but the client's message pump simply
+ * has no branch for it, so it is dropped harmlessly.
+ */
+export interface ArmedAckMessage {
+	type: "armedAck";
+	armed: boolean;
+}
+
+export type ServerMessage = HelloMessage | SyncMessage | StreamMessage | UnfoldRequestMessage | RecallRequestMessage | CompleteResultMessage | ArmedAckMessage;
 
 // ── Client → server (GUI → extension) ────────────────────────────────────────
 
@@ -314,12 +341,29 @@ export interface RecallResultMessage {
 	missing: string[];
 }
 
-export type ClientMessage = PlanMessage | UnfoldResultMessage | RecallResultMessage | CompleteRequestMessage;
+/**
+ * Client → extension: declare the client's ARMED state (additive on protocol v5). Armed, the
+ * extension switches its per-request plan wait from the short fast-path timeout
+ * (`ACCORDION_PLAN_TIMEOUT_MS`, default 250ms) to a hard deadline (`ACCORDION_PLAN_DEADLINE_MS`,
+ * default 10000ms), so a blocking session (interactive steering, or a benchmark that must hold
+ * its budget) actually waits for the plan instead of racing past it. Disarmed (the default on
+ * every fresh attach), a missed plan falls back fast and never blocks a model call.
+ *
+ * For the interactive GUI this is the wire form of the arm toggle (`folding.enabled`): a single
+ * source of truth for "is this client steering?" replacing the old benchmark-only
+ * `ACCORDION_STEERING` env flag. The extension answers every `armed` with an `armedAck`.
+ */
+export interface ArmedMessage {
+	type: "armed";
+	armed: boolean;
+}
+
+export type ClientMessage = PlanMessage | UnfoldResultMessage | RecallResultMessage | CompleteRequestMessage | ArmedMessage;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 export function isServerMessage(v: unknown): v is ServerMessage {
 	if (!v || typeof v !== "object" || !("type" in v)) return false;
 	const t = (v as any).type;
-	return t === "hello" || t === "sync" || t === "stream" || t === "unfoldRequest" || t === "recallRequest" || t === "completeResult";
+	return t === "hello" || t === "sync" || t === "stream" || t === "unfoldRequest" || t === "recallRequest" || t === "completeResult" || t === "armedAck";
 }

--- a/app/src/lib/ui/map/MapHeader.svelte
+++ b/app/src/lib/ui/map/MapHeader.svelte
@@ -5,8 +5,8 @@
 	import EditableNumber from "$lib/ui/EditableNumber.svelte";
 	import Icon from "$lib/ui/Icon.svelte";
 	import ConductorMenu from "./ConductorMenu.svelte";
-	import { folding, setFolding } from "$lib/live/folding.svelte";
-	import { live } from "$lib/live/liveClient.svelte";
+	import { folding } from "$lib/live/folding.svelte";
+	import { live, setArmed } from "$lib/live/liveClient.svelte";
 	import { conductorStatus } from "$lib/live/conductorClient.svelte";
 	import type { JSONValue } from "$conductors/contract";
 
@@ -197,7 +197,7 @@
 					title={folding.enabled
 						? "Accordion is applying folds to the live agent's context. Takes effect on the agent's next turn."
 						: "Folds are previewed in the view only. The agent's context is unchanged."}
-					onclick={() => setFolding(!folding.enabled)}
+					onclick={() => setArmed(!folding.enabled)}
 				>
 					<span class="fold-arm-dot" aria-hidden="true"></span>
 					<span class="fold-arm-eyebrow mono">FOLDING</span>

--- a/extension/README.md
+++ b/extension/README.md
@@ -75,18 +75,37 @@ reasons over at full fidelity.
 ## Configuration
 
 Advanced knobs, read from the environment once when the extension loads. Defaults are
-tuned for interactive use; the steering knobs matter mainly for benchmark harnesses that
-must enforce a hard context budget.
+tuned for interactive use. Whether the extension **blocks** on the plan is no longer an env
+flag — it follows the attached client's **armed** state, learned over the wire (see
+[Armed state](#armed-state-over-the-wire) below); the deadline knob matters mainly for a
+blocking session (interactive steering, or a benchmark harness that must enforce a hard
+context budget).
 
 | Env var | Default | Effect |
 |---|---|---|
-| `ACCORDION_PLAN_TIMEOUT_MS` | `250` | How long a model request waits for the GUI's fold plan before falling back. On a miss the extension re-applies the **last known plan** rather than shipping the conversation unfolded (a one-turn-stale plan is strictly better than none), and logs the fallback — it is never silent. |
-| `ACCORDION_STEERING` | off | Truthy (`1`/`true`) switches the wait to a hard **deadline** (`ACCORDION_PLAN_DEADLINE_MS`) instead of the short timeout, so a run whose cap must hold actually holds it. A missed deadline is logged loudly and still falls back to the last known plan. It never blocks when no GUI is attached, and a mid-wait disconnect resolves immediately. **Caution:** a hung-but-connected GUI (socket open, not replying) stalls *every* model request by the full deadline (10s by default) — there is deliberately no circuit breaker yet; a consecutive-miss breaker is tracked as follow-up work. |
-| `ACCORDION_PLAN_DEADLINE_MS` | `10000` | Steering-mode deadline. Ignored unless `ACCORDION_STEERING` is on. |
+| `ACCORDION_PLAN_TIMEOUT_MS` | `250` | How long a model request waits for the GUI's fold plan before falling back **while the attached client is disarmed** (the fast path). On a miss the extension re-applies the **last known plan** rather than shipping the conversation unfolded (a one-turn-stale plan is strictly better than none), and logs the fallback — it is never silent. |
+| `ACCORDION_PLAN_DEADLINE_MS` | `10000` | The plan wait used **while the attached client is armed**: a hard **deadline** instead of the short timeout, so a run whose cap must hold actually holds it. A missed deadline is logged loudly (`console.error`) and still falls back to the last known plan. It never blocks when no client is attached, and a mid-wait disconnect resolves immediately. **Caution:** a hung-but-connected client (socket open, not replying) stalls *every* model request by the full deadline (10s by default) **while armed** — there is deliberately no circuit breaker yet; a consecutive-miss breaker is tracked as follow-up work. |
 
 Invalid values (non-numeric, `NaN`, `≤0`, or non-integer such as `"250.5"`) fall back to
 the default. Values are parsed with `Number()`, so scientific notation (`"1e3"`) and hex
 (`"0x10"`) are also accepted as long as they resolve to a positive integer.
+
+### Armed state over the wire
+
+Blocking is driven by the attached client, not the environment. The client sends
+`{ "type": "armed", "armed": <boolean> }` on the live WebSocket to declare whether it is
+steering; the extension adopts that state for subsequent model requests (armed → wait the
+deadline; disarmed → the short timeout) and replies `{ "type": "armedAck", "armed": <boolean> }`
+to confirm it understood. Every fresh attach starts **disarmed**, and the GUI re-declares its
+state on connect, so a stale arming can never carry across sessions.
+
+For the interactive GUI this is simply the wire form of the **arm toggle** (the FOLDING
+`preview` / `steering` button) — one steering concept for both the UI and headless hosts,
+replacing the former benchmark-only `ACCORDION_STEERING` env flag. A headless benchmark host
+declares `armed:true` the same way; the `armedAck` lets it detect an old extension (which
+would silently drop the unknown message and run non-blocking) and fail loudly instead. These
+messages are **additive** — an old peer ignores an unknown type — so the wire
+`PROTOCOL_VERSION` is intentionally not bumped.
 
 Each request also records the plan round-trip time it waited, stamped onto the assistant
 message it produced as `usage.rttMs` (integer milliseconds) in the session file.

--- a/extension/accordion.ts
+++ b/extension/accordion.ts
@@ -33,13 +33,13 @@
  *
  * Env configuration (read once at module init):
  *   • ACCORDION_PLAN_TIMEOUT_MS  — how long a `context` hook waits on the GUI's plan
- *     before falling back (positive int, default 250).
- *   • ACCORDION_STEERING         — truthy ("1"/"true", case-insensitive) switches the
- *     plan wait to a hard DEADLINE (ACCORDION_PLAN_DEADLINE_MS) instead of the short
- *     timeout, so a benchmark harness actually enforces its cap. A missed deadline is
- *     logged loudly and still falls back to the last known plan (or passthrough). It
- *     never blocks when no GUI is attached, and a mid-wait disconnect resolves at once.
- *   • ACCORDION_PLAN_DEADLINE_MS — steering-mode deadline (positive int, default 10000).
+ *     before falling back when the attached client is DISARMED (positive int, default 250).
+ *   • ACCORDION_PLAN_DEADLINE_MS — the plan wait used when the attached client declares
+ *     itself ARMED (over the wire — see the `armed` message): a hard DEADLINE instead of
+ *     the short timeout, so a blocking session (interactive steering, or a benchmark that
+ *     must hold its cap) actually waits for the plan. A missed deadline is logged loudly and
+ *     still falls back to the last known plan (or passthrough). It never blocks when no GUI
+ *     is attached, and a mid-wait disconnect resolves at once. (positive int, default 10000).
  *   Parsed with `Number()`, then required to be a positive integer. Invalid values
  *   (missing / NaN / ≤0 / non-integer, e.g. "250.5") fall back to the default. Note
  *   `Number()` accepts more than plain decimal — scientific notation ("1e3") and hex
@@ -79,10 +79,13 @@ type Plan = { ops: FoldOp[]; groups: GroupOp[] };
  * through UNFOLDED and silently. This discriminates them:
  *   • "plan"    — the GUI delivered a plan (possibly genuinely empty).
  *   • "timeout" — the wait elapsed with no reply → fall back to the last known plan.
+ *                 `waitedMs` is the GOVERNING wait for this request (the armed deadline or
+ *                 the disarmed timeout), carried out so the caller logs the duration it was
+ *                 supposed to honor without re-deriving which knob applied.
  *   • "unsent"  — nothing was delivered (no GUI at call time, or the socket dropped /
  *                 was superseded mid-wait via flushPending) → passthrough, don't advance.
  */
-type PlanResult = { kind: "plan"; plan: Plan } | { kind: "timeout" } | { kind: "unsent" };
+type PlanResult = { kind: "plan"; plan: Plan } | { kind: "timeout"; waitedMs: number } | { kind: "unsent" };
 import {
 	REGISTRY_PROTOCOL,
 	REGISTRY_DIR,
@@ -101,25 +104,17 @@ function envPositiveInt(name: string, fallback: number): number {
 	const n = Number(raw.trim());
 	return Number.isInteger(n) && n > 0 ? n : fallback;
 }
-// Truthy env flag: "1" or "true" (case-insensitive). Everything else is false.
-function envTruthy(name: string): boolean {
-	const raw = process.env[name];
-	if (typeof raw !== "string") return false;
-	const v = raw.trim().toLowerCase();
-	return v === "1" || v === "true";
-}
 
-// How long a `context` hook waits on the GUI before falling back (issue #58). This
-// used to be a silent 250ms passthrough; it is now configurable and the fallback is
-// no longer silent (stale plan + log — see the `context` hook).
+// How long a `context` hook waits on the GUI before falling back when the attached client
+// is DISARMED (issue #58). This used to be a silent 250ms passthrough; it is now configurable
+// and the fallback is no longer silent (stale plan + log — see the `context` hook).
 const PLAN_TIMEOUT_MS = envPositiveInt("ACCORDION_PLAN_TIMEOUT_MS", 250);
-// Steering (blocking) mode: enforce the budget by waiting a hard DEADLINE for the plan
-// instead of the short timeout, so a benchmark run whose cap must hold actually holds it.
-const STEERING = envTruthy("ACCORDION_STEERING");
+// The plan wait used when the attached client declares itself ARMED over the wire (the
+// `armed` message): a hard DEADLINE instead of the short timeout, so a blocking session
+// (interactive steering, or a benchmark whose cap must hold) actually waits for the plan.
+// Either way a missed wait falls back (stale plan / passthrough). Which of the two applies
+// is decided PER REQUEST from the armed flag snapshotted in the `context` hook, not here.
 const PLAN_DEADLINE_MS = envPositiveInt("ACCORDION_PLAN_DEADLINE_MS", 10_000);
-// The wait a `context` plan request actually uses: the long deadline under steering,
-// the short timeout otherwise. Either way a missed wait falls back (stale plan / passthrough).
-const PLAN_WAIT_MS = STEERING ? PLAN_DEADLINE_MS : PLAN_TIMEOUT_MS;
 // Unfold replies arrive during the agent's OWN turn (not on the model-call critical
 // path), so a generous wait is fine — the user's next message isn't blocked.
 const UNFOLD_TIMEOUT_MS = 2000;
@@ -293,6 +288,14 @@ export default function accordionLive(pi: ExtensionAPI): void {
 	// whole conversation unfolded. Reset wherever the cursor/epoch resets (session_start +
 	// GUI (re)connect): a plan from a superseded view must never apply to a fresh sync.
 	let lastPlan: Plan | null = null;
+	// Whether the attached client has declared itself ARMED over the wire (the `armed`
+	// message — the single source of truth for "is this client steering?", replacing the old
+	// ACCORDION_STEERING env flag). Armed, each `context` hook waits the hard PLAN_DEADLINE_MS
+	// for the plan instead of the short PLAN_TIMEOUT_MS. Reset to false wherever the client
+	// context resets — new connection, session_start, and the drop closure — so a stale armed
+	// state can never carry into a fresh attach and silently block (or a benchmark can never
+	// inherit a prior session's arming). Snapshotted per request in the `context` hook.
+	let armed = false;
 	// Most recent plan round-trip time (ms), stashed by `context` and consumed by
 	// `message_end` to stamp `usage.rttMs` on the assistant message this request produced.
 	// null = no context RTT to attribute (e.g. no GUI attached this turn) → no field stamped.
@@ -693,6 +696,7 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			sentCount = 0; // re-sync the whole context to the freshly-connected GUI
 			reqSeq = 0;
 			lastPlan = null; // a new view starts with no known plan; never apply the old one to it
+			armed = false; // a fresh client is DISARMED until it declares otherwise over the wire
 			send(ws, { type: "hello", protocolVersion: PROTOCOL_VERSION, sessionId, meta });
 
 			// Flush existing history IMMEDIATELY on attach. Without this, a session that
@@ -733,6 +737,17 @@ export default function accordionLive(pi: ExtensionAPI): void {
 						// is honored as "no folds" and cached, not mistaken for a slow/absent GUI.
 						resolve({ kind: "plan", plan: { ops: Array.isArray(msg.ops) ? msg.ops : [], groups: Array.isArray(msg.groups) ? msg.groups : [] } });
 					}
+				}
+				if (msg?.type === "armed" && typeof msg.armed === "boolean") {
+					// The attached client declared its ARMED state (the single steering switch —
+					// interactive arm toggle or a headless benchmark host). Adopt it for subsequent
+					// `context` waits, and ACK so a headless client can confirm this extension
+					// understood the message (an old extension would silently drop the unknown type,
+					// leaving a "blocking" benchmark actually non-blocking). The snapshot semantics
+					// live in the `context` hook: an in-flight wait keeps its value; the next request
+					// picks up this one.
+					armed = msg.armed;
+					send(ws, { type: "armedAck", armed });
 				}
 				if (msg?.type === "unfoldResult" && typeof msg.reqId === "number") {
 					const resolve = pendingUnfold.get(msg.reqId);
@@ -831,10 +846,11 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			const drop = () => {
 				if (client === ws) {
 					client = null;
+					armed = false; // defense-in-depth: a dropped client is no longer steering anything
 					// The active GUI dropped mid-flight: resolve any in-flight plan/unfold/recall
 					// waits at once instead of letting them run out their timers. This matters most
-					// in steering mode, where the plan wait is a multi-second deadline — without this
-					// a disconnect would stall the model call until that deadline elapsed.
+					// when armed, where the plan wait is a multi-second deadline — without this a
+					// disconnect would stall the model call until that deadline elapsed.
 					flushPending();
 				}
 			};
@@ -853,22 +869,25 @@ export default function accordionLive(pi: ExtensionAPI): void {
 	/**
 	 * Send a sync and await the GUI's plan. Resolves a discriminated PlanResult:
 	 *   • "unsent"  — no GUI attached at call time (nothing sent).
-	 *   • "timeout" — sent, but no reply within PLAN_WAIT_MS (the caller falls back to
-	 *                 the last known plan). The wait is PLAN_DEADLINE_MS under steering.
+	 *   • "timeout" — sent, but no reply within the governing wait (the caller falls back to
+	 *                 the last known plan). `waitedMs` is that wait: PLAN_DEADLINE_MS when the
+	 *                 caller passes `armedNow`, PLAN_TIMEOUT_MS otherwise. Snapshotted by the
+	 *                 caller (the `context` hook) so an in-flight wait keeps its value.
 	 *   • "plan"    — the GUI replied (delivered via the pending resolver / flushPending).
 	 * The pending resolver is also driven by flushPending() (→ "unsent") on a superseded /
 	 * dropped / shutting-down GUI, so a mid-wait disconnect never runs out the full timer.
 	 */
-	function requestPlan(reqId: number, full: boolean, blocks: ReturnType<typeof linearize>): Promise<PlanResult> {
+	function requestPlan(reqId: number, full: boolean, blocks: ReturnType<typeof linearize>, armedNow: boolean): Promise<PlanResult> {
+		const waitMs = armedNow ? PLAN_DEADLINE_MS : PLAN_TIMEOUT_MS;
 		return new Promise((resolve) => {
 			const ws = client;
 			if (!ws || ws.readyState !== 1) return resolve({ kind: "unsent" });
 			const timer = setTimeout(() => {
 				if (pending.has(reqId)) {
 					pending.delete(reqId);
-					resolve({ kind: "timeout" }); // delivered but no reply in time → caller applies last known plan
+					resolve({ kind: "timeout", waitedMs: waitMs }); // delivered but no reply in time → caller applies last known plan
 				}
-			}, PLAN_WAIT_MS);
+			}, waitMs);
 			pending.set(reqId, (r) => {
 				clearTimeout(timer);
 				resolve(r);
@@ -926,6 +945,7 @@ export default function accordionLive(pi: ExtensionAPI): void {
 		sessionId = `s-${process.pid}-${Date.now()}`;
 		sentCount = 0;
 		lastPlan = null; // fresh session → no known plan yet (cursor also resets here)
+		armed = false; // fresh session → disarmed until the (re)attached client declares otherwise
 		lastPlanRttMs = null;
 		pendingSince = [];
 		// Seed the cache from the session itself. For a fresh session this is []; for a
@@ -1011,6 +1031,11 @@ export default function accordionLive(pi: ExtensionAPI): void {
 		lastPlanRttMs = null;
 		latestCtx = ctx;
 		const myEpoch = epoch;
+		// Snapshot the armed flag SYNCHRONOUSLY with myEpoch, BEFORE the await below. Mid-toggle
+		// semantics: an in-flight `context` wait keeps the value it started with; the NEXT request
+		// picks up a value the client changed meanwhile. This governs whether requestPlan waits the
+		// hard deadline (armed) or the short timeout (disarmed), and which log fires on a miss.
+		const myArmed = armed;
 		// Refresh model/usage in memory only — NO disk I/O on the model-call critical
 		// path. The 5s heartbeat persists these to the registry for the sidebar.
 		refreshFromCtx(ctx);
@@ -1031,7 +1056,7 @@ export default function accordionLive(pi: ExtensionAPI): void {
 		// outcome — the assistant message this request produces waited this long, whatever
 		// the result (applied / stale-fallback / timeout).
 		const t0 = Date.now();
-		const result = await requestPlan(reqId, full, fresh);
+		const result = await requestPlan(reqId, full, fresh, myArmed);
 		lastPlanRttMs = Date.now() - t0;
 
 		if (epoch !== myEpoch) return; // GUI reconnected mid-flight → don't apply/advance
@@ -1054,9 +1079,10 @@ export default function accordionLive(pi: ExtensionAPI): void {
 				: lastPlan
 					? "cached plan is empty (no folds) — passing through unfolded"
 					: "no cached plan — passing through unfolded";
-			if (STEERING) {
-				// Steering promised to hold the budget and didn't: shout, don't whisper.
-				console.error(`[accordion] STEERING deadline missed: plan reqId=${reqId} did not arrive within ${PLAN_WAIT_MS}ms (waited ${elapsed}ms) — ${detail}`);
+			if (myArmed) {
+				// Armed promised to hold the budget and didn't: shout, don't whisper. `result.waitedMs`
+				// is the deadline this request was supposed to honor (carried out of requestPlan).
+				console.error(`[accordion] armed deadline missed: plan reqId=${reqId} did not arrive within ${result.waitedMs}ms (waited ${elapsed}ms) — ${detail}`);
 			} else {
 				console.warn(`[accordion] plan timeout: reqId=${reqId} after ${elapsed}ms — ${detail}`);
 			}

--- a/extension/smoke-config.mjs
+++ b/extension/smoke-config.mjs
@@ -1,10 +1,12 @@
 /*
  * smoke-config.mjs — Feature B coverage (issue #58): configurable plan timeout,
- * steering (blocking) mode, and defensive env parsing.
+ * armed (blocking) mode, and defensive env parsing.
  *
- * These knobs are read ONCE at module init (ACCORDION_PLAN_TIMEOUT_MS / ACCORDION_STEERING
- * / ACCORDION_PLAN_DEADLINE_MS), so each scenario must run in its OWN process with the
- * env pre-set. This file is both the orchestrator (no ACCORDION_SMOKE_SCENARIO → spawn a
+ * The timeout/deadline knobs are read ONCE at module init (ACCORDION_PLAN_TIMEOUT_MS /
+ * ACCORDION_PLAN_DEADLINE_MS), so each scenario must run in its OWN process with the env
+ * pre-set. Whether a request BLOCKS is no longer an env flag — it follows the client's
+ * ARMED state over the wire, so the armed scenario's driver sends {type:"armed",armed:true}
+ * after connecting. This file is both the orchestrator (no ACCORDION_SMOKE_SCENARIO → spawn a
  * child per scenario) and the driver (ACCORDION_SMOKE_SCENARIO set → run that one scenario
  * in-process and exit 0/1). It complements smoke.mjs, which covers the default-env paths.
  *
@@ -25,20 +27,22 @@ const SCENARIO = process.env.ACCORDION_SMOKE_SCENARIO;
 // enough for timer jitter, tight enough to catch a broken parse (NaN → setTimeout fires
 // at ~0ms) or the wrong wait being used (steering ignored / custom value dropped).
 const SCENARIOS = {
-	// Steering uses the long DEADLINE (600ms here), logs LOUDLY via console.error, and
-	// still falls back to the last known plan. 600ms is unmistakably past the 250 default,
-	// so hitting the band proves the deadline (not the short timeout) governed the wait.
+	// Armed (the client declares armed:true over the wire) uses the long DEADLINE (600ms here),
+	// logs LOUDLY via console.error, and still falls back to the last known plan. 600ms is
+	// unmistakably past the 250 default, so hitting the band proves the deadline (not the short
+	// timeout) governed the wait. `arm` tells the driver to send the armed message after connect.
 	steering: {
-		env: { ACCORDION_STEERING: "1", ACCORDION_PLAN_DEADLINE_MS: "600" },
+		env: { ACCORDION_PLAN_DEADLINE_MS: "600" },
+		arm: true,
 		band: [430, 4000],
 		wantError: true,
 		wantWarn: false,
 		wantStaleFold: true,
 	},
-	// Invalid values must fall back to the 250 default (NOT NaN → immediate fire), and the
-	// non-steering path logs via console.warn.
+	// Invalid values must fall back to the 250 default (NOT NaN → immediate fire). Disarmed
+	// (no armed message sent), so the short-timeout path logs via console.warn.
 	"env-defaults": {
-		env: { ACCORDION_PLAN_TIMEOUT_MS: "not-a-number", ACCORDION_PLAN_DEADLINE_MS: "-5", ACCORDION_STEERING: "nope" },
+		env: { ACCORDION_PLAN_TIMEOUT_MS: "not-a-number", ACCORDION_PLAN_DEADLINE_MS: "-5" },
 		band: [150, 400],
 		wantError: false,
 		wantWarn: true,
@@ -94,7 +98,7 @@ if (!SCENARIO) {
 		console.error("SMOKE-CONFIG FAIL");
 		process.exit(1);
 	}
-	console.log("SMOKE-CONFIG PASS — steering deadline ✓  env defaults (invalid → 250) ✓  custom timeout honored ✓");
+	console.log("SMOKE-CONFIG PASS — armed deadline (armed over the wire) ✓  env defaults (invalid → 250) ✓  custom timeout honored ✓");
 	process.exit(0);
 }
 
@@ -156,15 +160,23 @@ const sample = [
 
 const gui = new WebSocket(`ws://127.0.0.1:${PORT}`);
 let mode = "ignore"; // "fold" → reply once to prime the cache; "drop" → withhold (force fallback)
+let armedAcked = false;
 gui.on("message", (data) => {
 	let m;
 	try { m = JSON.parse(data.toString()); } catch { return; }
+	if (m.type === "armedAck") { armedAcked = true; return; }
 	if (m.type !== "sync") return;
 	if (mode === "fold") gui.send(JSON.stringify({ type: "plan", reqId: m.reqId, ops: [{ id: "a:resp-abc:p0", digestText: "STALEFOLD" }], groups: [] }));
 	// "drop"/"ignore" → no reply
 });
 await new Promise((res, rej) => { gui.on("open", res); gui.on("error", rej); });
 await new Promise((r) => setTimeout(r, 100)); // settle the view-only attach flush
+// Declare ARMED over the wire for the blocking scenario (replaces the old ACCORDION_STEERING
+// env flag). Wait for the ack so the extension has adopted it before the timed request below.
+if (spec.arm) {
+	gui.send(JSON.stringify({ type: "armed", armed: true }));
+	await waitFor(() => armedAcked, 1000, "armedAck");
+}
 
 // Prime the cache with a delivered fold, then withhold the next reply to force the
 // timeout/deadline fallback and measure how long the wait took.
@@ -182,8 +194,8 @@ try { fs.rmSync(HOME, { recursive: true, force: true }); } catch { /* ignore */ 
 const fails = [];
 if (elapsed < spec.band[0] || elapsed > spec.band[1])
 	fails.push(`plan wait ${elapsed}ms outside expected band [${spec.band[0]}, ${spec.band[1]}]`);
-if (spec.wantError && errN < 1) fails.push("expected a console.error (steering deadline miss) but none fired");
-if (!spec.wantError && errN > 0) fails.push(`unexpected console.error fired (${errN}) for a non-steering fallback`);
+if (spec.wantError && errN < 1) fails.push("expected a console.error (armed deadline miss) but none fired");
+if (!spec.wantError && errN > 0) fails.push(`unexpected console.error fired (${errN}) for a disarmed fallback`);
 if (spec.wantWarn && warnN < 1) fails.push("expected a console.warn (timeout fallback) but none fired");
 if (spec.wantStaleFold) {
 	const folded = ret?.messages?.[1]?.content?.[0]?.text;

--- a/extension/smoke.mjs
+++ b/extension/smoke.mjs
@@ -1049,6 +1049,104 @@ const rtt2Message = unwrapMessageEnd(stale.rtt2);
 if (rtt2Message && rtt2Message.usage && typeof rtt2Message.usage.rttMs === "number")
 	fails.push("rttMs: a message with no preceding context RTT wrongly received a rttMs field (stale stash leaked)");
 
+// ── armed-over-wire: ARMED state (learned over the wire) drives blocking ──────
+// The client sends {type:"armed", armed:bool}; the extension acks and switches its
+// per-request plan wait between the short timeout (disarmed) and the hard deadline
+// (armed). This replaces the old ACCORDION_STEERING env flag. Default env here:
+// PLAN_TIMEOUT_MS=250, PLAN_DEADLINE_MS=10000. We never actually wait out the 10s
+// deadline — we deliver the plan to unblock — but we DO prove an armed request blocks
+// well past the 250ms short timeout that a disarmed request falls back at.
+const armedSmoke = { ackTrue: null, ackFalse: null, disarmedMs: null, armedMs: null, inflightPendingPastTimeout: null, nextDisarmedMs: null };
+{
+	const gui = new WebSocket(`ws://127.0.0.1:${PORT}`);
+	let lastAck = null;
+	let lastSyncReqId = null;
+	let replyMode = "ignore"; // "ignore" = withhold plan; "fold" = reply (optionally delayed)
+	let planReplyDelayMs = 0;
+	gui.on("message", (data) => {
+		let m;
+		try { m = JSON.parse(data.toString()); } catch { return; }
+		if (m.type === "armedAck") { lastAck = m; return; }
+		if (m.type !== "sync") return;
+		lastSyncReqId = m.reqId;
+		if (replyMode === "fold") {
+			const deliver = () => { try { gui.send(JSON.stringify({ type: "plan", reqId: m.reqId, ops: [], groups: [] })); } catch { /* closed */ } };
+			if (planReplyDelayMs > 0) setTimeout(deliver, planReplyDelayMs); else deliver();
+		}
+		// "ignore" → withhold (forces the fallback path / keeps the wait blocking)
+	});
+	await new Promise((res, rej) => { gui.on("open", res); gui.on("error", rej); });
+	await new Promise((r) => setTimeout(r, 100)); // settle the view-only attach flush
+
+	// 1) DISARMED (fresh connection defaults to disarmed): a withheld reply falls back at
+	//    the SHORT timeout (~250ms). No armed message has been sent yet.
+	replyMode = "ignore";
+	let t0 = Date.now();
+	await Promise.resolve(handlers.context({ messages: sample }, ctx));
+	armedSmoke.disarmedMs = Date.now() - t0;
+
+	// 2) Arm over the wire — the extension must ACK armed:true.
+	gui.send(JSON.stringify({ type: "armed", armed: true }));
+	await waitFor(() => lastAck?.armed === true, 1000, "armedAck(true)").catch(() => {});
+	armedSmoke.ackTrue = lastAck;
+
+	// 3) ARMED: a delayed reply (600ms — past the 250ms short timeout) must be WAITED for,
+	//    proving the wait is deadline-scale and did not fall back at the short timeout.
+	replyMode = "fold";
+	planReplyDelayMs = 600;
+	t0 = Date.now();
+	await Promise.resolve(handlers.context({ messages: sample }, ctx));
+	armedSmoke.armedMs = Date.now() - t0;
+
+	// 4) Mid-toggle snapshot: a request that STARTS armed keeps blocking even if the client
+	//    disarms mid-flight; only the NEXT request picks up the new (disarmed) value.
+	//    Start an armed request with the reply withheld so it blocks on the deadline.
+	replyMode = "ignore";
+	planReplyDelayMs = 0;
+	lastAck = null;
+	let inflightResolved = false;
+	const inflight = Promise.resolve(handlers.context({ messages: sample }, ctx)).then((r) => { inflightResolved = true; return r; });
+	await new Promise((r) => setTimeout(r, 60)); // let the sync go out + the request register
+
+	// Disarm mid-flight; wait for the ack so the module-level `armed` is now false.
+	gui.send(JSON.stringify({ type: "armed", armed: false }));
+	await waitFor(() => lastAck?.armed === false, 1000, "armedAck(false)").catch(() => {});
+	armedSmoke.ackFalse = lastAck;
+
+	// The in-flight request snapshotted armed=true, so it must STILL be blocking — NOT fallen
+	// back at the 250ms short timeout. Assert it is unresolved comfortably past that window.
+	await new Promise((r) => setTimeout(r, 350));
+	armedSmoke.inflightPendingPastTimeout = !inflightResolved;
+
+	// Unblock the in-flight request by answering its sync, so we don't wait the full deadline.
+	if (lastSyncReqId !== null) gui.send(JSON.stringify({ type: "plan", reqId: lastSyncReqId, ops: [], groups: [] }));
+	await inflight;
+
+	// 5) The NEXT request snapshots armed=false → falls back at the SHORT timeout again.
+	replyMode = "ignore";
+	t0 = Date.now();
+	await Promise.resolve(handlers.context({ messages: sample }, ctx));
+	armedSmoke.nextDisarmedMs = Date.now() - t0;
+
+	gui.close();
+	await new Promise((r) => setTimeout(r, 50));
+}
+// armedAck round-trips.
+if (!armedSmoke.ackTrue || armedSmoke.ackTrue.armed !== true) fails.push("armed: extension did not ack armed:true");
+if (!armedSmoke.ackFalse || armedSmoke.ackFalse.armed !== false) fails.push("armed: extension did not ack armed:false");
+// Disarmed default → short timeout (well under a second).
+if (!(armedSmoke.disarmedMs !== null && armedSmoke.disarmedMs < 900))
+	fails.push(`armed: disarmed wait ${armedSmoke.disarmedMs}ms did not fall back at the short timeout`);
+// Armed → blocked past the short timeout for the 600ms delayed plan (deadline-scale).
+if (!(armedSmoke.armedMs !== null && armedSmoke.armedMs >= 450))
+	fails.push(`armed: armed wait ${armedSmoke.armedMs}ms fell back at the short timeout instead of blocking (deadline-scale expected)`);
+// Mid-toggle: the in-flight armed request kept blocking despite a mid-flight disarm.
+if (armedSmoke.inflightPendingPastTimeout !== true)
+	fails.push("armed: in-flight request fell back at the short timeout after a mid-flight disarm (snapshot not honored)");
+// Mid-toggle: the NEXT request picked up the disarmed value → short timeout again.
+if (!(armedSmoke.nextDisarmedMs !== null && armedSmoke.nextDisarmedMs < 900))
+	fails.push(`armed: request after disarm did not use the short timeout (${armedSmoke.nextDisarmedMs}ms)`);
+
 // ── assertions ───────────────────────────────────────────────────────────────
 if (!seen.hello) fails.push("never received hello");
 if (!seen.flushOnAttach) fails.push("GUI received no history flush on attach (would stay empty until first message — the bug)");
@@ -1098,6 +1196,7 @@ console.log(
 				`anchor-less positional-id round-trip ✓  applyPlan guard (positional + empty-digest refused) ✓  ` +
 					`unfold tool (no-ids / detached guards, attached round-trip) ✓  ` +
 					`recall tool (no-ids / detached guards, content-echo round-trip) ✓  skill discovery ✓  ` +
-					`stale-plan fallback (timeout re-applies last plan, empty plan not overridden) ✓  rttMs stamp ✓`,
+					`stale-plan fallback (timeout re-applies last plan, empty plan not overridden) ✓  rttMs stamp ✓  ` +
+						`armed-over-wire (ack, disarmed=short / armed=deadline, mid-toggle snapshot) ✓`,
 );
 process.exit(0);


### PR DESCRIPTION
## Why

There were two disconnected notions of "steering":

- The **GUI arm toggle** (`folding.enabled`, the FOLDING `preview`/`steering` button) — decides whether the GUI's fold plan is actually applied to the live agent's context.
- The benchmark-only **`ACCORDION_STEERING`** env flag (added in #61) — decides whether the extension *blocks* each `context` hook on the plan (hard deadline) vs. races past it (short timeout).

Same word, two switches, and a naming collision waiting to bite (the UI already labels its armed state "steering"). This unifies them: the extension's blocking-vs-fast plan wait is now driven by the attached client's **ARMED** state, learned over the wire. The GUI's arm toggle becomes the single source of truth for interactive sessions; a headless host (bellows) declares armed the same way. `ACCORDION_STEERING` is deleted; the two env *tuning knobs* (`ACCORDION_PLAN_TIMEOUT_MS` default 250, `ACCORDION_PLAN_DEADLINE_MS` default 10000) remain. References #58 / #61.

## Wire (additive)

- client → server `{ "type": "armed", "armed": boolean }`
- server → client `{ "type": "armedAck", "armed": boolean }` — sent whenever the extension processes an `armed` message.

**`armedAck` rationale:** without it, a *new* headless client talking to an *old* extension gets silently non-blocking benchmarks — the old code drops unknown message types without error, so a "blocking" run would quietly race past its budget. The ack lets the client detect that (it sent `armed`, got no ack → old extension) and fail loudly instead of shipping a wrong result. The GUI ignores acks entirely.

## Protocol version: NOT bumped (stays v5)

The spec floated a v5→v6 bump. I investigated and **deliberately did not bump.** Both live peers that carry the pi wire reject on a **strict** `protocolVersion !== PROTOCOL_VERSION` mismatch, not `>=`:
- GUI hello handler — `app/src/lib/live/liveClient.svelte.ts` (`live.status = "error"` on mismatch)
- bellows host — `src/host/main.ts:428` (`fatal = new Error("protocol mismatch …")`)

A bump would therefore **break every mixed-version pairing** (old GUI/host ↔ new extension, and vice versa) even though `armed`/`armedAck` are purely additive — an old peer simply drops the unknown type and degrades to the non-blocking fast path. And the bump would buy nothing: capability is detected out-of-band via `armedAck`, not the version number. So the version stays 5, with a history note in `protocol.ts` explaining why.

## Mid-toggle semantics

`const myArmed = armed` is snapshotted synchronously with `myEpoch`, **before** the await in the `context` hook. An in-flight wait keeps the value it started with; the next request picks up the new one.

## Changes

- **protocol.ts** — `ArmedMessage` / `ArmedAckMessage`, added to the unions + `isServerMessage`; version-history note documenting the no-bump decision.
- **liveClient.svelte.ts** — `sendArmed` (guarded) + exported `setArmed = setFolding + sendArmed`; hello handler re-declares `armed:false` on every attach; `armedAck` tolerated.
- **MapHeader.svelte** — arm button `onclick` now calls `setArmed`.
- **accordion.ts** — module-level `armed` (reset on new connection / session_start / drop); adopted + acked in the message handler; `requestPlan` takes `armedNow` and waits deadline-vs-timeout; `PlanResult.timeout` carries `waitedMs`; timeout log branches on `myArmed`. Deleted `ACCORDION_STEERING`, `envTruthy`, `PLAN_WAIT_MS`.
- **README.md** — dropped the `ACCORDION_STEERING` row; reworded the deadline row + prose; documented the armed/armedAck wire; kept the hung-client caution (reworded "under ACCORDION_STEERING" → "while armed").
- **Tests** — new `liveClient.test.ts`; `smoke.mjs` armed-over-wire case; `smoke-config.mjs` steering scenario arms over the wire instead of the env flag.

## Verification

- `npm run build:extension` — clean
- `npm run smoke` — fully green (armed scenario waited 601ms/deadline; disarmed ~260ms short timeout — this is also the negative check that unarmed behavior matches the pre-change 250ms fast path)
- app vitest — 801 passed (41 files), including the new `liveClient.test.ts`
- `npm run check` (svelte-check) — 0 errors

## ⚠️ Merge order

This is **stacked on #61** (`fix/plan-timeout-stale-fallback-rtt`, base of this PR). Merge **#61 first**, then re-target this PR to `main` and merge. The paired **bellows** change (headless host declaring armed + reading `armedAck`) is a separate PR and must **not** deploy before this extension side lands — otherwise the host would send `armed` to an extension that doesn't understand it (and, correctly, get no ack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)