### PR TITLE
feat(wire): plan-applied ack + passthrough counters (issue #60, ADR 0020)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ README surfaces:
 
 **Invariants (don't break):**
 - Discovery I/O is best-effort; **never blocks or alters a model call**
-- No GUI / reply timeout / empty plan → messages pass through untouched
+- No GUI / empty plan → messages pass through untouched; a reply timeout falls back to the last known plan when one is cached, else passes through raw (issue #58). Every `context` hook outcome is counted and acked to the GUI as a `passthrough` message (issue #60, ADR 0020) — see `/__accordion/meta`'s `planOutcomes`
 - No disk I/O on the `context` (pre-model-call) hook
 - The completion relay (`completeRequest / completeResult`) runs out-of-band — **never on the `context` hook path** and never blocks the agent's own model call
 - Folding the live agent is OPT-IN and OFF by default (`folding.enabled`, a header toggle)

--- a/app/src/lib/engine/store.birthfold.test.ts
+++ b/app/src/lib/engine/store.birthfold.test.ts
@@ -467,3 +467,37 @@ describe("birth-fold — rawWire markSent (folding disarmed) clears the exemptio
 		expect(s.lastReports.some((r) => r.ids.includes("r:c1") && r.reason === "protected")).toBe(true);
 	});
 });
+
+// ── (n) issue #60 / ADR 0020: a passthrough-ack reconciliation overrides an
+//        earlier OPTIMISTIC markSent — the GUI thought its fold rode the wire, a
+//        later `passthrough` ack says otherwise, and the exemption must still die ──
+
+describe("birth-fold — timeout-ack reconciliation clears an exemption markSent already OK'd", () => {
+	it("a view-folded block markSent() judged safe loses its exemption once a stale-plan/raw ack arrives for that call", () => {
+		const s = makeLiveStore(sessionWithFreshResult(8000));
+		s.setProtect(20_000);
+		const conductor = new StubConductor();
+		conductor.cmds = [{ kind: "fold", ids: ["r:c1"] }];
+		s.attach(conductor);
+		expect(s.isFolded(s.get("r:c1")!)).toBe(true); // view-folded…
+
+		// The GUI replies to the planned sync believing its fold plan will ride the wire
+		// (folding armed → `rawWire: false`), so the ordinary birth-fold bookkeeping keeps
+		// the exemption alive (case (b)/(l) above).
+		s.markSent();
+		expect(s.isFolded(s.get("r:c1")!)).toBe(true); // still exempt — the model hasn't seen it whole yet
+
+		// …but the extension's `passthrough` ack for THAT SAME reqId later reveals the plan
+		// wait actually timed out server-side (the reply arrived too late, or never landed) —
+		// the extension applied the STALE cached plan (or raw) instead of this fresh fold. The
+		// live client's reconciliation (liveClient.svelte.ts) responds by calling markSent
+		// again with `rawWire: true`, conservatively dropping every exemption because the
+		// model may have seen ANY block from that call whole.
+		s.markSent({ rawWire: true });
+
+		conductor.cmds = [{ kind: "fold", ids: ["r:c1"] }];
+		s.refold();
+		expect(s.isFolded(s.get("r:c1")!)).toBe(false); // protection clamps like any seen block
+		expect(s.lastReports.some((r) => r.ids.includes("r:c1") && r.reason === "protected")).toBe(true);
+	});
+});

--- a/app/src/lib/live/liveClient.svelte.ts
+++ b/app/src/lib/live/liveClient.svelte.ts
@@ -492,8 +492,13 @@ export function connectLive(port: number = DEFAULT_PORT, opts: { host?: string; 
 			// 0020). Two jobs: tally the counter for the "wire N/M" readout, and — for the two
 			// causes that mean the GUI's OWN fresh plan did not ride the wire — reconcile
 			// birth-fold bookkeeping.
-			live.planOutcomes[msg.cause]++;
-			live.planOutcomes.total++;
+			// `msg.cause` comes off the wire untyped — a malformed/unknown cause must not add a
+			// spurious key (e.g. NaN-poisoning via prototype/array quirks) or bump `total` for an
+			// outcome we can't attribute. Only tally a cause we actually have a bucket for.
+			if (msg.cause in live.planOutcomes) {
+				live.planOutcomes[msg.cause]++;
+				live.planOutcomes.total++;
+			}
 
 			// Birth-fold reconciliation (the correctness half, not just the counter). A
 			// `"timeout-stale"`/`"timeout-raw"` ack means the plan THIS client sent for

--- a/app/src/lib/live/liveClient.svelte.ts
+++ b/app/src/lib/live/liveClient.svelte.ts
@@ -16,7 +16,7 @@ import { wireToBlock } from "./mapping";
 import { computeFoldOps, computeGroupOps, computeRecallOps, resolveUnfold, resolveRecall } from "./plan";
 import { folding, setFolding } from "./folding.svelte";
 import { activeRemoteRunner } from "./conductorClient.svelte";
-import { DEFAULT_PORT, PROTOCOL_VERSION, isServerMessage, type ServerMessage, type PlanMessage, type FoldOp, type GroupOp, type RecallOp, type UnfoldResultMessage, type RecallResultMessage, type CompleteRequestMessage, type ArmedMessage } from "./protocol";
+import { DEFAULT_PORT, PROTOCOL_VERSION, isServerMessage, type ServerMessage, type PlanMessage, type FoldOp, type GroupOp, type RecallOp, type UnfoldResultMessage, type RecallResultMessage, type CompleteRequestMessage, type ArmedMessage, type PassthroughCause } from "./protocol";
 import { ghostStart, ghostEnd, ghostClearAll } from "./ghostState.svelte";
 import type { CompletionRequest, CompletionResult } from "$conductors/contract";
 
@@ -49,13 +49,41 @@ const pendingCompletions = new Map<number, { resolve: (r: CompletionResult) => v
 /** Monotonic counter for `completeRequest` reqIds. Starts at 1 to distinguish from unset/zero. */
 let completionReqId = 0;
 
-/** Live connection status, for the UI. */
-export const live = $state<{ status: "idle" | "connecting" | "connected" | "error"; detail: string; sessionId: string | null; port: number | null }>({
+/** A fresh, all-zero `planOutcomes` counter map (issue #60) — one connection's worth. */
+function freshPlanOutcomes(): Record<PassthroughCause, number> & { total: number } {
+	return { applied: 0, "empty-plan": 0, "timeout-stale": 0, "timeout-raw": 0, "epoch-mismatch": 0, total: 0 };
+}
+
+/**
+ * Live connection status, for the UI. `planOutcomes` (issue #60, ADR 0020) tallies every
+ * `passthrough` ack this connection has received — one bucket per `PassthroughCause`, plus
+ * `total` (acked model calls seen this connection). Reset to zero on every new connection
+ * (see `connectLive`) alongside `sessionId`/`port` — it describes THIS connection's wire
+ * history, not a running lifetime total (contrast the extension's own `/__accordion/meta`
+ * counters, which ARE lifetime totals).
+ */
+export const live = $state<{
+	status: "idle" | "connecting" | "connected" | "error";
+	detail: string;
+	sessionId: string | null;
+	port: number | null;
+	planOutcomes: Record<PassthroughCause, number> & { total: number };
+}>({
 	status: "idle",
 	detail: "",
 	sessionId: null,
 	port: null,
+	planOutcomes: freshPlanOutcomes(),
 });
+
+/**
+ * The reqId of the last PLANNED sync this client replied to (issue #60). Gates birth-fold
+ * reconciliation on a `passthrough` ack: an ack for an OLDER or unknown reqId means either a
+ * reconnect happened in between (the store is already fresh — see the `hello` handler's
+ * structural reset) or the ack is stray, so it must never retroactively reconcile a store
+ * that has moved on. Reset alongside the other per-connection state on every new connection.
+ */
+let lastPlannedReqId: number | null = null;
 
 /**
  * The fold plan the GUI returns for a sync — Milestone 2, "engine on."
@@ -226,6 +254,8 @@ export function connectLive(port: number = DEFAULT_PORT, opts: { host?: string; 
 	live.detail = `ws://${host}:${port}`;
 	live.sessionId = null;
 	live.port = port;
+	live.planOutcomes = freshPlanOutcomes(); // issue #60: counters describe THIS connection only
+	lastPlannedReqId = null;
 	session.error = "";
 
 	let ws: WebSocket;
@@ -358,7 +388,12 @@ export function connectLive(port: number = DEFAULT_PORT, opts: { host?: string; 
 			// folding replied with an EMPTY plan above, so this call's wire was raw — every block
 			// crossed whole, and the store must drop birth-fold exemptions accordingly (else a
 			// disarmed-era exemption leaks into a later armed run).
-			if (msg.planned) session.store.markSent({ rawWire: !folding.enabled });
+			if (msg.planned) {
+				// Issue #60: remember which reqId this reply answers, so a later `passthrough` ack
+				// for it can be told apart from a stray/superseded one (see the `passthrough` handler).
+				lastPlannedReqId = msg.reqId;
+				session.store.markSent({ rawWire: !folding.enabled });
+			}
 		} else if (msg.type === "unfoldRequest") {
 			// The live agent asked (via the `unfold` tool) to restore folded blocks it saw
 			// tagged `{#<code> FOLDED}`. Resolve each code to its folded block(s) and hold
@@ -451,6 +486,40 @@ export function connectLive(port: number = DEFAULT_PORT, opts: { host?: string; 
 				}
 				// `pending.resolve/reject` already delete the entry via the `settle` wrapper
 				// in `sendCompletion`, so no explicit `pendingCompletions.delete` here.
+			}
+		} else if (msg.type === "passthrough") {
+			// The extension's per-outcome ack for a `context` hook resolution (issue #60, ADR
+			// 0020). Two jobs: tally the counter for the "wire N/M" readout, and — for the two
+			// causes that mean the GUI's OWN fresh plan did not ride the wire — reconcile
+			// birth-fold bookkeeping.
+			live.planOutcomes[msg.cause]++;
+			live.planOutcomes.total++;
+
+			// Birth-fold reconciliation (the correctness half, not just the counter). A
+			// `"timeout-stale"`/`"timeout-raw"` ack means the plan THIS client sent for
+			// `msg.reqId` missed the wait — the extension applied a stale cached plan (or
+			// nothing) instead, so the model may have seen ANY block from that call whole.
+			// Conservatively drop every birth-fold exemption exactly as a disarmed (`rawWire`)
+			// planned reply would; `markSent`'s cursor advance is a `Math.max`, so calling it
+			// again here is idempotent and safe even if it already ran for other reasons.
+			//
+			// Guard: only reconcile when this ack answers the reqId this client actually
+			// planned-synced LAST (`lastPlannedReqId`) — an ack for an unknown/older reqId means
+			// a reconnect happened in between (the store is already fresh) or the ack is stray.
+			// `"epoch-mismatch"` acks are for a SUPERSEDED view and are never reconciled (counted
+			// only) — matching the extension's own comment at that send site.
+			//
+			// Ordering assumption: WS delivery is FIFO and the extension sends this ack strictly
+			// AFTER the plan wait for `msg.reqId` resolves — i.e. after the sync it answers and
+			// before the NEXT planned sync — so this reconciliation always lands before this
+			// client's next `markSent()` call and can never race a later legitimate exemption.
+			if (
+				(msg.cause === "timeout-stale" || msg.cause === "timeout-raw") &&
+				session.store &&
+				lastPlannedReqId !== null &&
+				msg.reqId === lastPlannedReqId
+			) {
+				session.store.markSent({ rawWire: true });
 			}
 		}
 	};

--- a/app/src/lib/live/liveClient.test.ts
+++ b/app/src/lib/live/liveClient.test.ts
@@ -3,6 +3,7 @@ import { connectLive, disconnectLive, setArmed, live } from "./liveClient.svelte
 import { folding } from "./folding.svelte";
 import { session } from "../session.svelte";
 import { PROTOCOL_VERSION } from "./protocol";
+import type { Conductor, ConductorView, Command } from "$conductors/contract";
 
 /*
  * liveClient armed-over-wire coverage. The live client is a WebSocket CLIENT, so we drive it
@@ -261,5 +262,61 @@ describe("liveClient — passthrough ack handling (issue #60)", () => {
 		ws.emit({ type: "passthrough", reqId: 30, cause: "applied", ops: 1, groups: 0, recalls: 0 });
 		ws.emit({ type: "passthrough", reqId: 30, cause: "empty-plan", ops: 0, groups: 0, recalls: 0 });
 		expect(spy).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * The whole reconciliation scheme rests on FIFO wire ordering: the extension sends the
+	 * `passthrough` ack for reqId N strictly AFTER the planned sync it answers and strictly
+	 * BEFORE the next sync — so reconciliation can never race a block that arrives later. If
+	 * that ordering were violated (ack processed after newer blocks already landed), `markSent`'s
+	 * `Math.max` against the store's then-current last block would advance `sentThroughOrder`
+	 * past those newer blocks too, wrongly marking a never-sent block as already sent (it would
+	 * read `fresh:false` and lose birth-fold eligibility, see store.svelte.ts `isFresh`/
+	 * `birthFoldEligible`, ADR 0018/#43).
+	 *
+	 * `sentThroughOrder`/`birthFolded` are private to `AccordionStore`, so this asserts the
+	 * sharpest available public equivalent: attach a stub conductor (same pattern as
+	 * store.birthfold.test.ts) purely to observe `ConductorView.fresh` — a block the store still
+	 * considers un-sent reads `fresh:true` regardless of protection or fold state.
+	 */
+	it("a passthrough ack for reqId N does not swallow a block that arrives in a LATER sync (FIFO ordering)", () => {
+		connectAndHello();
+		const ws = FakeWebSocket.last!;
+		expect(session.store).not.toBeNull();
+
+		class StubConductor implements Conductor {
+			readonly id = "stub";
+			readonly label = "Stub";
+			lastView: ConductorView | null = null;
+			conduct(view: ConductorView): Command[] | null {
+				this.lastView = view;
+				return []; // no fold decisions — this conductor exists only to capture the view
+			}
+		}
+		const conductor = new StubConductor();
+		session.store!.attach(conductor);
+
+		// (a) planned sync reqId=5 — client replies, sets lastPlannedReqId=5, and (folding
+		// disarmed by default in this suite) optimistically calls markSent({rawWire:true}).
+		ws.emit(plannedSyncFrame(5));
+
+		// (b) the extension's passthrough ack for that SAME reqId — reconciliation fires and
+		// calls markSent({rawWire:true}) again (idempotent).
+		ws.emit({ type: "passthrough", reqId: 5, cause: "timeout-raw", ops: 0, groups: 0, recalls: 0 });
+
+		// (c) a VIEW-ONLY sync (no `planned`) carrying a brand-new block, arriving strictly
+		// AFTER the reconciliation above.
+		ws.emit({
+			type: "sync",
+			reqId: 6,
+			full: false,
+			blocks: [{ id: "u:6", kind: "user", turn: 2, order: 1, text: "later", tokens: 5 }],
+			contextWindow: 1000,
+			planned: false,
+		});
+
+		const newBlock = conductor.lastView!.blocks.find((b) => b.id === "u:6");
+		expect(newBlock).toBeDefined();
+		expect(newBlock!.fresh).toBe(true); // never marked sent — FIFO ordering preserved
 	});
 });

--- a/app/src/lib/live/liveClient.test.ts
+++ b/app/src/lib/live/liveClient.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { connectLive, disconnectLive, setArmed, live } from "./liveClient.svelte";
 import { folding } from "./folding.svelte";
+import { session } from "../session.svelte";
 import { PROTOCOL_VERSION } from "./protocol";
 
 /*
@@ -138,5 +139,127 @@ describe("liveClient — armed over the wire", () => {
 		expect(folding.enabled).toBe(true);
 		// Nothing to assert on a socket; the point is it does not throw and does not require a socket.
 		expect(FakeWebSocket.last).toBeNull();
+	});
+});
+
+/*
+ * passthrough-ack handling (issue #60, ADR 0020). The extension acks every `context` hook
+ * outcome as a `passthrough` message; the live client (1) tallies `live.planOutcomes` for the
+ * "wire N/M" readout and (2) reconciles birth-fold bookkeeping when the ack reveals the GUI's
+ * own fresh plan did NOT ride the wire (`timeout-stale`/`timeout-raw`). Driven end-to-end
+ * through the FakeWebSocket harness (this file's existing pattern) rather than the store alone
+ * — the reconciliation GUARD (last-answered reqId, epoch-mismatch exemption) lives entirely in
+ * liveClient.svelte.ts, so a store-only test would miss it. The deeper mechanics of WHY dropping
+ * the exemption matters (a block un-refoldable once "protected") are covered end-to-end through
+ * the real store in store.birthfold.test.ts (case (n)).
+ */
+describe("liveClient — passthrough ack handling (issue #60)", () => {
+	/** A minimal PLANNED sync — enough for the client to append a block, reply with a plan,
+	 *  and record `reqId` as the last-answered planned sync. */
+	function plannedSyncFrame(reqId: number) {
+		return {
+			type: "sync",
+			reqId,
+			full: false,
+			blocks: [{ id: `u:${reqId}`, kind: "user", turn: 1, order: 0, text: "hi", tokens: 10 }],
+			contextWindow: 1000,
+			planned: true,
+		};
+	}
+
+	it("tallies planOutcomes counters per cause and a running total", () => {
+		connectAndHello();
+		const ws = FakeWebSocket.last!;
+		expect(live.planOutcomes.total).toBe(0);
+
+		ws.emit({ type: "passthrough", reqId: 1, cause: "applied", ops: 2, groups: 0, recalls: 0 });
+		ws.emit({ type: "passthrough", reqId: 2, cause: "empty-plan", ops: 0, groups: 0, recalls: 0 });
+		ws.emit({ type: "passthrough", reqId: 3, cause: "timeout-stale", ops: 1, groups: 0, recalls: 0 });
+		ws.emit({ type: "passthrough", reqId: 4, cause: "timeout-raw", ops: 0, groups: 0, recalls: 0 });
+		ws.emit({ type: "passthrough", reqId: 5, cause: "epoch-mismatch", ops: 0, groups: 0, recalls: 0 });
+
+		expect(live.planOutcomes).toEqual({
+			applied: 1,
+			"empty-plan": 1,
+			"timeout-stale": 1,
+			"timeout-raw": 1,
+			"epoch-mismatch": 1,
+			total: 5,
+		});
+	});
+
+	it("resets planOutcomes to zero on a fresh connection", () => {
+		connectAndHello();
+		FakeWebSocket.last!.emit({ type: "passthrough", reqId: 1, cause: "applied", ops: 0, groups: 0, recalls: 0 });
+		expect(live.planOutcomes.total).toBe(1);
+
+		connectAndHello(); // fresh connect — connectLive() drops the prior socket first
+		expect(live.planOutcomes.total).toBe(0);
+	});
+
+	it("a timeout-stale ack for the last-answered planned reqId reconciles via markSent({rawWire:true})", () => {
+		connectAndHello();
+		const ws = FakeWebSocket.last!;
+		expect(session.store).not.toBeNull();
+		const spy = vi.spyOn(session.store!, "markSent");
+
+		ws.emit(plannedSyncFrame(7)); // client replies, sets lastPlannedReqId=7, calls markSent() once
+		spy.mockClear(); // drop that call — assert only the ack-triggered one below
+
+		ws.emit({ type: "passthrough", reqId: 7, cause: "timeout-stale", ops: 0, groups: 0, recalls: 0 });
+		expect(spy).toHaveBeenCalledWith({ rawWire: true });
+	});
+
+	it("a timeout-raw ack for the last-answered planned reqId ALSO reconciles", () => {
+		connectAndHello();
+		const ws = FakeWebSocket.last!;
+		const spy = vi.spyOn(session.store!, "markSent");
+
+		ws.emit(plannedSyncFrame(9));
+		spy.mockClear();
+
+		ws.emit({ type: "passthrough", reqId: 9, cause: "timeout-raw", ops: 0, groups: 0, recalls: 0 });
+		expect(spy).toHaveBeenCalledWith({ rawWire: true });
+	});
+
+	it("an epoch-mismatch ack is counted but never triggers reconciliation (superseded view)", () => {
+		connectAndHello();
+		const ws = FakeWebSocket.last!;
+		const spy = vi.spyOn(session.store!, "markSent");
+
+		ws.emit(plannedSyncFrame(11));
+		spy.mockClear();
+
+		ws.emit({ type: "passthrough", reqId: 11, cause: "epoch-mismatch", ops: 0, groups: 0, recalls: 0 });
+		expect(spy).not.toHaveBeenCalled();
+		expect(live.planOutcomes["epoch-mismatch"]).toBe(1);
+	});
+
+	it("an ack for an unknown/older reqId (not the last-answered one) is ignored for reconciliation", () => {
+		connectAndHello();
+		const ws = FakeWebSocket.last!;
+		const spy = vi.spyOn(session.store!, "markSent");
+
+		ws.emit(plannedSyncFrame(20));
+		spy.mockClear();
+
+		// A stale ack for an OLDER reqId than the one this client last answered.
+		ws.emit({ type: "passthrough", reqId: 19, cause: "timeout-stale", ops: 0, groups: 0, recalls: 0 });
+		expect(spy).not.toHaveBeenCalled();
+		// The counter still counts it — only reconciliation is gated on the reqId match.
+		expect(live.planOutcomes["timeout-stale"]).toBe(1);
+	});
+
+	it("an applied/empty-plan ack never forces a redundant rawWire markSent call", () => {
+		connectAndHello();
+		const ws = FakeWebSocket.last!;
+		const spy = vi.spyOn(session.store!, "markSent");
+
+		ws.emit(plannedSyncFrame(30));
+		spy.mockClear();
+
+		ws.emit({ type: "passthrough", reqId: 30, cause: "applied", ops: 1, groups: 0, recalls: 0 });
+		ws.emit({ type: "passthrough", reqId: 30, cause: "empty-plan", ops: 0, groups: 0, recalls: 0 });
+		expect(spy).not.toHaveBeenCalled();
 	});
 });

--- a/app/src/lib/live/protocol.ts
+++ b/app/src/lib/live/protocol.ts
@@ -18,8 +18,14 @@
  *   2. Extension sends `sync` with the blocks added since the last sync.
  *   3. GUI updates its live store, runs the engine, replies `plan { ops }`.
  *   4. Extension applies the ops to the real messages and returns them to pi.
- *      If no GUI is connected, or the reply times out, the extension passes the
- *      messages through UNMODIFIED (never corrupts context).
+ *      If no GUI is connected, the reply times out with no cached plan, or the
+ *      GUI's view was superseded mid-wait, the extension passes the messages
+ *      through UNMODIFIED (never corrupts context). A timeout WITH a cached plan
+ *      re-applies that last-known plan instead of shipping raw (issue #58). Every
+ *      one of these outcomes — including success — is counted and, where a client
+ *      is reachable, acked back as a `passthrough` message (issue #60, ADR 0020) so
+ *      the GUI (and the bellows bench rig polling `/__accordion/meta`) can see what
+ *      actually rode the wire instead of inferring it from silence.
  *
  * Milestone 1 deliberately ships an EMPTY plan (`ops: []`) from the GUI: the loop
  * is proven end-to-end while never altering a single model call.
@@ -45,6 +51,12 @@
  *    fast path. Capability is detected out-of-band via `armedAck` — a new client
  *    that sends `armed` and gets no ack back knows it is talking to an old extension
  *    (and can scream) — so the version number buys nothing a bump would cost.
+ *  - (no bump, additive) `passthrough`: the extension's per-outcome ack for every
+ *    `context` hook resolution (issue #60, ADR 0020) — `applied` / `empty-plan` /
+ *    `timeout-stale` / `timeout-raw` / `epoch-mismatch`. Purely informational (the
+ *    GUI never replies to it), so the same reasoning as `armed`/`armedAck` applies:
+ *    an old GUI simply drops the unknown message type and stays on the pre-#60
+ *    silent-passthrough behavior.
  */
 export const PROTOCOL_VERSION = 7;
 
@@ -284,7 +296,49 @@ export interface ArmedAckMessage {
 	armed: boolean;
 }
 
-export type ServerMessage = HelloMessage | SyncMessage | StreamMessage | UnfoldRequestMessage | RecallRequestMessage | CompleteResultMessage | ArmedAckMessage;
+/**
+ * The cause of one `context` hook resolution the extension is willing to ack over the
+ * wire (issue #60). The full server-side taxonomy also has `"no-gui"` and `"unsent"` —
+ * those two mean there is no reachable client to ack, so they never appear here; they
+ * are counter-only on the extension side (see `/__accordion/meta`'s `planOutcomes`).
+ *   • "applied"       — the GUI's plan (non-empty) was applied to the model call.
+ *   • "empty-plan"    — the GUI intentionally replied with no folds; the call rode raw.
+ *   • "timeout-stale" — the plan reply missed the wait; the LAST KNOWN plan was
+ *     re-applied instead (issue #58). The GUI's fresh plan for this `reqId` did NOT
+ *     ride the wire.
+ *   • "timeout-raw"   — the plan reply missed the wait and there was no usable cached
+ *     plan; the call rode raw, same as "empty-plan" but caused by a miss, not intent.
+ *   • "epoch-mismatch" — a new client attached mid-wait, superseding the view that sent
+ *     this request; acked to the CURRENT client (whoever that now is) purely so it can
+ *     count the outcome — `reqId` belongs to the superseded view, not to anything the
+ *     current client itself sent.
+ */
+export type PassthroughCause = "applied" | "empty-plan" | "timeout-stale" | "timeout-raw" | "epoch-mismatch";
+
+/**
+ * Sent by the extension after EVERY `context` hook resolution (issue #60, ADR 0020) —
+ * the observability fix for the silent-passthrough branches (`no-gui` excepted, which has
+ * no reachable client to ack). `ops`/`groups`/`recalls` are the counts ACTUALLY applied to
+ * the wire for this call (0 for every raw/empty cause); on `"applied"`/`"timeout-stale"`
+ * they reflect the plan that was really used (the fresh plan, or the stale fallback,
+ * respectively).
+ *
+ * This message is purely informational — the GUI never replies to it. Its two jobs on the
+ * receiving end: (1) tally `planOutcomes` for the UI's "wire N/M" readout, and (2) drive
+ * birth-fold reconciliation — a `"timeout-stale"`/`"timeout-raw"` ack means the GUI's OWN
+ * fresh plan for `reqId` did not ride the wire, so any birth-fold exemption it assumed on
+ * reply must be conservatively dropped (see `liveClient.svelte.ts`'s handling).
+ */
+export interface PassthroughMessage {
+	type: "passthrough";
+	reqId: number;
+	cause: PassthroughCause;
+	ops: number;
+	groups: number;
+	recalls: number;
+}
+
+export type ServerMessage = HelloMessage | SyncMessage | StreamMessage | UnfoldRequestMessage | RecallRequestMessage | CompleteResultMessage | ArmedAckMessage | PassthroughMessage;
 
 // ── Client → server (GUI → extension) ────────────────────────────────────────
 
@@ -406,5 +460,5 @@ export type ClientMessage = PlanMessage | UnfoldResultMessage | RecallResultMess
 export function isServerMessage(v: unknown): v is ServerMessage {
 	if (!v || typeof v !== "object" || !("type" in v)) return false;
 	const t = (v as any).type;
-	return t === "hello" || t === "sync" || t === "stream" || t === "unfoldRequest" || t === "recallRequest" || t === "completeResult" || t === "armedAck";
+	return t === "hello" || t === "sync" || t === "stream" || t === "unfoldRequest" || t === "recallRequest" || t === "completeResult" || t === "armedAck" || t === "passthrough";
 }

--- a/app/src/lib/ui/map/MapHeader.svelte
+++ b/app/src/lib/ui/map/MapHeader.svelte
@@ -102,6 +102,21 @@
 	// What "Revert to auto" will clear: every block carrying a manual/agent override.
 	const editCount = $derived(store.blocks.filter((b) => b.override !== null).length);
 
+	// ── Wire outcome readout (issue #60, ADR 0020): "applied" acked model calls seen this
+	// connection out of the total acked. Failure causes (timeout-stale/timeout-raw/
+	// epoch-mismatch) make the numerator fall behind the denominator; an empty-plan reply
+	// counts as a SUCCESS (the GUI intentionally asked for no folds, same as applying one).
+	const wireTotal = $derived(live.planOutcomes.total);
+	const wireApplied = $derived(live.planOutcomes.applied + live.planOutcomes["empty-plan"]);
+	const wireTip = $derived(
+		`Model calls this connection: ${wireTotal}\n` +
+			`applied: ${live.planOutcomes.applied}\n` +
+			`empty-plan (intentional, no folds): ${live.planOutcomes["empty-plan"]}\n` +
+			`timeout-stale (fell back to last known plan): ${live.planOutcomes["timeout-stale"]}\n` +
+			`timeout-raw (no plan to fall back to): ${live.planOutcomes["timeout-raw"]}\n` +
+			`epoch-mismatch (view superseded mid-wait): ${live.planOutcomes["epoch-mismatch"]}`,
+	);
+
 	// ── Involvement locks (ADR 0011) — the honest mirror of the engine's gating. A locked
 	// control LOOKS locked in every mode (preview/demo/read-only included), driven purely off
 	// `store.isLocked(...)`. The engine already no-ops the underlying action; this is the UI
@@ -203,6 +218,22 @@
 					<span class="fold-arm-eyebrow mono">FOLDING</span>
 					<span class="fold-arm-state">{folding.enabled ? "steering" : "preview"}</span>
 				</button>
+			{/if}
+
+			<!-- Wire outcome readout (issue #60): hidden entirely until this connection has seen
+			     at least one acked model call — browsing/read-only/demo sessions have no wire, so
+			     they must show nothing (preview is NOT a more permissive mode). Neutral/mono only —
+			     #044EFF is reserved for the user block kind, never UI chrome. -->
+			{#if live.status === "connected" && wireTotal > 0}
+				<div class="ctl-field wire-read" title={wireTip}>
+					<span class="ctl-eyebrow mono">
+						<Icon name="activity" size={10} />
+						WIRE
+					</span>
+					<span class="ctl-value mono tnum" class:wire-partial={wireApplied < wireTotal}>
+						{wireApplied}/{wireTotal}
+					</span>
+				</div>
 			{/if}
 
 			<!-- Protect readout: eyebrow + editable mono value (the dial lives on the bar). -->
@@ -626,6 +657,16 @@
 	/* Protect readout (the dial lives on the bar) */
 	.protect-read {
 		cursor: default;
+	}
+
+	/* Wire outcome readout (issue #60) — quiet, monochrome; never the reserved user-block
+	   blue. A partial ratio (some calls fell back) dims to --muted rather than alarming red -
+	   a stale-plan fallback is a graceful degradation, not an error state. */
+	.wire-read {
+		cursor: default;
+	}
+	.wire-read .wire-partial {
+		color: var(--muted);
 	}
 
 	/* A control gated by an involvement lock (ADR 0011): greyed, reduced affordance. The

--- a/docs/adr/0020-plan-applied-ack.md
+++ b/docs/adr/0020-plan-applied-ack.md
@@ -1,0 +1,167 @@
+# ADR 0020 — `passthrough`: acking every `context` hook outcome back to the GUI
+
+**Status:** accepted
+**Date:** 2026-07-09
+**Builds on:** [ADR 0018](0018-conductor-birth-fold.md) (the birth-fold exemption and its `markSent`
+cursor — the mechanism this ADR's reconciliation calls into), issue #58 (the stale-plan fallback:
+a timeout re-applies the last known plan instead of shipping raw) and its follow-up #61
+(steering mode + plan RTT), which is where the observability gap below was first named but
+deliberately left open.
+
+## Context
+
+`extension/accordion.ts`'s `context` hook has always had more outcomes than "apply the GUI's
+plan": no GUI attached, the reply timing out, a GUI reconnect superseding the in-flight request,
+the socket dropping mid-wait, and (post-#58) a timeout falling back to a **stale** cached plan.
+Every one of those branches returned `undefined` (or the stale-applied messages) and the GUI never
+found out. Two concrete costs of that silence:
+
+1. **No visibility for anyone.** A benchmark rig (bellows) polling for "how much of this session
+   actually got folded" had nothing to poll — the extension's own state was the only place that
+   knew, and it never left the process. #58 contamination — a stale-plan fallback silently
+   diverging from what the GUI's engine believed it sent — was diagnosed by reading logs after the
+   fact, not by anything either side could check live.
+2. **A real correctness gap in birth-fold bookkeeping.** `liveClient.svelte.ts` calls
+   `session.store.markSent({ rawWire: !folding.enabled })` the instant it **replies** to a planned
+   sync — on the assumption that its reply is what rides the wire. On a timeout that assumption is
+   false: the extension applied the *stale* plan (or nothing), not the fresh one the GUI just
+   computed. A block the GUI's fresh plan folded — believing the model would never see it whole —
+   could ride the wire unfolded via the stale plan, while the birth-fold exemption survives
+   (ADR 0018's sticky `birthFolded` set has no way to learn its assumption was wrong). This was
+   called out as a known, unfixed gap in the stale-fallback code comment (search "Known gap
+   (pre-existing on both parents, issue #60)" — now resolved, comment updated in the same commit
+   as this ADR).
+
+## Decision
+
+### 1. A cause taxonomy for every `context` hook resolution
+
+Every `context` hook invocation resolves to **exactly one** of seven causes
+(`PlanOutcomeCause` in `accordion.ts`):
+
+- `applied` — the GUI's non-empty plan was applied.
+- `empty-plan` — the GUI intentionally replied with no folds (a real success, not a failure —
+  this is the conductor's own decision, distinct from a miss).
+- `timeout-stale` — the plan reply missed the wait; the last known plan was re-applied (#58).
+- `timeout-raw` — the plan reply missed the wait and there was no usable cached plan; raw
+  passthrough, same wire effect as `empty-plan` but caused by a miss, not intent.
+- `no-gui` — no client attached at all.
+- `epoch-mismatch` — a new client attached mid-wait, superseding the view the request was sent to.
+- `unsent` — the socket dropped mid-wait with no reconnect (so there is no client to ack).
+
+The last two have no reachable client to notify, so they are **counter-only**; the other five are
+also acked to the GUI as a `passthrough` message (`PassthroughCause` in `protocol.ts` is the same
+union minus those two).
+
+### 2. The `passthrough` ack (wire, additive, no version bump)
+
+`PassthroughMessage { type: "passthrough", reqId, cause, ops, groups, recalls }` — sent
+fire-and-forget from `recordPlanOutcome` (never awaited; `send()` itself is try/catch-and-forget,
+matching every other push in this file). `ops`/`groups`/`recalls` are the counts **actually
+applied to the wire** for that call (0 for every raw/empty cause; the real plan's counts for
+`applied`; the stale plan's counts for `timeout-stale`).
+
+Follows the `armed`/`armedAck` precedent (protocol.ts's version-history comment): purely additive,
+**no `PROTOCOL_VERSION` bump**. An old GUI simply drops the unknown message type and silently
+keeps the pre-#60 behavior — there is no mixed-version hazard to force a bump over, since the
+extension never requires a reply to this message.
+
+`epoch-mismatch` is acked to the **current** client (whoever that now is), not dropped — it can
+still count the outcome, even though the `reqId` belongs to the view it superseded. This is the
+one cause where the ack's `reqId` does not correspond to anything the receiving client itself
+sent.
+
+### 3. Counters, not events: `/__accordion/meta`'s `planOutcomes`
+
+Module-scoped, in-memory, per-extension-lifetime counters (`planOutcomeCounts`, mirroring the
+existing `sentCount` pattern) — one per cause, plus `contextHookCount` (the total). **Never
+persisted** (the context hook stays disk-I/O-free, a hard invariant) and **not reset on
+`session_start`**: unlike `sentCount`/`epoch`/`lastPlan`, which describe the current session's
+cursor and must not leak across a session swap, these are a running lifetime total whose
+observability value survives a swap. Exposed as `planOutcomes` in the existing
+`/__accordion/meta` HTTP response (ungated, same reasoning as the rest of that endpoint) — this is
+the shape the bellows bench rig polls to see how much of a run actually rode the GUI's plan versus
+a silent/fallback passthrough, without instrumenting pi itself.
+
+Transition-only logging: a `console.warn` fires when a `context` hook resolves to a **silent**
+cause (`no-gui`/`unsent`/`epoch-mismatch`) immediately after a **healthy** one (`applied`/
+`empty-plan`/`timeout-stale`/`timeout-raw`) — not on every silent call, since every session
+legitimately starts unattached and per-turn no-gui logging would be pure noise. The already-loud
+timeout branches (`console.warn`/`console.error` with cause + reqId + elapsed) are untouched.
+
+### 4. Birth-fold reconciliation on the GUI side
+
+`liveClient.svelte.ts` tracks `lastPlannedReqId` — the `reqId` of the last planned sync it
+replied to. On a `passthrough` ack:
+
+- `timeout-stale` / `timeout-raw` **and** `msg.reqId === lastPlannedReqId` → call
+  `session.store.markSent({ rawWire: true })` again. This is the correctness fix: the GUI's
+  optimistic `markSent()` call (made at reply time, believing its plan would ride) is
+  retroactively overridden — `rawWire: true` conservatively drops **every** birth-fold exemption,
+  because the model may have seen any block from that call whole via the stale/raw fallback.
+  `markSent`'s cursor advance is a `Math.max`, so calling it twice for the same call is idempotent.
+- `epoch-mismatch` → counted, never reconciled — the ack is for a superseded view; the GUI that
+  answers today has already rebuilt its store from scratch (a fresh attach) and has nothing to
+  reconcile.
+- An ack for any other `reqId` (unknown or older than `lastPlannedReqId`) → ignored for
+  reconciliation, counted only. Since a WS connection processes one `context` hook at a time,
+  reqIds and their acks arrive strictly in order, so an exact-match guard suffices — no
+  "older-or-equal" comparison needed.
+
+This relies on one ordering assumption, stated as a comment at the call site: WS delivery is FIFO
+and the extension sends the ack strictly **after** the plan wait for that `reqId` resolves — i.e.
+after the sync it answers and before the *next* planned sync — so reconciliation always lands
+before this client's next `markSent()` call and can never race a later, legitimate exemption.
+
+### 5. UI surfacing
+
+`MapHeader.svelte` shows a small monochrome "wire N/M" readout (M = acked model calls seen this
+connection, N = calls where the GUI's plan — or its intentional empty plan — actually applied,
+i.e. `applied + empty-plan`) with a tooltip breakdown by cause. Gated on
+`live.status === "connected" && total > 0`, following the existing pattern for live-only chrome
+(the arm toggle, the READ-ONLY badge): hidden entirely for a browsing/read-only/demo session,
+which has no wire at all. `#044EFF` (reserved for `user` blocks) is never used here.
+
+## Non-goals
+
+- **No cross-check against provider-reported usage.** This ADR counts *hook resolutions*, not
+  tokens actually billed — it says nothing about whether `wireTokens`/the model's own usage report
+  matches what the GUI believes it sent. That reconciliation (if ever wanted) is a separate,
+  larger effort and out of scope here.
+- **No bellows-side consumption.** This ADR ships the counters and the endpoint; how (or whether)
+  the bellows bench rig ingests `planOutcomes` into its own dashboards is bellows' repo, not this
+  one.
+- **No change to the stale-plan fallback policy itself** (#58's decision to re-apply the last known
+  plan on timeout stands untouched) — this ADR only makes that decision *observable*, on both the
+  counter/log side and the GUI's own bookkeeping.
+
+## Consequences
+
+- **The GUI's birth-fold exemption can no longer silently outlive a call it assumed rode the wire
+  but didn't.** The fix is conservative (drops every exemption, not just the affected block's) by
+  design — precise per-block tracking of "which blocks did the stale plan actually differ on" would
+  require diffing two plans against the live message array, disproportionate to a rare fallback
+  path.
+- **Every `context` hook outcome is now counted somewhere** — no branch is unaccounted for, and the
+  five reachable-client causes are individually observable over the wire.
+- **No protocol version bump, no breaking change** for any existing peer (GUI, headless bellows
+  host, or a stale extension) — same reasoning as `armed`/`armedAck`.
+- **The golden conductor test is untouched** — this ADR touches only the extension's outcome
+  bookkeeping and the GUI's wire handling, never fold decisions themselves.
+
+## Rejected alternatives
+
+- **Only fix the birth-fold bug, skip the observability counters/UI.** Rejected: the same
+  `passthrough` ack that lets the GUI reconcile birth-fold is the natural vehicle for counting —
+  building the wire message just for internal reconciliation and not exposing it would waste the
+  one thing bellows actually needs (see #58/#61's own after-the-fact log-reading pain).
+  Additionally, this project would remain difficult to debug (both `no-gui` and `epoch-mismatch`
+  are silent by construction) without the counters.
+- **Precise per-block reconciliation** (diff the stale plan against the fresh plan and only drop
+  exemptions for blocks that actually differ). Rejected as disproportionate: the stale-fallback
+  path is already a rare, logged-loudly degradation; conservatively dropping the whole exemption
+  set costs at most a few blocks' folding for one extra call, versus real implementation and
+  testing cost for a narrow win.
+- **Bump `PROTOCOL_VERSION` for the new message.** Rejected for the same reason `armed`/`armedAck`
+  didn't: the strict version-mismatch check both peers already do would break every mixed-version
+  pairing for a message that is purely additive and never blocks on a reply.

--- a/extension/accordion.ts
+++ b/extension/accordion.ts
@@ -30,9 +30,12 @@
  *     yet, pass through as before — but always log the timeout (never silent). Note:
  *     on a timeout-with-stale-fallback turn, what the GUI is showing can diverge for
  *     that one turn from what the extension actually sent the model (the stale plan
- *     may be missing folds/unfolds the GUI has since queued) — the fold alarm has no
- *     visibility into this, since it never receives the applied plan back. The next
- *     plan the GUI delivers resyncs both sides.
+ *     may be missing folds/unfolds the GUI has since queued) — the next plan the GUI
+ *     delivers resyncs both sides. Unlike before #60, this divergence is no longer
+ *     invisible: every `context` hook outcome (including this one) is counted and, when
+ *     a client is reachable, acked back as a `passthrough` message (issue #60, ADR 0020)
+ *     — see `recordPlanOutcome` below — so the GUI's birth-fold bookkeeping and the
+ *     bellows bench rig can both observe it instead of assuming the fresh plan rode.
  *   • pi's native /compact is suppressed ONLY while the GUI is attached.
  *   • The shared mapping (linearize/applyPlan) carries the provider-safety rules
  *     (durable-id + kind checks); the engine is the single foldability gate and
@@ -377,6 +380,88 @@ export default function accordionLive(pi: ExtensionAPI): void {
 	// `message_end` to stamp `usage.rttMs` on the assistant message this request produced.
 	// null = no context RTT to attribute (e.g. no GUI attached this turn) → no field stamped.
 	let lastPlanRttMs: number | null = null;
+
+	// ── plan-outcome observability (issue #60, ADR 0020) ────────────────────────────
+	// Every `context` hook resolves to EXACTLY one of these causes — the full taxonomy of
+	// what happened to a model call's context, including the two that used to be totally
+	// silent (`no-gui`, `epoch-mismatch`) and the pre-existing-but-unobservable timeout
+	// fallbacks. `no-gui`/`unsent` have no reachable client to ack (see `recordPlanOutcome`),
+	// so they are counter-only; the other five are also acked to the GUI as a `passthrough`
+	// message (`PassthroughCause` in protocol.ts is this type minus those two).
+	type PlanOutcomeCause = "applied" | "empty-plan" | "timeout-stale" | "timeout-raw" | "no-gui" | "epoch-mismatch" | "unsent";
+	// Per-extension-lifetime counters (plain in-memory state, mirrors `sentCount`'s pattern).
+	// Deliberately NOT reset on `session_start` — a session swap doesn't invalidate the
+	// observability value of a running total, unlike `sentCount`/`epoch`/`lastPlan`, which
+	// genuinely describe THIS session's cursor and must not leak across a swap. Never
+	// persisted (the context hook must stay disk-I/O-free — see the header Safety note).
+	const planOutcomeCounts: Record<PlanOutcomeCause, number> = {
+		applied: 0,
+		"empty-plan": 0,
+		"timeout-stale": 0,
+		"timeout-raw": 0,
+		"no-gui": 0,
+		"epoch-mismatch": 0,
+		unsent: 0,
+	};
+	let contextHookCount = 0; // total `context` hook invocations this extension lifetime
+	// Previous outcome cause — used ONLY to log a TRANSITION into a silent-passthrough state
+	// (not every call: every session legitimately starts unattached, so per-turn no-gui
+	// logging would be pure noise). null until the first `context` hook ever resolves.
+	let lastOutcomeCause: PlanOutcomeCause | null = null;
+	const SILENT_CAUSES: ReadonlySet<PlanOutcomeCause> = new Set(["no-gui", "unsent", "epoch-mismatch"]);
+
+	/**
+	 * Record the outcome of ONE `context` hook resolution (issue #60). Called exactly once
+	 * per hook invocation, on every exit path — including the success path — so every
+	 * `context` call increments exactly one counter.
+	 *
+	 * Side effects, in order:
+	 *   1. Bump `planOutcomeCounts[cause]` and `contextHookCount`.
+	 *   2. `console.warn` iff this call is entering a SILENT state (no-gui/unsent/
+	 *      epoch-mismatch) from a non-silent ("healthy") one — e.g. the first no-gui call
+	 *      after having been attached, or the first unsent/epoch-mismatch after a healthy
+	 *      run. Never warns on the very first call ever (nothing to transition FROM), and
+	 *      never warns silent→silent (already noisy enough at the transition). The
+	 *      already-logged timeout branches (`timeout-stale`/`timeout-raw`) are untouched —
+	 *      they log every call via `console.warn`/`console.error` at their call sites.
+	 *   3. Fire-and-forget a `passthrough` ack to `ackTarget` iff it is non-null and OPEN.
+	 *      `ackTarget` is null for `no-gui`/`unsent` (no reachable client — counter-only per
+	 *      spec) and the CURRENT client for every other cause, including `epoch-mismatch`
+	 *      (whose `reqId` belongs to the superseded view — the current client can still
+	 *      count it, it just can't correlate the id to anything it itself sent).
+	 *
+	 * NEVER awaited by the caller — `send()` is itself fire-and-forget (try/catch, no
+	 * return value), so this can never delay or block the `context` hook's own return.
+	 */
+	function recordPlanOutcome(
+		cause: PlanOutcomeCause,
+		reqId: number | null,
+		applied: { ops: number; groups: number; recalls: number },
+		ackTarget: WebSocket | null,
+	): void {
+		planOutcomeCounts[cause]++;
+		contextHookCount++;
+		if (SILENT_CAUSES.has(cause) && lastOutcomeCause !== null && !SILENT_CAUSES.has(lastOutcomeCause)) {
+			console.warn(
+				`[accordion] context hook: silent passthrough (${cause})${reqId != null ? ` reqId=${reqId}` : ""} — previous outcome was '${lastOutcomeCause}'`,
+			);
+		}
+		lastOutcomeCause = cause;
+		if (ackTarget && ackTarget.readyState === 1 /* OPEN */) {
+			// Cast: `no-gui`/`unsent` never reach here with a non-null ackTarget (every call
+			// site below passes `null` for those two causes), so `cause` is always one of
+			// protocol.ts's narrower `PassthroughCause` at runtime despite the wider static type.
+			send(ackTarget, {
+				type: "passthrough",
+				reqId: reqId ?? -1,
+				cause: cause as Exclude<PlanOutcomeCause, "no-gui" | "unsent">,
+				ops: applied.ops,
+				groups: applied.groups,
+				recalls: applied.recalls,
+			});
+		}
+	}
+
 	// Unfold requests: keyed by reqId, resolved when the GUI replies (or null on flush).
 	// Deliberately NOT reset on reconnect (unlike reqSeq): a late reply from a superseded
 	// GUI can never alias a fresh request's reqId, and flushPending() drains the map anyway.
@@ -700,7 +785,11 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			// any other origin because we set no CORS headers.
 			if (u.pathname === "/__accordion/meta") {
 				res.writeHead(200, { "Content-Type": "application/json" });
-				res.end(JSON.stringify({ served: true, sessionId, protocolVersion: PROTOCOL_VERSION }));
+				// `planOutcomes` (issue #60, ADR 0020): per-cause counts of every `context` hook
+				// resolution this extension has ever resolved, plus `total` (= `contextHookCount`,
+				// the total invocation count) — what the bellows bench rig polls to see how much
+				// of a session actually rode the GUI's plan vs. a silent/fallback passthrough.
+				res.end(JSON.stringify({ served: true, sessionId, protocolVersion: PROTOCOL_VERSION, planOutcomes: { ...planOutcomeCounts, total: contextHookCount } }));
 				return;
 			}
 
@@ -1250,7 +1339,10 @@ export default function accordionLive(pi: ExtensionAPI): void {
 		lastMessages = event.messages as unknown as PiMessage[];
 		pendingSince = [];
 		const all = linearize(lastMessages);
-		if (!attached()) return; // no GUI → pass through untouched
+		if (!attached()) {
+			recordPlanOutcome("no-gui", null, { ops: 0, groups: 0, recalls: 0 }, null);
+			return; // no GUI → pass through untouched
+		}
 
 		const fresh = all.slice(sentCount);
 		const reqId = ++reqSeq;
@@ -1262,8 +1354,17 @@ export default function accordionLive(pi: ExtensionAPI): void {
 		const result = await requestPlan(reqId, full, fresh, myArmed);
 		lastPlanRttMs = Date.now() - t0;
 
-		if (epoch !== myEpoch) return; // GUI reconnected mid-flight → don't apply/advance
-		if (result.kind === "unsent") return; // couldn't deliver (no GUI / dropped) → pass through, don't advance
+		if (epoch !== myEpoch) {
+			// A new client attached mid-wait, superseding the view this request was sent to.
+			// Ack the CURRENT client anyway (it can still count the outcome) — its `reqId`
+			// belongs to the superseded view, not to anything the current client itself sent.
+			recordPlanOutcome("epoch-mismatch", reqId, { ops: 0, groups: 0, recalls: 0 }, client);
+			return; // GUI reconnected mid-flight → don't apply/advance
+		}
+		if (result.kind === "unsent") {
+			recordPlanOutcome("unsent", reqId, { ops: 0, groups: 0, recalls: 0 }, null);
+			return; // couldn't deliver (no GUI / dropped) → pass through, don't advance
+		}
 
 		if (result.kind === "timeout") {
 			// Issue #58: the plan missed the wait. Blocks WERE delivered, so advance the cursor
@@ -1291,11 +1392,21 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			}
 			// Recalls replay with the rest of the stale plan: a recall op is "keep this text
 			// injected for this call" desired state, exactly like a fold op, and applyPlan's
-			// anchor fallback keeps a stale anchor safe. Known gap (pre-existing on both parents,
-			// issue #60): the GUI cannot observe this fallback, so its birth-fold markSent()
-			// assumed the plan IT sent was applied — a fresh plan's fold that the stale plan
-			// lacks rode the wire whole while the exemption survives.
-			if (hasStale) return { messages: applyPlan(event.messages as unknown as PiMessage[], lastPlan!.ops, lastPlan!.groups, lastPlan!.recalls) as unknown as AgentMessage[] };
+			// anchor fallback keeps a stale anchor safe. Issue #60 (fixed): the GUI's own fresh
+			// plan for this reqId did NOT ride the wire, so its birth-fold markSent() cannot
+			// assume it did. `recordPlanOutcome` below acks `timeout-stale`/`timeout-raw` to the
+			// GUI so it can reconcile — see `liveClient.svelte.ts`'s passthrough handling and
+			// ADR 0020.
+			if (hasStale) {
+				recordPlanOutcome(
+					"timeout-stale",
+					reqId,
+					{ ops: lastPlan!.ops.length, groups: lastPlan!.groups.length, recalls: lastPlan!.recalls.length },
+					client,
+				);
+				return { messages: applyPlan(event.messages as unknown as PiMessage[], lastPlan!.ops, lastPlan!.groups, lastPlan!.recalls) as unknown as AgentMessage[] };
+			}
+			recordPlanOutcome("timeout-raw", reqId, { ops: 0, groups: 0, recalls: 0 }, client);
 			return;
 		}
 
@@ -1305,8 +1416,13 @@ export default function accordionLive(pi: ExtensionAPI): void {
 		const plan = result.plan;
 		lastPlan = plan;
 		sentCount = Math.max(sentCount, all.length); // advance cursor; never rewind (a message_end during the await may have advanced it further)
-		if (plan.ops.length === 0 && plan.groups.length === 0 && (plan.recalls?.length ?? 0) === 0) return; // empty plan → pass through
+		const recallCount = plan.recalls?.length ?? 0;
+		if (plan.ops.length === 0 && plan.groups.length === 0 && recallCount === 0) {
+			recordPlanOutcome("empty-plan", reqId, { ops: 0, groups: 0, recalls: 0 }, client);
+			return; // empty plan → pass through
+		}
 
+		recordPlanOutcome("applied", reqId, { ops: plan.ops.length, groups: plan.groups.length, recalls: recallCount }, client);
 		return { messages: applyPlan(event.messages as unknown as PiMessage[], plan.ops, plan.groups, plan.recalls) as unknown as AgentMessage[] };
 	});
 

--- a/extension/smoke.mjs
+++ b/extension/smoke.mjs
@@ -1049,12 +1049,16 @@ function unwrapMessageEnd(result) {
 	return result.message;
 }
 const stale = { primedFold: null, staleFold: null, emptyPass: undefined, afterEmptyPass: undefined, rtt: null, rtt2: null };
+// issue #60: every `context` outcome below also acks a `passthrough` message to this same
+// GUI socket — collected here in delivery order so we can assert cause/counts per scenario.
+const passthroughs = [];
 {
 	const gui = new WebSocket(`ws://127.0.0.1:${PORT}`);
 	let mode = "ignore"; // "fold" | "empty" | "drop" | "ignore"
 	gui.on("message", (data) => {
 		let m;
 		try { m = JSON.parse(data.toString()); } catch { return; }
+		if (m.type === "passthrough") { passthroughs.push(m); return; }
 		if (m.type !== "sync") return;
 		if (mode === "fold") gui.send(JSON.stringify({ type: "plan", reqId: m.reqId, ops: [{ id: "a:resp-abc:p0", digestText: "STALEFOLD" }], groups: [] }));
 		else if (mode === "empty") gui.send(JSON.stringify({ type: "plan", reqId: m.reqId, ops: [], groups: [] }));
@@ -1064,22 +1068,30 @@ const stale = { primedFold: null, staleFold: null, emptyPass: undefined, afterEm
 	await new Promise((r) => setTimeout(r, 100)); // let the view-only attach flush settle
 
 	// 1) Prime the cache: the GUI delivers a NON-EMPTY plan → lastPlan cached + applied.
+	//    Outcome: passthrough #1, cause "applied".
 	mode = "fold";
 	stale.primedFold = await Promise.resolve(handlers.context({ messages: sample }, ctx));
+	await waitFor(() => passthroughs.length >= 1, 1000, "passthrough ack #1 (applied)").catch(() => fails.push("passthrough: no ack received for the primed fold (applied)"));
 
 	// 2) TIMEOUT → the extension must re-apply the LAST KNOWN plan, not pass through
 	//    unfolded. The GUI withholds its reply; after the 250ms default wait the
 	//    context hook falls back to the cached STALEFOLD plan.
+	//    Outcome: passthrough #2, cause "timeout-stale".
 	mode = "drop";
 	stale.staleFold = await Promise.resolve(handlers.context({ messages: sample }, ctx));
+	await waitFor(() => passthroughs.length >= 2, 1000, "passthrough ack #2 (timeout-stale)").catch(() => fails.push("passthrough: no ack received for the stale-plan fallback (timeout-stale)"));
 
 	// 3) A delivered EMPTY plan (conductor wants no folds) must REPLACE the cached
 	//    non-empty plan — a later timeout must then pass through unfolded, never
 	//    resurrect the old fold.
+	//    Outcome: passthrough #3, cause "empty-plan".
 	mode = "empty";
 	stale.emptyPass = await Promise.resolve(handlers.context({ messages: sample }, ctx));
+	await waitFor(() => passthroughs.length >= 3, 1000, "passthrough ack #3 (empty-plan)").catch(() => fails.push("passthrough: no ack received for the delivered empty plan (empty-plan)"));
+	// Outcome: passthrough #4, cause "timeout-raw" (no cached plan survives the empty reply above).
 	mode = "drop";
 	stale.afterEmptyPass = await Promise.resolve(handlers.context({ messages: sample }, ctx));
+	await waitFor(() => passthroughs.length >= 4, 1000, "passthrough ack #4 (timeout-raw)").catch(() => fails.push("passthrough: no ack received for the raw timeout after an empty plan (timeout-raw)"));
 
 	// 4) rttMs stamp: a context wait stashes an RTT that the NEXT assistant message_end
 	//    stamps onto usage.rttMs; a following assistant message with no preceding context
@@ -1115,6 +1127,58 @@ if (rttMessage?.role !== "assistant") fails.push("rttMs: injected message must k
 const rtt2Message = unwrapMessageEnd(stale.rtt2);
 if (rtt2Message && rtt2Message.usage && typeof rtt2Message.usage.rttMs === "number")
 	fails.push("rttMs: a message with no preceding context RTT wrongly received a rttMs field (stale stash leaked)");
+
+// ── issue #60 / ADR 0020: passthrough acks for every outcome above ───────────
+// Four scenarios above each produced exactly one `context` hook resolution — assert the
+// GUI received a `passthrough` ack with the right cause and applied-op counts for each,
+// in delivery order (a 5th ack lands for the rtt-priming `context` call, "applied" again).
+if (passthroughs.length < 4) {
+	fails.push(`passthrough: expected at least 4 acks for the stale-fallback scenarios, got ${passthroughs.length}`);
+} else {
+	const [applied1, timeoutStale, emptyPlan, timeoutRaw] = passthroughs;
+	if (applied1.cause !== "applied") fails.push(`passthrough #1 expected cause 'applied', got '${applied1.cause}'`);
+	else if (!(applied1.ops >= 1)) fails.push(`passthrough #1 (applied) expected ops>=1 (the primed fold), got ${applied1.ops}`);
+
+	if (timeoutStale.cause !== "timeout-stale") fails.push(`passthrough #2 expected cause 'timeout-stale', got '${timeoutStale.cause}'`);
+	else if (!(timeoutStale.ops >= 1)) fails.push(`passthrough #2 (timeout-stale) expected ops>=1 (the re-applied stale plan), got ${timeoutStale.ops}`);
+
+	if (emptyPlan.cause !== "empty-plan") fails.push(`passthrough #3 expected cause 'empty-plan', got '${emptyPlan.cause}'`);
+	else if (emptyPlan.ops !== 0 || emptyPlan.groups !== 0 || emptyPlan.recalls !== 0)
+		fails.push(`passthrough #3 (empty-plan) expected all-zero counts, got ${JSON.stringify(emptyPlan)}`);
+
+	if (timeoutRaw.cause !== "timeout-raw") fails.push(`passthrough #4 expected cause 'timeout-raw', got '${timeoutRaw.cause}'`);
+	else if (timeoutRaw.ops !== 0 || timeoutRaw.groups !== 0 || timeoutRaw.recalls !== 0)
+		fails.push(`passthrough #4 (timeout-raw) expected all-zero counts, got ${JSON.stringify(timeoutRaw)}`);
+}
+
+// `/__accordion/meta` must expose the SAME outcomes as lifetime `planOutcomes` counters
+// (issue #60) — this is what the bellows bench rig polls. Counts are cumulative across the
+// WHOLE smoke run (earlier scenarios above already contributed some), so assert lower
+// bounds rather than exact equality.
+{
+	const metaRes = await new Promise((resolve, reject) => {
+		const r = http.get({ host: "127.0.0.1", port: PORT, path: "/__accordion/meta" }, (res) => {
+			let buf = "";
+			res.on("data", (d) => (buf += d));
+			res.on("end", () => resolve({ status: res.statusCode, body: buf }));
+		});
+		r.on("error", reject);
+	});
+	if (metaRes.status !== 200) fails.push(`/__accordion/meta (planOutcomes check) returned ${metaRes.status}, expected 200`);
+	else {
+		let parsed = null;
+		try { parsed = JSON.parse(metaRes.body); } catch { /* fall through */ }
+		const po = parsed?.planOutcomes;
+		if (!po) fails.push("/__accordion/meta did not carry a planOutcomes object");
+		else {
+			if (!(po.applied >= 2)) fails.push(`/__accordion/meta planOutcomes.applied expected >=2, got ${po.applied}`);
+			if (!(po["empty-plan"] >= 1)) fails.push(`/__accordion/meta planOutcomes["empty-plan"] expected >=1, got ${po["empty-plan"]}`);
+			if (!(po["timeout-stale"] >= 1)) fails.push(`/__accordion/meta planOutcomes["timeout-stale"] expected >=1, got ${po["timeout-stale"]}`);
+			if (!(po["timeout-raw"] >= 1)) fails.push(`/__accordion/meta planOutcomes["timeout-raw"] expected >=1, got ${po["timeout-raw"]}`);
+			if (!(typeof po.total === "number" && po.total >= 5)) fails.push(`/__accordion/meta planOutcomes.total expected >=5, got ${po.total}`);
+		}
+	}
+}
 
 // ── armed-over-wire: ARMED state (learned over the wire) drives blocking ──────
 // The client sends {type:"armed", armed:bool}; the extension acks and switches its
@@ -1264,6 +1328,7 @@ console.log(
 					`unfold tool (no-ids / detached guards, attached round-trip) ✓  ` +
 					`recall tool (no-ids / detached guards, content-echo round-trip) ✓  skill discovery ✓  ` +
 					`stale-plan fallback (timeout re-applies last plan, empty plan not overridden) ✓  rttMs stamp ✓  ` +
-						`armed-over-wire (ack, disarmed=short / armed=deadline, mid-toggle snapshot) ✓`,
+						`armed-over-wire (ack, disarmed=short / armed=deadline, mid-toggle snapshot) ✓  ` +
+							`passthrough acks (applied/empty-plan/timeout-stale/timeout-raw) ✓  /__accordion/meta planOutcomes ✓`,
 );
 process.exit(0);


### PR DESCRIPTION
Closes #60.

## Why

#58 proved the extension can silently send unfolded context on nearly every request while all telemetry looks healthy — bench runs count plans SENT, not APPLIED, and the wire had no ack. Every fallback branch in the `context` hook (no GUI, epoch mismatch, unsent/flush, timeout) passed through with zero observability. Separately, the main→devmain merge documented a correctness gap this same blindness causes: on a plan timeout the GUI's birth-fold `markSent()` assumes its fresh plan rode the wire when it didn't, leaving an exemption alive for a block the model has seen whole.

## What

- **Extension** (`extension/accordion.ts`): every `context` hook resolution lands in exactly one of seven outcome causes (`applied / empty-plan / timeout-stale / timeout-raw / no-gui / epoch-mismatch / unsent`), counted in memory (lifetime totals, `sentCount` pattern, no disk I/O on the hook). Previously-silent branches now `console.warn` on the *transition* into a silent state, not per call. Counters exposed as `planOutcomes` on `/__accordion/meta` — the bellows rig can poll this with no protocol change and would have caught #58 automatically.
- **Wire** (`protocol.ts`): new additive `passthrough` ServerMessage (reqId, cause, applied op counts), fire-and-forget on the same send path as `sync`. No PROTOCOL_VERSION bump, per the documented `armed`/`armedAck` convention — an old GUI drops the unknown type and keeps pre-#60 behavior.
- **Host** (`liveClient.svelte.ts`): per-connection `live.planOutcomes` tally, and the correctness half — a `timeout-stale`/`timeout-raw` ack matching the last planned-sync reqId this client answered triggers `markSent({ rawWire: true })`, conservatively dropping birth-fold exemptions because the GUI's plan factually did not ride. Unknown causes are ignored (defensive parse); acks for unknown/older reqIds are counted but never reconcile.
- **UI** (`MapHeader.svelte`): minimal monochrome "wire N/M" readout (N = calls where the GUI's plan or intentional empty plan applied), per-cause tooltip, hidden entirely when no acks have been seen — read-only/CC/demo sessions show nothing.
- **Docs**: ADR 0020; stale CLAUDE.md invariant line fixed (timeout now falls back to the last known plan); protocol flow comment updated.

## Verification

- svelte-check: 438 files, 0 errors / 0 warnings
- vitest: 893/893 (baseline 884 + 9 new: birth-fold reconciliation end-to-end through the real `AccordionStore`, liveClient ack handling incl. reqId guard and a FIFO-ordering regression test, per-connection reset)
- `extension/smoke.mjs` + `smoke-config.mjs`: pass, incl. new per-cause ack assertions and `/__accordion/meta` planOutcomes checks
- Opus adversarial review: no blocker/major/minor findings; both nits it raised are fixed in the follow-up commit; its coverage suggestion (pin the transport-ordering invariant) is the new FIFO test

## Out of scope (deliberate)

The issue's third proposal — cross-checking provider token usage against a host-side wireTokens belief — is carved out: nothing captures provider-reported input tokens today and the consumer is bellows-side. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)