### PR TITLE
fix(engine): heal stale protected folds in markSent; gate birth-fold on durable ids; protocol v8

### DIFF
--- a/app/src/lib/engine/store.birthfold.test.ts
+++ b/app/src/lib/engine/store.birthfold.test.ts
@@ -457,12 +457,14 @@ describe("birth-fold — rawWire markSent (folding disarmed) clears the exemptio
 		expect(s.isFolded(s.get("r:c1")!)).toBe(true); // view-folded…
 
 		// …but folding is DISARMED: the client replied with an EMPTY plan, so the model call
-		// carried r:c1 WHOLE. The exemption must die with that call, even though the view
-		// still renders the fold at this instant (the disarm→arm leak, adversarial review).
+		// carried r:c1 WHOLE. The exemption must die with that call AND the stale fold must heal
+		// RIGHT NOW, inside markSent itself (PR #52 review): production has no manual refold after
+		// markSent, and a zero-delta planned sync would otherwise skip appendBlocks' refold and let
+		// computeFoldOps ship a fold of already-seen content.
 		s.markSent({ rawWire: true });
 
-		conductor.cmds = [{ kind: "fold", ids: ["r:c1"] }];
-		s.refold();
+		// Healed with NO manual refold: markSent re-ran the conductor (still asking to fold r:c1)
+		// and clamped it, because r:c1 is now protected, non-fresh, and un-exempt.
 		expect(s.isFolded(s.get("r:c1")!)).toBe(false); // protection clamps like any seen block
 		expect(s.lastReports.some((r) => r.ids.includes("r:c1") && r.reason === "protected")).toBe(true);
 	});
@@ -495,9 +497,66 @@ describe("birth-fold — timeout-ack reconciliation clears an exemption markSent
 		// model may have seen ANY block from that call whole.
 		s.markSent({ rawWire: true });
 
-		conductor.cmds = [{ kind: "fold", ids: ["r:c1"] }];
-		s.refold();
+		// Healed inside markSent (PR #52 review) — no manual refold. The reconciliation drops the
+		// exemption AND springs the stale fold back to live, so a following zero-delta plan can't
+		// ship it.
 		expect(s.isFolded(s.get("r:c1")!)).toBe(false); // protection clamps like any seen block
 		expect(s.lastReports.some((r) => r.ids.includes("r:c1") && r.reason === "protected")).toBe(true);
+	});
+});
+
+// ── (o) zero-delta planned sync: markSent heals with no follow-up refold ───────
+//        The exact production window PR #52 review flagged: after a raw-wire markSent clears an
+//        exemption, the NEXT planned sync can be zero-delta (extension sends planned:true with
+//        fresh=[]) — appendBlocks early-returns WITHOUT refolding, then computePlan runs. If the
+//        stale fold were still standing, computeFoldOps would emit a FoldOp for content the model
+//        already received whole. markSent must therefore heal the fold itself, in-band.
+
+describe("birth-fold — zero-delta planned sync sees no stale protected fold", () => {
+	it("markSent({rawWire:true}) heals the fold and computeFoldOps emits nothing for it — no manual refold", () => {
+		const s = makeLiveStore(sessionWithFreshResult(8000));
+		s.setProtect(20_000);
+		const conductor = new StubConductor();
+		conductor.cmds = [{ kind: "fold", ids: ["r:c1"] }];
+		s.attach(conductor);
+		expect(s.isFolded(s.get("r:c1")!)).toBe(true);
+		// While the exemption stands, the wire genuinely carries the folded form.
+		expect(computeFoldOps(s).some((o) => o.id === "r:c1")).toBe(true);
+
+		// A disarmed/raw planned sync clears the exemption. NO manual refold follows — this mirrors
+		// a zero-delta next sync where appendBlocks([]) skips its refold and computePlan runs raw.
+		s.markSent({ rawWire: true });
+
+		expect(s.isFolded(s.get("r:c1")!)).toBe(false); // view already shows it live…
+		expect(computeFoldOps(s).some((o) => o.id === "r:c1")).toBe(false); // …and the wire plan is empty for it
+	});
+});
+
+// ── (p) a non-durable (positional-id) fresh block is NEVER birth-foldable ──────
+//        A malformed message emits a positional id (m<i>:…). Both computeFoldOps and applyPlan
+//        drop non-durable ids on the wire, so a birth-fold of one would recess the view tile and
+//        count the saving while the model still receives the block WHOLE — the view↔wire
+//        divergence the host must make unrepresentable. The birth-fold path must refuse it
+//        (PR #52 review) even though it is fresh + protected + a foldable kind.
+
+describe("birth-fold — non-durable id is never birth-folded (wire-truth)", () => {
+	it("a fresh, protected, oversized block with a POSITIONAL id clamps protected — not exempt", () => {
+		const s = makeLiveStore([
+			blk("u:1", "user", 1, 0, 500),
+			blk("m1:r", "tool_result", 1, 1, 8000), // non-durable positional id, fresh + oversized
+		]);
+		s.setProtect(20_000);
+		expect(s.isProtected(s.get("m1:r")!)).toBe(true);
+
+		const conductor = new StubConductor();
+		conductor.cmds = [{ kind: "fold", ids: ["m1:r"] }];
+		s.attach(conductor);
+
+		// Not birth-folded: clamped protected exactly like a non-fresh protected block, because the
+		// fold could never ride the wire (isDurableId false).
+		expect(s.isFolded(s.get("m1:r")!)).toBe(false);
+		expect(s.lastReports.some((r) => r.ids.includes("m1:r") && r.reason === "protected")).toBe(true);
+		// Nothing rides the wire for it either — no view↔wire divergence.
+		expect(computeFoldOps(s).some((o) => o.id === "m1:r")).toBe(false);
 	});
 });

--- a/app/src/lib/engine/store.svelte.ts
+++ b/app/src/lib/engine/store.svelte.ts
@@ -994,6 +994,18 @@ export class AccordionStore {
 	 * protection allows a fold, never WHAT kind is foldable.
 	 */
 	private birthFoldEligible(b: Block): boolean {
+		// DURABILITY gate (#43 wire-truth fix, PR #52 review): a positional/non-durable id
+		// (`m<i>:…`, emitted only for a malformed message missing its timestamp/responseId/
+		// toolCallId) is DROPPED by both `computeFoldOps` and `applyPlan` (each guards on
+		// `isDurableId`). Birth-folding such a block would recess the tile and count the saving in
+		// the view while the model still receives the block WHOLE — the exact view↔wire divergence
+		// the host must make unrepresentable. Deny the exemption so `substOne`'s protected clamp
+		// fires instead of granting a fold that can never ride the wire; this also keeps a
+		// non-durable id out of the sticky `birthFolded` set entirely (the set is recorded only
+		// AFTER this gate passes). NOTE the scope: this narrow durable-id check lives ONLY on the
+		// birth-fold / protected-tail path — PR #45 deliberately keeps durable-id OUT of the
+		// general (kind-only) foldability gate, so ordinary folds outside the tail are unchanged.
+		if (!isDurableId(b.id)) return false;
 		return wireFoldable(b) && (this.birthFolded.has(b.id) || this.isFresh(b));
 	}
 	/** Drop any `birthFolded` id whose block has aged out of the protected tail — the
@@ -1029,7 +1041,19 @@ export class AccordionStore {
 		// wire effect, so EVERY block on this call crossed whole, folded-looking ones included.
 		// Drop the whole set; otherwise a disarmed-era exemption would survive into a later ARMED
 		// run and fold protected content the model has factually seen (the disarm→arm leak).
+		// Detect a STALE protected fold: a block still rendered folded whose exemption is about to
+		// be dropped. Only the `rawWire` clear can strand one — it drops exemptions from currently-
+		// FOLDED blocks. The armed prune's `!isFolded` filter drops exemptions only for blocks that
+		// already settled LIVE, so it can never leave a fold behind.
+		let staleProtectedFold = false;
 		if (opts.rawWire) {
+			for (const id of this.birthFolded) {
+				const b = this.get(id);
+				if (b && this.isFolded(b)) {
+					staleProtectedFold = true;
+					break;
+				}
+			}
 			this.birthFolded.clear();
 		} else {
 			for (const id of this.birthFolded) {
@@ -1038,6 +1062,18 @@ export class AccordionStore {
 			}
 		}
 		this.sentThroughOrder = Math.max(this.sentThroughOrder, this.blocks[this.blocks.length - 1].order);
+		// HEAL now (PR #52 review — stale protected fold via zero-delta sync): re-run folding so a
+		// block that just lost its exemption springs back to live instead of lingering
+		// autoFolded+protected. After the cursor advance no block is `isFresh` and its id is out of
+		// `birthFolded`, so `substOne` re-clamps the fold as `protected` — that fold can no longer
+		// ride the wire, and the view must not keep showing it. Without this, a zero-delta planned
+		// sync (the extension sends `planned:true` with `fresh=[]`) skips `appendBlocks`' refold via
+		// its early return, and `computeFoldOps` would then emit a `FoldOp` for the stale fold —
+		// folding content the model already received WHOLE on the raw wire. Safe to refold here:
+		// `markSent` runs AFTER the reply is sent (liveClient's planned-sync handler and the
+		// passthrough-ack path), so this pass can never alter an in-flight reply. Gated on an actual
+		// stranded fold so the common armed call takes no redundant pass.
+		if (staleProtectedFold) this.refold();
 	}
 	/**
 	 * Mark every block currently in the store as already sent. Called once, at construction,

--- a/app/src/lib/live/protocol.ts
+++ b/app/src/lib/live/protocol.ts
@@ -51,14 +51,20 @@
  *    fast path. Capability is detected out-of-band via `armedAck` — a new client
  *    that sends `armed` and gets no ack back knows it is talking to an old extension
  *    (and can scream) — so the version number buys nothing a bump would cost.
- *  - (no bump, additive) `passthrough`: the extension's per-outcome ack for every
- *    `context` hook resolution (issue #60, ADR 0020) — `applied` / `empty-plan` /
- *    `timeout-stale` / `timeout-raw` / `epoch-mismatch`. Purely informational (the
- *    GUI never replies to it), so the same reasoning as `armed`/`armedAck` applies:
- *    an old GUI simply drops the unknown message type and stays on the pre-#60
- *    silent-passthrough behavior.
+ *  - v8: `passthrough`: the extension's per-outcome ack for every `context` hook resolution
+ *        (issue #60, ADR 0020) — `applied` / `empty-plan` / `timeout-stale` / `timeout-raw` /
+ *        `epoch-mismatch`. Unlike `armed`/`armedAck`, this is NOT purely informational: its
+ *        `timeout-stale`/`timeout-raw` cause is what lets the GUI learn its optimistic birth-fold
+ *        `markSent` assumed a plan that never rode the wire, and repair the exemption bookkeeping
+ *        (ADR 0018/0020). A v8 peer therefore MUST emit it — a silent v7-era extension paired with
+ *        a birth-folding GUI would leave a stale exemption that folds already-seen protected
+ *        content. It landed on the wire without a bump (v7 was never promoted past devmain); this
+ *        bump to v8 makes the correctness-critical ack part of the version contract, and `main`
+ *        (still v5 at the time of the devmain→main promotion) has to jump anyway, so the bump is
+ *        free. The strict `protocolVersion !== PROTOCOL_VERSION` check both peers do then refuses a
+ *        pre-ack peer instead of pairing silently.
  */
-export const PROTOCOL_VERSION = 7;
+export const PROTOCOL_VERSION = 8;
 
 /**
  * Browser dev-loop fallback port only. In the desktop ("pull") model each pi
@@ -323,11 +329,15 @@ export type PassthroughCause = "applied" | "empty-plan" | "timeout-stale" | "tim
  * they reflect the plan that was really used (the fresh plan, or the stale fallback,
  * respectively).
  *
- * This message is purely informational — the GUI never replies to it. Its two jobs on the
- * receiving end: (1) tally `planOutcomes` for the UI's "wire N/M" readout, and (2) drive
- * birth-fold reconciliation — a `"timeout-stale"`/`"timeout-raw"` ack means the GUI's OWN
- * fresh plan for `reqId` did not ride the wire, so any birth-fold exemption it assumed on
- * reply must be conservatively dropped (see `liveClient.svelte.ts`'s handling).
+ * The GUI never REPLIES to this message, but it is not merely informational: a v8 peer MUST
+ * emit it, because it is correctness-critical for birth-fold. Its two jobs on the receiving end:
+ * (1) tally `planOutcomes` for the UI's "wire N/M" readout, and (2) drive birth-fold
+ * reconciliation — a `"timeout-stale"`/`"timeout-raw"` ack means the GUI's OWN fresh plan for
+ * `reqId` did not ride the wire, so any birth-fold exemption it assumed on reply must be
+ * conservatively dropped (see `liveClient.svelte.ts`'s handling). A silent extension that skipped
+ * this ack would leave the GUI folding protected content the model has already seen whole — which
+ * is exactly why `passthrough` is now part of the version contract (bumped to v8), rather than an
+ * additive no-bump message like `armed`/`armedAck`.
  */
 export interface PassthroughMessage {
 	type: "passthrough";

--- a/docs/adr/0020-plan-applied-ack.md
+++ b/docs/adr/0020-plan-applied-ack.md
@@ -8,6 +8,18 @@ a timeout re-applies the last known plan instead of shipping raw) and its follow
 (steering mode + plan RTT), which is where the observability gap below was first named but
 deliberately left open.
 
+> **Update (PR #52 review, birth-fold wire-truth):** section 2 and the Rejected-alternatives note
+> below shipped `passthrough` *without* a `PROTOCOL_VERSION` bump, by analogy to `armed`/`armedAck`.
+> That analogy is now judged wrong for this message: `passthrough`'s `timeout-stale`/`timeout-raw`
+> ack is **correctness-critical**, not informational — it is the only signal that repairs the GUI's
+> optimistic birth-fold `markSent` when its plan did not ride the wire (section 4). A silent v7-era
+> extension paired with a birth-folding GUI would leave a stale exemption that folds already-seen
+> protected content. `passthrough` was therefore promoted into the version contract: **`PROTOCOL_VERSION`
+> is bumped 7 → 8**, so the strict `protocolVersion !== PROTOCOL_VERSION` check both peers already do
+> refuses a pre-ack peer rather than pairing silently. The bump is free in practice — `main` was
+> still v5 when devmain (v7) was promoted, so a jump was forced regardless, and v7 never shipped
+> past devmain. Read "no bump" in sections 2 and Rejected-alternatives as superseded by this note.
+
 ## Context
 
 `extension/accordion.ts`'s `context` hook has always had more outcomes than "apply the GUI's


### PR DESCRIPTION
## Why

gpt5.6SOL's review of the promotion PR (#52) flagged two High defects in birth-fold bookkeeping, both independently confirmed by tracing at 57cb8e0. Both share one root shape: `markSent` used the view's `isFolded` as a proxy for "what actually rode the wire."

1. **Stale protected fold after raw-wire reconcile.** `markSent({rawWire:true})` cleared the birth-fold exemption but never re-folded, stranding a block `autoFolded` + `protected` — a fold steering could no longer produce. The repo's own tests proved the gap (cases m/n needed a manual `refold()`); worse, a zero-delta *planned* sync (extension sends `planned:true` with `fresh=[]`, skipping `appendBlocks`' refold) could ship that stale fold to the wire — folding content the model had already seen whole, the cardinal invariant.
2. **Non-durable sticky exemption.** `birthFoldEligible` never checked durability, so a positional-id (`m…`) block could be view-folded with a permanent false "never seen whole" exemption while `computeFoldOps` silently dropped its fold — the model received it whole every call, surviving detach/conductor swaps.

## What

- `markSent` now detects when the rawWire clear strands a still-folded block and calls `refold()` in-band, gated to the rawWire branch (the armed prune only drops exemptions from already-live blocks and can never strand a fold). Safe at both call sites — each runs after the reply is sent.
- `birthFoldEligible` requires `isDurableId`; a non-durable fresh protected block now clamps `protected` instead of earning an exemption for a fold that can never ride the wire. Scope is the birth-fold path only — PR #45's deliberate kind-only general view gate is untouched.
- `PROTOCOL_VERSION` 7 → 8: the passthrough ack repairs optimistic birth-fold bookkeeping, so it's correctness-critical, not informational — v8 makes a pre-ack peer refuse loudly instead of degrading silently. Comments + ADR 0020 updated; the extension imports the constant, nothing hardcodes 7.

## Verification

- 895 tests green (+2 new: zero-delta regression, non-durable clamp); updated birthfold cases m/n now assert the heal happens with no manual `refold()`. All four fail against pre-fix source.
- Golden `conductor.builtin` snapshot byte-identical; svelte-check 0/0; extension `smoke.mjs` PASS.
- Adversarial (Opus) review: PASS, merge-ready — traced every `birthFolded` mutation path, reentrancy (latched by `conducting`), and plan/heal ordering at both `markSent` call sites.

## Watch items

- Review noted a cosmetic follow-up: `buildView` reports `fresh:true` for non-durable protected blocks, so a conductor may attempt the fold and collect a `protected` clamp each pass (log noise, self-limiting). Left out deliberately to keep this diff minimal.
- The pre-existing outside-the-tail non-durable view/wire divergence (PR #45 Slice 2, deferred) is unchanged — this PR closes the protected-tail slice of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)