### PR TITLE
fix(extension): server/auth hardening — ports, bind errors, IPv6, cookies, reaper, honest ack counts

### DIFF
--- a/app/src/lib/live/mapping.appliedCounts.test.ts
+++ b/app/src/lib/live/mapping.appliedCounts.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import { applyPlan, type PiMessage, type AppliedCounts } from "./mapping";
+import type { FoldOp, GroupOp, RecallOp } from "./protocol";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// applyPlan's optional `appliedOut` param (issue #60 follow-up, ADR 0020): the
+// extension's plan-applied ack must count what was ACTUALLY substituted onto the
+// wire, not what the plan merely SUBMITTED. A shape-valid op/group whose id(s)
+// match nothing live in `messages` (e.g. a stale plan re-applied after the
+// conversation moved on) has zero wire effect and must not be counted.
+//
+// Purely additive: every pre-existing call site omits the 5th arg and is
+// unaffected (covered by every other mapping*.test.ts file passing unchanged).
+// ─────────────────────────────────────────────────────────────────────────────
+
+function msgs(): PiMessage[] {
+	return [
+		{ role: "user", content: "fix the bug", timestamp: 1000 }, // m0  u:1000
+		{
+			role: "assistant",
+			responseId: "resp_a",
+			timestamp: 1001,
+			content: [
+				{ type: "thinking", thinking: "let me look" },
+				{ type: "text", text: "reading the file" },
+				{ type: "toolCall", id: "call_1", name: "read", arguments: { path: "a.ts" } },
+			],
+		}, // m1  a:resp_a:p0..p2
+		{ role: "toolResult", toolCallId: "call_1", toolName: "read", content: "file body" }, // m2  r:call_1
+		{ role: "user", content: "now refactor it", timestamp: 2000 }, // m3  u:2000
+	];
+}
+
+function counts(): AppliedCounts {
+	return { ops: -1, groups: -1, recalls: -1 }; // sentinel so an un-set field is obvious
+}
+
+describe("applyPlan — appliedOut counts (actually-applied, not submitted)", () => {
+	it("omitting appliedOut changes nothing — same return value as before", () => {
+		const out = applyPlan(msgs(), [{ id: "a:resp_a:p1", digestText: "FOLDED" }]);
+		expect(Array.isArray(out)).toBe(true);
+		expect((out[1].content as any[])[1].text).toBe("FOLDED");
+	});
+
+	it("a matched FoldOp on a text part is counted as applied", () => {
+		const out = counts();
+		applyPlan(msgs(), [{ id: "a:resp_a:p1", digestText: "FOLDED" }], [], [], out);
+		expect(out.ops).toBe(1);
+		expect(out.groups).toBe(0);
+		expect(out.recalls).toBe(0);
+	});
+
+	it("a matched FoldOp on a tool_result is counted as applied", () => {
+		const out = counts();
+		applyPlan(msgs(), [{ id: "r:call_1", digestText: "folded read" }], [], [], out);
+		expect(out.ops).toBe(1);
+	});
+
+	it("a shape-valid FoldOp whose id matches NOTHING in messages is NOT counted (the stale-plan case)", () => {
+		const out = counts();
+		const src = msgs();
+		const staleOps: FoldOp[] = [{ id: "a:resp_zzz:p0", digestText: "FOLDED" }]; // durable id, no such block
+		const result = applyPlan(src, staleOps, [], [], out);
+		expect(out.ops).toBe(0);
+		expect(result).toBe(src); // identity passthrough — nothing actually changed
+	});
+
+	it("a FoldOp id that resolves to a tool_call part is never applied and is NOT counted", () => {
+		// a:resp_a:p2 is the toolCall part — foldOne deliberately never folds it (would orphan
+		// the tool_result). The id is present in `byId` but never substituted.
+		const out = counts();
+		applyPlan(msgs(), [{ id: "a:resp_a:p2", digestText: "FOLDED" }], [], [], out);
+		expect(out.ops).toBe(0);
+	});
+
+	it("mixed matched + unmatched ops: only the matched one is counted", () => {
+		const out = counts();
+		applyPlan(
+			msgs(),
+			[
+				{ id: "a:resp_a:p1", digestText: "FOLDED" }, // matches → applied
+				{ id: "u:9999999", digestText: "FOLDED" }, // durable shape, no such message → not applied
+			],
+			[],
+			[],
+			out,
+		);
+		expect(out.ops).toBe(1);
+	});
+
+	it("a GroupOp whose members fully match is counted as one applied group", () => {
+		const out = counts();
+		const group: GroupOp = {
+			id: "g:1",
+			memberIds: ["a:resp_a:p0", "a:resp_a:p1", "a:resp_a:p2", "r:call_1"],
+			summaryText: "{#g FOLDED} read the file",
+		};
+		applyPlan(msgs(), [], [group], [], out);
+		expect(out.groups).toBe(1);
+		expect(out.ops).toBe(0);
+	});
+
+	it("a shape-valid GroupOp whose members match NOTHING live is NOT counted", () => {
+		const out = counts();
+		const staleGroup: GroupOp = {
+			id: "g:stale",
+			memberIds: ["a:resp_zzz:p0", "a:resp_zzz:p1"],
+			summaryText: "{#g FOLDED} nothing here",
+		};
+		applyPlan(msgs(), [], [staleGroup], [], out);
+		expect(out.groups).toBe(0);
+		// Passthrough: nothing durable matched, so applyPlan returns the identity (no change).
+		const src = msgs();
+		expect(applyPlan(src, [], [staleGroup])).toBe(src);
+	});
+
+	it("a GroupOp demoted to straggler by the tool-pair fixpoint is NOT counted", () => {
+		// Only the tool_result member is listed; its call (m1) is outside the group, so the
+		// fixpoint demotes this to a straggler — nothing is actually removed.
+		const out = counts();
+		const straggler: GroupOp = { id: "g:2", memberIds: ["r:call_1"], summaryText: null };
+		applyPlan(msgs(), [], [straggler], [], out);
+		expect(out.groups).toBe(0);
+	});
+
+	it("two groups submitted, only one matches live messages — exactly one counted", () => {
+		const out = counts();
+		const real: GroupOp = {
+			id: "g:real",
+			memberIds: ["a:resp_a:p0", "a:resp_a:p1", "a:resp_a:p2", "r:call_1"],
+			summaryText: "{#g FOLDED} done",
+		};
+		const stale: GroupOp = { id: "g:stale", memberIds: ["a:resp_zzz:p0"], summaryText: "{#g FOLDED} stale" };
+		applyPlan(msgs(), [], [real, stale], [], out);
+		expect(out.groups).toBe(1);
+	});
+
+	it("a safe RecallOp is always counted as applied (every safe recall inserts somewhere)", () => {
+		const out = counts();
+		const recalls: RecallOp[] = [{ id: "rc:1", afterId: "u:1000", text: "the original folded text" }];
+		applyPlan(msgs(), [], [], recalls, out);
+		expect(out.recalls).toBe(1);
+		expect(out.ops).toBe(0);
+		expect(out.groups).toBe(0);
+	});
+
+	it("a recall whose anchor is unknown still applies (append-at-end fallback) and is counted", () => {
+		const out = counts();
+		const recalls: RecallOp[] = [{ id: "rc:1", afterId: "u:999999999", text: "orphaned recall text" }];
+		const result = applyPlan(msgs(), [], [], recalls, out);
+		expect(out.recalls).toBe(1);
+		expect(JSON.stringify(result)).toContain("orphaned recall text");
+	});
+
+	it("a shape-INVALID recall (empty text) is filtered before counting — not counted", () => {
+		const out = counts();
+		const recalls: RecallOp[] = [{ id: "rc:1", afterId: "u:1000", text: "" }];
+		applyPlan(msgs(), [], [], recalls, out);
+		expect(out.recalls).toBe(0);
+	});
+
+	it("everything empty/omitted → all-zero counts, no crash on the early-return path", () => {
+		const out = counts();
+		applyPlan(msgs(), [], [], [], out);
+		expect(out).toEqual({ ops: 0, groups: 0, recalls: 0 });
+	});
+
+	it("combined plan: matched op + matched group + matched recall — all three counted independently", () => {
+		const out = counts();
+		const ops: FoldOp[] = [{ id: "u:2000", digestText: "FOLDED-USER" }]; // user role never folds → not applied
+		const group: GroupOp = {
+			id: "g:1",
+			memberIds: ["a:resp_a:p0", "a:resp_a:p1", "a:resp_a:p2", "r:call_1"],
+			summaryText: "{#g FOLDED} read the file",
+		};
+		const recalls: RecallOp[] = [{ id: "rc:1", afterId: "u:1000", text: "recalled text" }];
+		applyPlan(msgs(), ops, [group], recalls, out);
+		expect(out.ops).toBe(0); // user messages are never folded by foldOne
+		expect(out.groups).toBe(1);
+		expect(out.recalls).toBe(1);
+	});
+});

--- a/app/src/lib/live/mapping.ts
+++ b/app/src/lib/live/mapping.ts
@@ -189,6 +189,18 @@ export function wireToBlock(w: WireBlock): Block {
 	};
 }
 
+/**
+ * Optional out-param for `applyPlan` (additive — omitting it changes nothing). Populated with
+ * the counts of ops/groups/recalls ACTUALLY applied to the returned messages, as distinct from
+ * merely SUBMITTED in the plan: a shape-valid op/group whose id(s) match nothing live in
+ * `messages` has zero wire effect and must not be counted (see `applyPlan`'s doc comment).
+ */
+export interface AppliedCounts {
+	ops: number;
+	groups: number;
+	recalls: number;
+}
+
 /** The durable block ids a single message emits + its tool-pair callIds (mirrors `linearize`). */
 interface MsgInfo {
 	ids: string[];
@@ -237,23 +249,30 @@ function messageInfo(m: PiMessage, i: number): MsgInfo {
 
 /** Apply one message's in-place FoldOps (the original substitution path). Returns the same
  *  message by reference when nothing folds; clones lazily otherwise. `mark()` flags a change.
+ *  `onApplied(id)` is called for each op ACTUALLY substituted (not merely present in `byId`) —
+ *  an op whose id matches a `tool_call` part (or any non-text/thinking kind) is deliberately
+ *  never applied, and an op whose id matches no part at all is never even looked at again after
+ *  the `.get()` miss. Both cases must NOT be counted as applied (see `applyPlan`'s `appliedOut`).
  *  The wire trusts the engine's plan: the engine is the single foldability gate and it never
  *  folds a protected block, so no separate wire-side position protection is needed here.
  *  The durable-id + structural guards (kind checks, non-empty digest) remain the safety floor. */
-function foldOne(m: PiMessage, i: number, byId: Map<string, FoldOp>, mark: () => void): PiMessage {
+function foldOne(m: PiMessage, i: number, byId: Map<string, FoldOp>, mark: () => void, onApplied: (id: string) => void): PiMessage {
 	if (m.role === "assistant" && Array.isArray(m.content)) {
 		let parts: PiPart[] | null = null; // lazily cloned only if we actually fold
 		(m.content as PiPart[]).forEach((b, j) => {
-			const op = byId.get(blockId(m, i, j));
+			const id = blockId(m, i, j);
+			const op = byId.get(id);
 			if (!op || !op.digestText) return;
 			if (b?.type === "text") {
 				parts ??= (m.content as PiPart[]).slice();
 				parts[j] = { ...(b as PiTextPart), text: op.digestText };
+				onApplied(id);
 			} else if (b?.type === "thinking") {
 				parts ??= (m.content as PiPart[]).slice();
 				parts[j] = { ...(b as PiThinkingPart), thinking: op.digestText };
+				onApplied(id);
 			}
-			// tool_call or any other kind → ignored (never fold / id mis-map)
+			// tool_call or any other kind → ignored (never fold / id mis-map) — NOT applied
 		});
 		if (parts) {
 			mark();
@@ -262,9 +281,11 @@ function foldOne(m: PiMessage, i: number, byId: Map<string, FoldOp>, mark: () =>
 		return m;
 	}
 	if (m.role === "toolResult") {
-		const op = byId.get(blockId(m, i));
+		const id = blockId(m, i);
+		const op = byId.get(id);
 		if (op && op.digestText) {
 			mark();
+			onApplied(id);
 			return { ...m, content: [{ type: "text", text: op.digestText }] };
 		}
 		return m;
@@ -306,8 +327,21 @@ function foldOne(m: PiMessage, i: number, byId: Map<string, FoldOp>, mark: () =>
  * (no orphaned tool pair, no emptied message). Safe because this output feeds the model only
  * — the GUI's block sync/cursor run off the un-collapsed `linearize`, so removals never
  * desync the view (ADR 0006 §4).
+ *
+ * `appliedOut` (optional, additive — every pre-existing caller omits it and is unaffected) is
+ * populated with the counts ACTUALLY applied, as opposed to merely SUBMITTED: a shape-valid
+ * `FoldOp`/`GroupOp` whose id(s) match nothing in `messages` (e.g. a stale plan re-applied on
+ * timeout against messages that have since moved on) has zero effect here and must not be
+ * counted as applied — callers (the extension's plan-applied ack, ADR 0020) promise counts of
+ * what actually rode the wire, not what the plan merely asked for.
  */
-export function applyPlan(messages: PiMessage[], ops: FoldOp[], groups: GroupOp[] = [], recalls: RecallOp[] = []): PiMessage[] {
+export function applyPlan(
+	messages: PiMessage[],
+	ops: FoldOp[],
+	groups: GroupOp[] = [],
+	recalls: RecallOp[] = [],
+	appliedOut?: AppliedCounts,
+): PiMessage[] {
 	// Defense in depth (matches the GUI's `computeFoldOps`/`computeGroupOps`): refuse any op
 	// whose id is NOT durable or whose digest is empty, and any group with no summary/members.
 	// This is the shared safety boundary on the path that feeds the real model, so it cannot
@@ -334,9 +368,16 @@ export function applyPlan(messages: PiMessage[], ops: FoldOp[], groups: GroupOp[
 	const safeRecalls = (recalls ?? []).filter(
 		(r) => r && typeof r.afterId === "string" && r.afterId && typeof r.text === "string" && r.text,
 	);
-	if (!safeOps.length && !safeGroups.length && !safeRecalls.length) return messages;
+	if (!safeOps.length && !safeGroups.length && !safeRecalls.length) {
+		if (appliedOut) { appliedOut.ops = 0; appliedOut.groups = 0; appliedOut.recalls = 0; }
+		return messages;
+	}
 
 	const byId = new Map(safeOps.map((o) => [o.id, o] as const));
+	// Ids ACTUALLY substituted by foldOne (a subset of byId's keys: an id present in the plan
+	// but matching no part in `messages`, or matching a non-foldable part kind like tool_call,
+	// is never added here). Size = the real applied-ops count for `appliedOut`.
+	const appliedOpIds = new Set<string>();
 
 	// ── Phase A: decide which whole messages each group may remove ───────────────
 	const owner: (GroupOp | null)[] = new Array(messages.length).fill(null);
@@ -382,6 +423,11 @@ export function applyPlan(messages: PiMessage[], ops: FoldOp[], groups: GroupOp[
 			}
 		}
 	}
+	// Groups ACTUALLY applied: a safe (shape-valid) group whose member ids matched no message
+	// (or lost every member to the straggler fixpoint above) never appears in `owner` and must
+	// not be counted — only groups that own at least one surviving message really changed output.
+	const appliedGroups = new Set<GroupOp>();
+	for (const g of owner) if (g) appliedGroups.add(g);
 
 	// ── Phase B: build the output — collapse runs, fold survivors in place ────────
 	let changed = false;
@@ -416,7 +462,7 @@ export function applyPlan(messages: PiMessage[], ops: FoldOp[], groups: GroupOp[
 			i = j;
 			continue;
 		}
-		out.push(foldOne(messages[i], i, byId, mark));
+		out.push(foldOne(messages[i], i, byId, mark, (id) => appliedOpIds.add(id)));
 		outPosOf[i] = out.length - 1;
 		i++;
 	}
@@ -483,6 +529,14 @@ export function applyPlan(messages: PiMessage[], ops: FoldOp[], groups: GroupOp[
 				out.splice(end, 0, ...appended);
 			}
 		}
+	}
+	if (appliedOut) {
+		appliedOut.ops = appliedOpIds.size;
+		appliedOut.groups = appliedGroups.size;
+		// Every safe (shape-valid) recall always resolves to an insertion above (interior or
+		// appended — there is no additional "matched nothing" drop path for recalls, unlike
+		// ops/groups), so the applied count equals the safe count.
+		appliedOut.recalls = safeRecalls.length;
 	}
 	return changed ? out : messages;
 }

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -124,7 +124,7 @@
 
 	// Forward the per-session token (when present in the page URL ?token=…) on the WS
 	// upgrade so an off-loopback (0.0.0.0-bound) session can be steered from a remote
-	// browser. NOTE: the accordion_token cookie is HttpOnly, so JS cannot read it here —
+	// browser. NOTE: the per-port accordion_token_p<port> cookie is HttpOnly, so JS cannot read it here —
 	// that is deliberate. On a reload without ?token=…, readServedToken() returns null and
 	// the WS URL carries no token, but the browser still sends the HttpOnly cookie on the
 	// same-origin WS upgrade and the extension's verifyWsUpgrade accepts that cookie

--- a/docs/adr/0020-plan-applied-ack.md
+++ b/docs/adr/0020-plan-applied-ack.md
@@ -58,8 +58,9 @@ union minus those two).
 `PassthroughMessage { type: "passthrough", reqId, cause, ops, groups, recalls }` — sent
 fire-and-forget from `recordPlanOutcome` (never awaited; `send()` itself is try/catch-and-forget,
 matching every other push in this file). `ops`/`groups`/`recalls` are the counts **actually
-applied to the wire** for that call (0 for every raw/empty cause; the real plan's counts for
-`applied`; the stale plan's counts for `timeout-stale`).
+applied to the wire** for that call (0 for every raw/empty cause; for `applied` and
+`timeout-stale`, the counts after applyPlan filtering of unmatched ids and straggler-demoted
+groups; recalls = safe recalls only).
 
 Follows the `armed`/`armedAck` precedent (protocol.ts's version-history comment): purely additive,
 **no `PROTOCOL_VERSION` bump**. An old GUI simply drops the unknown message type and silently

--- a/extension/accordion.ts
+++ b/extension/accordion.ts
@@ -77,7 +77,7 @@ import { Type } from "typebox";
 import type { ExtensionAPI, ExtensionContext, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 
-import { linearize, applyPlan, type PiMessage } from "../app/src/lib/live/mapping";
+import { linearize, applyPlan, type PiMessage, type AppliedCounts } from "../app/src/lib/live/mapping";
 import { DEFAULT_PORT, PROTOCOL_VERSION, type FoldOp, type GroupOp, type RecallOp, type ServerMessage, type StreamMessage, type UnfoldRequestMessage, type UnfoldResultMessage, type RecallRequestMessage, type RecallContent, type CompleteRequestMessage, type CompleteResultMessage } from "../app/src/lib/live/protocol";
 
 /** The GUI's reply to a sync: in-place fold ops + group-collapse ops (ADR 0006). */
@@ -146,7 +146,10 @@ const ACCORDION_APP_ENV = "ACCORDION_APP_PATH";
 // Defaults keep the original loopback + OS-assigned-ephemeral behavior; setting
 // the host to 0.0.0.0 (or a specific interface) lets a remote browser reach the
 // session. Flag wins over env, which wins over the default — same precedence as
-// the ACCORDION_APP path knob above.
+// the ACCORDION_APP path knob above. Binding to a SPECIFIC non-loopback, non-wildcard
+// interface (e.g. a LAN IP) excludes loopback: the desktop app's discovery always dials
+// 127.0.0.1, so it will list such a session but cannot reach it — only the browser URL
+// (dialed via that interface) works; startServer() logs a one-time console.warn for this.
 const ACCORDION_HOST_FLAG = "accordion-host";
 const ACCORDION_HOST_ENV = "ACCORDION_HOST";
 const ACCORDION_PORT_FLAG = "accordion-port";
@@ -161,18 +164,73 @@ function resolveBindHost(pi: ExtensionAPI): string {
 	return "127.0.0.1";
 }
 
-/** Resolve the bind port: flag -> env -> 0 (OS-assigned ephemeral). Invalid/empty -> 0. */
+/**
+ * Validate a PORT string the way a config value deserves: the WHOLE trimmed string must be
+ * 1-5 ASCII digits in [0, 65535], not just a numeric PREFIX. `Number.parseInt` silently accepts
+ * "8080junk" (→ 8080) and truncates "1.5" (→ 1) — both look like a validated port but aren't.
+ * Returns null for an explicitly-set-but-invalid value (the caller logs + falls back to 0).
+ */
+export function parseBindPort(raw: string): number | null {
+	const trimmed = raw.trim();
+	if (!/^\d{1,5}$/.test(trimmed)) return null;
+	const n = Number(trimmed);
+	return n <= 65535 ? n : null;
+}
+
+/**
+ * Resolve the bind port: flag -> env -> 0 (OS-assigned ephemeral). Unset (both empty) -> 0,
+ * silently (that is the documented default, not an error). An explicitly-set but INVALID value
+ * (non-numeric, fractional, out-of-range, or trailing garbage — e.g. "8080junk", "1.5", "-1",
+ * "99999") also falls back to 0, but logs a console.warn naming the flag/env var and the
+ * rejected value, so a typo'd config doesn't silently downgrade to "OS picks a port".
+ */
 function resolveBindPort(pi: ExtensionAPI): number {
 	const flagVal = pi.getFlag(ACCORDION_PORT_FLAG);
-	const raw = (typeof flagVal === "string" ? flagVal : "") || process.env[ACCORDION_PORT_ENV] || "";
-	const n = Number.parseInt(String(raw).trim(), 10);
-	return Number.isFinite(n) && n >= 0 && n <= 65535 ? n : 0;
+	const source: { raw: string; name: string } | null =
+		typeof flagVal === "string" && flagVal.trim()
+			? { raw: flagVal, name: `--${ACCORDION_PORT_FLAG}` }
+			: process.env[ACCORDION_PORT_ENV]
+				? { raw: process.env[ACCORDION_PORT_ENV]!, name: ACCORDION_PORT_ENV }
+				: null;
+	if (!source) return 0; // nothing configured — the documented default, no warning
+	const parsed = parseBindPort(source.raw);
+	if (parsed === null) {
+		console.warn(`[accordion] ${source.name} is not a valid port (rejected value: ${JSON.stringify(source.raw)}) — falling back to an OS-assigned ephemeral port`);
+		return 0;
+	}
+	return parsed;
 }
 
 /** True if a BIND HOST string names only loopback (so off-loopback peers can't reach). */
 function isLoopbackHost(host: string): boolean {
 	const h = host.toLowerCase();
 	return h === "127.0.0.1" || h === "::1" || h === "localhost";
+}
+
+/** True if a BIND HOST string is a wildcard (binds every interface, loopback included). */
+function isWildcardHost(host: string): boolean {
+	const h = host.toLowerCase();
+	return h === "0.0.0.0" || h === "::";
+}
+
+/**
+ * The host to show in the `/accordion` status line's browser URL, given the resolved BIND
+ * host. Three distinct cases the old single `isLoopbackHost(bh) ? "127.0.0.1" : bh` conflated:
+ *   • `::1` binds IPv6-ONLY — showing "127.0.0.1" (an IPv4 address) can be unreachable on a
+ *     host without dual-stack loopback. Show the bracketed IPv6 literal instead.
+ *   • a wildcard bind (0.0.0.0 / ::) is reachable via loopback regardless — keep showing
+ *     "127.0.0.1" (a local user's own browser always works that way).
+ *   • any OTHER host containing ":" is an IPv6 literal and MUST be bracketed in a URL, or the
+ *     colons are parsed as a port separator (e.g. "http://fe80::1:PORT" is not what it looks
+ *     like).
+ */
+export function displayHostFor(bindHost: string): string {
+	const h = bindHost.toLowerCase();
+	if (h === "127.0.0.1" || h === "localhost") return "127.0.0.1";
+	if (isWildcardHost(h)) return "127.0.0.1";
+	if (h === "::1") return "[::1]";
+	if (h.includes(":")) return `[${bindHost}]`;
+	return bindHost;
 }
 
 /** True if a socket peer address is loopback (127.0.0.1 / ::1, incl. IPv4-mapped IPv6). */
@@ -502,6 +560,11 @@ export default function accordionLive(pi: ExtensionAPI): void {
 	let tokens: number | null = null;
 	let contextWindow: number | null = null;
 	let heartbeat: ReturnType<typeof setInterval> | null = null;
+	// Set iff the HTTP server's bind failed (e.g. EADDRINUSE on a fixed --accordion-port).
+	// Previously the "error" listener discarded the error entirely, so `port` stayed 0
+	// forever and `/accordion` printed "port starting…" — indistinguishable from a slow,
+	// still-booting server. Surfaced verbatim in the /accordion status line instead.
+	let bindError: string | null = null;
 
 	const attached = (): boolean => !!client && client.readyState === 1; /* OPEN */
 
@@ -621,8 +684,28 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			} else if (raw && typeof raw === "object" && typeof (raw as { sessionId?: unknown }).sessionId === "string") {
 				// Recognizably a registry entry, just stale or an old protocol version — reap it.
 				// A merely-paused (not dead) session self-heals: its next heartbeat rewrites the
-				// file, so reaping a transient staleness read is harmless.
-				fs.promises.unlink(filePath).catch(() => {});
+				// file, so reaping a transient staleness read is harmless — UNLESS that heartbeat
+				// lands in the gap between our read above and the unlink below, in which case we'd
+				// delete a file a concurrent writeEntry() just atomically renamed into place (a live
+				// session's live advertisement). Narrow that window: re-read + re-check staleness
+				// immediately before unlinking. This does not ELIMINATE the race (a heartbeat could
+				// still land between this re-check and the unlink itself), only narrows it from "one
+				// readdir pass" to "one extra read" — accepted, since closing it fully would need a
+				// file lock this best-effort registry deliberately doesn't have. Any read/parse
+				// failure here (file renamed/deleted mid-recheck) is swallowed: nothing to reap.
+				fs.promises
+					.readFile(filePath, "utf8")
+					.then((freshRaw) => {
+						let fresh: unknown;
+						try {
+							fresh = JSON.parse(freshRaw);
+						} catch {
+							return; // corrupt/partial re-read — leave it for the next pass
+						}
+						if (isLiveEntry(fresh, Date.now())) return; // a heartbeat healed it — don't reap
+						return fs.promises.unlink(filePath);
+					})
+					.catch(() => {});
 			}
 		}
 		out.sort((a, b) => a.startedAt - b.startedAt);
@@ -759,12 +842,22 @@ export default function accordionLive(pi: ExtensionAPI): void {
 		return null;
 	}
 
+	// Cookie name is PORT-QUALIFIED (not just "accordion_token"): cookies are host-scoped, not
+	// port-scoped, so two sessions on the same host (e.g. two pi sessions both browser-served on
+	// 127.0.0.1, different ports) would otherwise clobber each other's cookie — opening session B
+	// overwrites A's `accordion_token` cookie, and A's next cookie-authed request 403s. Qualifying
+	// by port keeps each session's cookie distinct. `port` is closed over and only read from
+	// request handlers, which never run before `startServer`'s `listen` callback sets it.
+	function accordionCookieName(): string {
+		return `accordion_token_p${port}`;
+	}
+
 	/** Is this request authenticated for static-file serving? (token query OR cookie.) */
 	function isWebAuthed(req: http.IncomingMessage, u: URL): boolean {
 		if (!webToken) return false;
 		if (u.searchParams.get("token") === webToken) return true;
 		const cookie = req.headers["cookie"];
-		if (typeof cookie === "string" && cookie.split(";").some((c) => c.trim() === `accordion_token=${webToken}`)) return true;
+		if (typeof cookie === "string" && cookie.split(";").some((c) => c.trim() === `${accordionCookieName()}=${webToken}`)) return true;
 		return false;
 	}
 
@@ -772,18 +865,25 @@ export default function accordionLive(pi: ExtensionAPI): void {
 	 * HTTP request handler — serves the browser build of the Accordion app, gated by a
 	 * per-session token. Runs ENTIRELY off the pi `context`/model-call hook path: it does
 	 * no folding, touches no plan, and a failure to serve a file never crashes a session
-	 * (every path is wrapped). The token gates ONLY file serving; `/__accordion/meta` is
-	 * deliberately reachable WITHOUT a token (it leaks only sessionId + protocol version,
-	 * which are unreadable cross-origin since we send NO CORS headers).
+	 * (every path is wrapped). The token gates file serving AND (off-loopback) `/meta` too —
+	 * see the meta branch below for why "same-origin protects it" was never actually true.
 	 */
 	function handleHttp(req: http.IncomingMessage, res: http.ServerResponse): void {
 		try {
 			const u = new URL(req.url || "/", "http://127.0.0.1");
 
-			// Meta endpoint — UNGATED so the browser (and the smoke test) can probe the
-			// server without the token. Harmless: same-origin policy hides the body from
-			// any other origin because we set no CORS headers.
+			// Meta endpoint. UNGATED for a LOOPBACK peer only — local tooling (the smoke test,
+			// bellows polling from the same machine) and the browser's own same-origin fetch both
+			// depend on that. The original "same-origin policy hides the body from any other
+			// origin" justification was wrong for non-browser clients: a bare `curl` from off-
+			// loopback has no origin/CORS concept to enforce, so it read this fine over the
+			// network. Off-loopback now mirrors the static-file gate: token required.
 			if (u.pathname === "/__accordion/meta") {
+				if (!isLoopbackPeer(req.socket.remoteAddress) && !isWebAuthed(req, u)) {
+					res.writeHead(403, { "Content-Type": "application/json" });
+					res.end(JSON.stringify({ error: "forbidden" }));
+					return;
+				}
 				res.writeHead(200, { "Content-Type": "application/json" });
 				// `planOutcomes` (issue #60, ADR 0020): per-cause counts of every `context` hook
 				// resolution this extension has ever resolved, plus `total` (= `contextHookCount`,
@@ -832,7 +932,7 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			// asset fetches, which don't carry the query string) stay authenticated.
 			const headers: Record<string, string> = {};
 			if (u.searchParams.get("token") === webToken) {
-				headers["Set-Cookie"] = `accordion_token=${webToken}; HttpOnly; SameSite=Strict; Path=/`;
+				headers["Set-Cookie"] = `${accordionCookieName()}=${webToken}; HttpOnly; SameSite=Strict; Path=/`;
 			}
 
 			const root = resolveClientRoot();
@@ -907,14 +1007,15 @@ export default function accordionLive(pi: ExtensionAPI): void {
 	 * steering for them, while a port-scanner on the network is refused.
 	 */
 	// The static-file surface (isWebAuthed) accepts the token via query OR the
-	// accordion_token cookie. The WS upgrade must accept the SAME cookie too: the cookie
-	// is HttpOnly (so JS can't read it to forward it on a reconnect without ?token=…),
-	// but the browser auto-sends it on a same-origin WS upgrade, which is the only path
-	// that lets a bookmarked/reloaded browser-served session re-steer off-loopback.
+	// port-qualified accordion cookie (see accordionCookieName). The WS upgrade must accept
+	// the SAME cookie too: the cookie is HttpOnly (so JS can't read it to forward it on a
+	// reconnect without ?token=…), but the browser auto-sends it on a same-origin WS upgrade,
+	// which is the only path that lets a bookmarked/reloaded browser-served session re-steer
+	// off-loopback.
 	function hasAccordionCookie(req: http.IncomingMessage): boolean {
 		const cookie = req.headers["cookie"];
 		return typeof cookie === "string"
-			&& cookie.split(";").some((c) => c.trim() === `accordion_token=${webToken}`);
+			&& cookie.split(";").some((c) => c.trim() === `${accordionCookieName()}=${webToken}`);
 	}
 
 	function verifyWsUpgrade(info: { req: http.IncomingMessage }, cb: (res: boolean, code?: number, message?: string) => void): void {
@@ -932,6 +1033,7 @@ export default function accordionLive(pi: ExtensionAPI): void {
 
 	function startServer(): void {
 		if (wss || httpServer) return;
+		bindError = null; // fresh attempt — clear any failure a prior call recorded
 		// Per-session token for the HTTP static surface AND (when bound off-loopback) the
 		// WS upgrade for non-loopback peers — see verifyWsUpgrade for the auth split: a
 		// loopback peer (the desktop app, or a same-machine browser) dials tokenless and
@@ -952,8 +1054,14 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			// Attach the WS server to the HTTP server (NOT { port: 0 }) so the upgrade
 			// shares the port. verifyWsUpgrade gates non-loopback peers (see above).
 			wss = new WebSocketServer({ server: httpServer, verifyClient: verifyWsUpgrade });
-			httpServer.on("error", () => {
-				// e.g. unexpected bind failure — run headless (passthrough).
+			httpServer.on("error", (err: NodeJS.ErrnoException) => {
+				// e.g. a fixed --accordion-port already in use (EADDRINUSE): run headless
+				// (passthrough), but — unlike before — record and log WHY, so `/accordion`
+				// can show a real failure instead of an eternal "port starting…". No retry:
+				// a visible failure is the fix; the user re-runs with a free port/flag.
+				const code = err?.code ?? "unknown";
+				bindError = `bind failed: ${code} ${bindHost}:${bindPort}`;
+				console.warn(`[accordion] ${bindError}`);
 				try { httpServer?.close(); } catch { /* ignore */ }
 				httpServer = null;
 				wss = null;
@@ -962,6 +1070,16 @@ export default function accordionLive(pi: ExtensionAPI): void {
 				const addr = httpServer?.address();
 				if (addr && typeof addr === "object") {
 					port = addr.port;
+					// A specific non-loopback, non-wildcard interface bind excludes loopback:
+					// the desktop app's discovery always dials 127.0.0.1, so it will list this
+					// session but never reach it (only the browser URL, dialed via that
+					// interface, works). One-time warning, not a hard error — this bind mode
+					// is intentional (issue #42), just easy to misread as "discovered ⇒ reachable".
+					if (!isLoopbackHost(bindHost) && !isWildcardHost(bindHost)) {
+						console.warn(
+							`[accordion] bound to ${bindHost}:${port} — desktop discovery (which always dials 127.0.0.1) will list this session but cannot reach it; the browser URL (via ${bindHost}) still works.`,
+						);
+					}
 					writeEntry(); // advertise immediately, now that the port is known
 					if (!heartbeat) {
 						heartbeat = setInterval(writeEntry, HEARTBEAT_INTERVAL_MS);
@@ -1398,13 +1516,21 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			// GUI so it can reconcile — see `liveClient.svelte.ts`'s passthrough handling and
 			// ADR 0020.
 			if (hasStale) {
-				recordPlanOutcome(
-					"timeout-stale",
-					reqId,
-					{ ops: lastPlan!.ops.length, groups: lastPlan!.groups.length, recalls: lastPlan!.recalls.length },
-					client,
+				// Apply FIRST, ack AFTER — with the counts applyPlan actually substituted, not the
+				// stale plan's submitted lengths. A stale plan re-applied against messages that have
+				// moved on can easily have ids that no longer match anything live; the old code acked
+				// `lastPlan!.ops.length` etc. regardless, over-reporting what really rode the wire
+				// (ADR 0020 promises counts ACTUALLY applied).
+				const appliedCounts: AppliedCounts = { ops: 0, groups: 0, recalls: 0 };
+				const newMessages = applyPlan(
+					event.messages as unknown as PiMessage[],
+					lastPlan!.ops,
+					lastPlan!.groups,
+					lastPlan!.recalls,
+					appliedCounts,
 				);
-				return { messages: applyPlan(event.messages as unknown as PiMessage[], lastPlan!.ops, lastPlan!.groups, lastPlan!.recalls) as unknown as AgentMessage[] };
+				recordPlanOutcome("timeout-stale", reqId, appliedCounts, client);
+				return { messages: newMessages as unknown as AgentMessage[] };
 			}
 			recordPlanOutcome("timeout-raw", reqId, { ops: 0, groups: 0, recalls: 0 }, client);
 			return;
@@ -1422,8 +1548,14 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			return; // empty plan → pass through
 		}
 
-		recordPlanOutcome("applied", reqId, { ops: plan.ops.length, groups: plan.groups.length, recalls: recallCount }, client);
-		return { messages: applyPlan(event.messages as unknown as PiMessage[], plan.ops, plan.groups, plan.recalls) as unknown as AgentMessage[] };
+		// Apply FIRST, ack AFTER (same reasoning as the timeout-stale branch above): a shape-valid
+		// op/group whose id matches nothing live in `messages` is silently skipped by applyPlan, so
+		// the SUBMITTED plan length (`plan.ops.length` etc.) can overstate what actually rode the
+		// wire. `appliedCounts` reflects the real substitutions.
+		const appliedCounts: AppliedCounts = { ops: 0, groups: 0, recalls: 0 };
+		const newMessages = applyPlan(event.messages as unknown as PiMessage[], plan.ops, plan.groups, plan.recalls, appliedCounts);
+		recordPlanOutcome("applied", reqId, appliedCounts, client);
+		return { messages: newMessages as unknown as AgentMessage[] };
 	});
 
 	// ── model swap: keep the GUI's context window (and budget) in lockstep ───────
@@ -1631,16 +1763,20 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			const wasAttached = attached();
 			const launch = wasAttached ? null : await launchAccordionApp(pi);
 			const action = launchResultLine(launch);
+			// Port status: the real port once bound, a captured bind FAILURE (no more eternal
+			// "starting…" on an EADDRINUSE-type error — see startServer's httpServer "error"
+			// handler), or "starting" while the async listen() is still pending.
+			const portStatus = port ? String(port) : bindError ? `failed (${bindError})` : "starting";
 			const lines = [
 				action.text,
-				`Live link: ${wasAttached ? "attached" : "detached"} · port ${port || "starting"} · streamed ${sentCount} blocks`,
+				`Live link: ${wasAttached ? "attached" : "detached"} · port ${portStatus} · streamed ${sentCount} blocks`,
 			];
 			// Browser entry point: the extension also serves the web build of Accordion on
 			// the same ephemeral port, gated by a per-session token. Surface the tokenized
 			// URL so the user can open the UI in a browser instead of the desktop app.
 			if (port && webToken) {
 				const bh = resolveBindHost(pi);
-				const displayHost = isLoopbackHost(bh) ? "127.0.0.1" : bh;
+				const displayHost = displayHostFor(bh);
 				// Keep the token-bearing line FIRST so the smoke regex (token=…) still matches.
 				lines.push(`Browser: http://${displayHost}:${port}/?token=${webToken}`);
 				// When bound off-loopback, surface a remote-friendly hint using the machine's LAN IP.
@@ -1648,7 +1784,11 @@ export default function accordionLive(pi: ExtensionAPI): void {
 					const lan = firstLanIp();
 					if (lan) lines.push(`Remote:  http://${lan}:${port}/?token=${webToken}`);
 				}
-			} else lines.push("Browser: starting…");
+			} else if (bindError) {
+				lines.push(`Browser: unavailable — ${bindError}`);
+			} else {
+				lines.push("Browser: starting…");
+			}
 			ctx.ui.notify(lines.join("\n"), action.type);
 		},
 	});

--- a/extension/smoke.mjs
+++ b/extension/smoke.mjs
@@ -33,6 +33,48 @@ const mod = await jiti.import("./accordion.ts");
 const accordionLive = mod.default;
 if (typeof accordionLive !== "function") throw new Error("default export is not a function");
 
+// ── unit tests: pure port/host helpers (exported for exactly this purpose) ───
+// PORT VALIDATION (adversarial-review finding): `parseBindPort` must validate the WHOLE
+// trimmed string, not accept a numeric PREFIX like the old `Number.parseInt` did.
+const portCases = [
+	["8080", 8080],
+	["  8080  ", 8080], // trimmed
+	["0", 0],
+	["65535", 65535],
+	["8080junk", null], // trailing garbage — old code silently returned 8080
+	["1.5", null], // fractional — old code silently truncated to 1
+	["-1", null], // negative — regex rejects the leading "-"
+	["70000", null], // out of range
+	["", null], // empty string — caller treats as "unset", not tested here
+	["   ", null],
+	["0x10", null], // hex — Number() would accept this; regex must not
+	["1e3", null], // scientific notation — Number() would accept this; regex must not
+	["007", 7], // leading zero — decimal, not octal
+];
+const portFails = [];
+for (const [raw, expected] of portCases) {
+	const got = mod.parseBindPort(raw);
+	if (got !== expected) portFails.push(`parseBindPort(${JSON.stringify(raw)}) = ${got}, expected ${expected}`);
+}
+if (portFails.length) throw new Error("parseBindPort unit tests failed:\n" + portFails.join("\n"));
+
+// IPv6/DISPLAY URL host resolution.
+const hostCases = [
+	["127.0.0.1", "127.0.0.1"],
+	["localhost", "127.0.0.1"],
+	["0.0.0.0", "127.0.0.1"], // wildcard → still shown as loopback
+	["::", "127.0.0.1"], // IPv6 wildcard → same
+	["::1", "[::1]"], // IPv6 loopback-ONLY bind — 127.0.0.1 would be unreachable
+	["fe80::1", "[fe80::1]"], // arbitrary IPv6 literal must be bracketed
+	["192.168.1.20", "192.168.1.20"], // specific IPv4 interface — shown as-is
+];
+const hostFails = [];
+for (const [raw, expected] of hostCases) {
+	const got = mod.displayHostFor(raw);
+	if (got !== expected) hostFails.push(`displayHostFor(${JSON.stringify(raw)}) = ${JSON.stringify(got)}, expected ${JSON.stringify(expected)}`);
+}
+if (hostFails.length) throw new Error("displayHostFor unit tests failed:\n" + hostFails.join("\n"));
+
 async function waitFor(predicate, ms, label) {
 	const start = Date.now();
 	while (Date.now() - start < ms) {
@@ -151,6 +193,10 @@ if (accordionCmd) {
 	if (noToken.status !== 403) fails.push(`GET / without a token returned ${noToken.status}, expected 403`);
 
 	// GET /?token=<token> → 200 index.html (only if the build exists).
+	// The cookie name is PORT-QUALIFIED (accordion_token_p<PORT>) — cookies are host-scoped,
+	// not port-scoped, so a fixed "accordion_token" would clobber a second session on the same
+	// host (see accordionCookieName() in accordion.ts).
+	const COOKIE_NAME = `accordion_token_p${PORT}`;
 	if (TOKEN) {
 		const buildIndex = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "app", "build", "index.html");
 		const indexExists = fs.existsSync(buildIndex);
@@ -158,10 +204,17 @@ if (accordionCmd) {
 			const ok = await httpGet(`/?token=${TOKEN}`);
 			if (ok.status !== 200) fails.push(`GET /?token=<valid> returned ${ok.status}, expected 200`);
 			const setCookie = ok.headers["set-cookie"];
-			if (!setCookie || !String(setCookie).includes(`accordion_token=${TOKEN}`))
-				fails.push("GET /?token=<valid> did not mint the accordion_token cookie");
-			// Cookie-only auth (no query token) must ALSO pass the gate.
-			const viaCookie = await httpGet("/", { Cookie: `accordion_token=${TOKEN}` });
+			if (!setCookie || !String(setCookie).includes(`${COOKIE_NAME}=${TOKEN}`))
+				fails.push(`GET /?token=<valid> did not mint the ${COOKIE_NAME} cookie (got: ${setCookie})`);
+			// A cookie name carrying the WRONG (or no) port must NOT authenticate — this is the
+			// regression the port-qualified name fixes: two sessions on the same host no longer
+			// share one cookie namespace, so a stale/foreign-port cookie must be rejected.
+			const wrongPortCookie = await httpGet("/", { Cookie: `accordion_token_p${PORT + 1}=${TOKEN}` });
+			if (wrongPortCookie.status !== 403) fails.push(`GET / with a wrong-port cookie returned ${wrongPortCookie.status}, expected 403`);
+			const unqualifiedCookie = await httpGet("/", { Cookie: `accordion_token=${TOKEN}` });
+			if (unqualifiedCookie.status !== 403) fails.push(`GET / with the OLD unqualified cookie name returned ${unqualifiedCookie.status}, expected 403 (cookie collision regression)`);
+			// Cookie-only auth (no query token), with the CORRECT port-qualified name, must pass.
+			const viaCookie = await httpGet("/", { Cookie: `${COOKIE_NAME}=${TOKEN}` });
 			if (viaCookie.status !== 200) fails.push(`GET / with cookie auth returned ${viaCookie.status}, expected 200`);
 		} else {
 			console.log("NOTE: app/build/index.html absent — skipping the index 200 assertion (meta + 403 still verified). Run `npm run build` in app/ to cover it.");
@@ -1278,6 +1331,159 @@ if (armedSmoke.inflightPendingPastTimeout !== true)
 if (!(armedSmoke.nextDisarmedMs !== null && armedSmoke.nextDisarmedMs < 900))
 	fails.push(`armed: request after disarm did not use the short timeout (${armedSmoke.nextDisarmedMs}ms)`);
 
+// ── ack counts reflect APPLIED, not SUBMITTED (issue #60 follow-up / ADR 0020) ──
+// A plan carrying one op that matches a live block and one shape-valid op that matches
+// NOTHING live (a stale id) must ack ops:1, not ops:2 — the count is what actually rode
+// the wire, computed AFTER applyPlan runs (see recordPlanOutcome call sites in the
+// `context` hook).
+{
+	const gui2 = new WebSocket(`ws://127.0.0.1:${PORT}`);
+	const acks2 = [];
+	gui2.on("message", (data) => {
+		let m;
+		try { m = JSON.parse(data.toString()); } catch { return; }
+		if (m.type === "passthrough") { acks2.push(m); return; }
+		if (m.type !== "sync" || !m.planned) return;
+		gui2.send(
+			JSON.stringify({
+				type: "plan",
+				reqId: m.reqId,
+				ops: [
+					{ id: "a:resp-abc:p0", digestText: "FOLDED-AGAIN" }, // matches a live block in `sample`
+					{ id: "a:resp-stale-zzz:p0", digestText: "FOLDED" }, // durable shape, matches nothing
+				],
+				groups: [],
+			}),
+		);
+	});
+	await new Promise((res, rej) => { gui2.on("open", res); gui2.on("error", rej); });
+	await new Promise((r) => setTimeout(r, 100)); // settle the view-only attach flush
+	await Promise.resolve(handlers.context({ messages: sample }, ctx));
+	await waitFor(() => acks2.length >= 1, 1000, "ack-counts passthrough").catch(() => fails.push("ack-counts: no passthrough ack received"));
+	if (acks2.length) {
+		const ack = acks2[acks2.length - 1];
+		if (ack.cause !== "applied") fails.push(`ack-counts: expected cause 'applied', got '${ack.cause}'`);
+		else if (ack.ops !== 1)
+			fails.push(`ack-counts: expected ops=1 (1 matched + 1 stale submitted, only the matched one applied), got ${ack.ops}`);
+	}
+	gui2.close();
+	await new Promise((r) => setTimeout(r, 50));
+}
+
+// ── bind failure is surfaced, not swallowed (defect #2) ─────────────────────
+// A second extension instance forced onto the SAME port the first instance already
+// bound must fail its `listen()` — the old code discarded the error entirely, leaving
+// `/accordion` printing "port starting…" forever. It must now report a real failure.
+{
+	const handlers2 = {};
+	const flags2 = new Map();
+	let accordionCmd2 = null;
+	const pi2 = {
+		on: (name, fn) => (handlers2[name] = fn),
+		registerFlag: (name, def) => flags2.set(name, def?.default),
+		getFlag: (name) => flags2.get(name),
+		registerCommand: (name, def) => { if (name === "accordion") accordionCmd2 = def.handler; },
+		registerTool: () => {},
+	};
+	accordionLive(pi2);
+	flags2.set("accordion-port", String(PORT)); // force EADDRINUSE against the first instance
+	const notifications2 = [];
+	const ctx2 = {
+		ui: { setStatus() {}, notify(message, type) { notifications2.push({ message, type }); }, theme: { fg: (_c, s) => s } },
+		model: { id: "test/model2", contextWindow: 1000 },
+		getContextUsage: () => ({ tokens: 1, contextWindow: 1000 }),
+	};
+	handlers2.session_start({}, ctx2);
+	let statusLine = "";
+	const start = Date.now();
+	while (Date.now() - start < 3000) {
+		if (accordionCmd2) {
+			await Promise.resolve(accordionCmd2("", ctx2));
+			statusLine = notifications2.at(-1)?.message ?? "";
+			if (/bind failed/i.test(statusLine)) break;
+		}
+		await new Promise((r) => setTimeout(r, 100));
+	}
+	if (!/bind failed/i.test(statusLine) || !/EADDRINUSE/.test(statusLine))
+		fails.push(`/accordion did not surface the bind failure — got: ${JSON.stringify(statusLine)}`);
+	if (!/unavailable/i.test(statusLine)) fails.push(`/accordion did not mark the Browser line unavailable on a bind failure — got: ${JSON.stringify(statusLine)}`);
+	if (handlers2.session_shutdown) handlers2.session_shutdown({}, ctx2);
+}
+
+// ── explicit-but-invalid --accordion-port still boots + warns (defect #1, integration) ──
+// Complements the direct `parseBindPort` unit tests above by proving `resolveBindPort`
+// actually warns (naming the flag + rejected value) when driven through session_start,
+// not just in isolation.
+{
+	const handlers4 = {};
+	const flags4 = new Map();
+	const pi4 = {
+		on: (name, fn) => (handlers4[name] = fn),
+		registerFlag: (name, def) => flags4.set(name, def?.default),
+		getFlag: (name) => flags4.get(name),
+		registerCommand: () => {},
+		registerTool: () => {},
+	};
+	accordionLive(pi4);
+	flags4.set("accordion-port", "8080junk");
+	const warnings4 = [];
+	const origWarn4 = console.warn;
+	console.warn = (...args) => { warnings4.push(args.join(" ")); origWarn4.apply(console, args); };
+	const ctx4 = {
+		ui: { setStatus() {}, notify() {}, theme: { fg: (_c, s) => s } },
+		model: { id: "test/model4", contextWindow: 1000 },
+		getContextUsage: () => ({ tokens: 1, contextWindow: 1000 }),
+	};
+	handlers4.session_start({}, ctx4);
+	await waitFor(() => warnings4.some((w) => w.includes("accordion-port") && w.includes("8080junk")), 2000, "invalid --accordion-port warning").catch(
+		() => fails.push("resolveBindPort did not warn for an invalid explicit --accordion-port (integration)"),
+	);
+	console.warn = origWarn4;
+	if (handlers4.session_shutdown) handlers4.session_shutdown({}, ctx4);
+}
+
+// ── specific-interface bind warns about desktop-discovery unreachability (defect #4) ──
+// Skipped gracefully if this machine has no non-loopback IPv4 interface to bind to.
+{
+	const ifaces = os.networkInterfaces();
+	let lanIp = null;
+	outer: for (const list of Object.values(ifaces)) {
+		if (!list) continue;
+		for (const i of list) {
+			if (i.family === "IPv4" && !i.internal) { lanIp = i.address; break outer; }
+		}
+	}
+	if (!lanIp) {
+		console.log("NOTE: no non-loopback IPv4 interface found on this machine — skipping the specific-interface bind warning assertion.");
+	} else {
+		const handlers3 = {};
+		const flags3 = new Map();
+		const pi3 = {
+			on: (name, fn) => (handlers3[name] = fn),
+			registerFlag: (name, def) => flags3.set(name, def?.default),
+			getFlag: (name) => flags3.get(name),
+			registerCommand: () => {},
+			registerTool: () => {},
+		};
+		accordionLive(pi3);
+		flags3.set("accordion-host", lanIp);
+		const warnings3 = [];
+		const origWarn3 = console.warn;
+		console.warn = (...args) => { warnings3.push(args.join(" ")); origWarn3.apply(console, args); };
+		const ctx3 = {
+			ui: { setStatus() {}, notify() {}, theme: { fg: (_c, s) => s } },
+			model: { id: "test/model3", contextWindow: 1000 },
+			getContextUsage: () => ({ tokens: 1, contextWindow: 1000 }),
+		};
+		handlers3.session_start({}, ctx3);
+		await waitFor(() => warnings3.some((w) => w.includes(lanIp) && w.includes("desktop discovery")), 2000, "specific-interface bind warning").catch(() =>
+			fails.push(`bind to specific interface ${lanIp} did not warn about desktop-discovery unreachability`),
+		);
+		console.warn = origWarn3;
+		if (handlers3.session_shutdown) handlers3.session_shutdown({}, ctx3);
+	}
+}
+
 // ── assertions ───────────────────────────────────────────────────────────────
 if (!seen.hello) fails.push("never received hello");
 if (!seen.flushOnAttach) fails.push("GUI received no history flush on attach (would stay empty until first message — the bug)");
@@ -1329,6 +1535,9 @@ console.log(
 					`recall tool (no-ids / detached guards, content-echo round-trip) ✓  skill discovery ✓  ` +
 					`stale-plan fallback (timeout re-applies last plan, empty plan not overridden) ✓  rttMs stamp ✓  ` +
 						`armed-over-wire (ack, disarmed=short / armed=deadline, mid-toggle snapshot) ✓  ` +
-							`passthrough acks (applied/empty-plan/timeout-stale/timeout-raw) ✓  /__accordion/meta planOutcomes ✓`,
+							`passthrough acks (applied/empty-plan/timeout-stale/timeout-raw) ✓  /__accordion/meta planOutcomes ✓  ` +
+							`port-qualified cookie (collision guard) ✓  parseBindPort/displayHostFor unit tests ✓  ` +
+							`ack counts reflect applied-not-submitted ✓  bind failure surfaced ✓  invalid --accordion-port warns ✓  ` +
+							`specific-interface bind warns ✓`,
 );
 process.exit(0);


### PR DESCRIPTION
## Why

gpt5.6SOL's review of the promotion PR (#52) confirmed seven defects in the extension's server/registry/ack surface, plus one the adversarial verification pass added (`/meta`'s auth rationale). Individually small, they compound: a typo'd port ("1.5" → port 1) hits a privileged bind that fails with EACCES, which the error handler then swallowed without even capturing the error object, leaving `/accordion` saying "starting…" forever.

## What

- **Strict port parsing** — whole-string `/^\d{1,5}$/` + range check; an explicit-but-invalid `ACCORDION_PORT` now warns with the rejected value instead of binding a garbage-prefix port.
- **Bind failures surfaced** — the error is captured into `bindError` (cleared on each start attempt) and `/accordion` shows `port failed (bind failed: EADDRINUSE host:port)` instead of the eternal "starting…".
- **IPv6 display URLs** — `[::1]` for IPv6-loopback binds, bracketed literals elsewhere; no more `http://:::8080`.
- **Specific-interface binds** — one-time warning that desktop discovery will list but not reach a session bound off-loopback (the registry advertises port only and Tauri dials 127.0.0.1); full host-advertising in `SessionEntry` is scoped as follow-up.
- **Reaper race narrowed** — re-read + re-check staleness immediately before unlink (documented as narrowing, not eliminating, the rename/unlink window; the entry self-heals on the next heartbeat regardless).
- **Per-port cookies** — `accordion_token_p<port>` at minting and both check sites (`isWebAuthed`, `hasAccordionCookie`, incl. the WS upgrade path), fixing the cross-port clobber where opening session B 403'd session A's polls. Transparent to the client (HttpOnly, auto-sent); smoke gained negative checks (wrong-port and old-name cookies must 403).
- **Honest ack counts** — `applyPlan` gained an additive `AppliedCounts` out-param counting ops/groups/recalls *actually substituted* (unmatched ids, straggler-demoted groups excluded), and the ack is emitted after application on both `applied` and `timeout-stale` paths. The protocol/ADR always promised "counts actually applied"; the implementation now matches. No current reader consumes the numbers (GUI keys off `cause`), so the change is inert on the live path — it makes the record honest for future consumers (bellows).
- **`/meta` gating** — ungated on loopback (local tooling unaffected), token off-loopback; the old "same-origin protects it" comment was wrong for non-browser clients and is corrected.

## Verification

- Extension smoke PASS with 7 new assertion groups (incl. forced EADDRINUSE and cookie negative checks); app suite 908/908 (15 new `applyPlan` count tests covering exactly the overcounted cases); svelte-check 0/0.
- Adversarial (Opus) review: PASS, merge-ready — enumerated every HTTP/WS auth consumer for the cookie rename (no old-name reader remains, no upgrade 403 loop possible), verified count units match the old submitted-length units (groups counted as groups), confirmed FIFO ack ordering preserved (no await between apply and ack) and zero new disk I/O on the context hook. Confirmed no conflict with the concurrent `PROTOCOL_VERSION` bump branch (protocol.ts untouched here).
- Review's two doc nits (ADR 0020 §2 stale parenthetical, stale cookie-name comment) closed in the follow-up commit.

## Watch items

- Off-loopback tokenless consumers of `/__accordion/meta` now get 403. Bellows workers poll pi on the same machine (loopback), so they should be unaffected — worth a one-line confirmation if any bench rig polls `/meta` cross-machine.
- The off-loopback branches of the `/meta` gate and `verifyWsUpgrade` remain untestable in the smoke harness (pre-existing gap); implemented and verified by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)