### PR TITLE
fix(extension): close PR #72 WS auth and limiter gaps

### DIFF
--- a/extension/accordion.ts
+++ b/extension/accordion.ts
@@ -133,6 +133,39 @@ const UNFOLD_TIMEOUT_MS = 2000;
 // folded block's full content back THIS turn — so the same generous wait applies.
 const RECALL_TIMEOUT_MS = 2000;
 
+// ── WS hardening (private security review of the devmain promotion) ──────────────
+// Cap on any single inbound WS frame. `ws` defaults to 100 MiB (maxPayload), which lets an
+// unauthenticated loopback peer stream ~100 MiB per message straight into JSON.parse. Real
+// plans/backlogs are kilobytes; 8 MiB is a comfortable ceiling far below the default.
+const MAX_WS_PAYLOAD_BYTES = 8 * 1024 * 1024;
+// Cap on concurrently in-flight paid provider completions (`completeRequest`). Each accepted
+// request launches a real, billable model call; without a ceiling a client (or a hijacked
+// socket) can fan out unbounded spend. The legitimate handoff/compaction path issues one at a
+// time, so a small cap never blocks it.
+const MAX_CONCURRENT_COMPLETIONS = 4;
+// Does this browser Origin belong to the trusted Tauri DESKTOP webview? The Tauri app dials
+// `new WebSocket("ws://127.0.0.1:<port>")` from inside its own webview (see
+// app/src/lib/live/liveClient.svelte.ts) — so WebView2 (Windows) / WKWebView (macOS/Linux)
+// DO attach an Origin to the handshake. NOTE: this contradicts the "Tauri sends no Origin"
+// assumption — the dial is a browser WebSocket, so it always carries one. The webview's origin
+// is one of a small fixed family (see tauri.conf.json: devUrl http://localhost:1420;
+// frontendDist ⇒ the `tauri.localhost` custom-protocol origin in a production build). A hostile
+// web page in the user's NORMAL browser cannot forge any of these: the browser sets Origin from
+// the page's real origin, and no public site is served from the `tauri:` scheme or the
+// `tauri.localhost` host. Matched by predicate (not an exact-string set) so a scheme/port
+// variant across Tauri/OS versions still authorizes the legitimate desktop dial.
+function isTrustedNativeWebviewOrigin(origin: string): boolean {
+	let u: URL;
+	try { u = new URL(origin); } catch { return false; }
+	// macOS / Linux custom protocol: tauri://localhost
+	if (u.protocol === "tauri:") return true;
+	// Windows (WebView2) custom protocol: http(s)://tauri.localhost
+	if (u.hostname === "tauri.localhost") return true;
+	// `npm run tauri dev`: the webview loads devUrl http://localhost:1420
+	if ((u.hostname === "localhost" || u.hostname === "127.0.0.1") && u.port === "1420") return true;
+	return false;
+}
+
 // Base dir is overridable for tests (smoke.mjs) so they don't touch the real home.
 const HOME = process.env.ACCORDION_HOME || os.homedir();
 const REGISTRY_ROOT = path.join(HOME, REGISTRY_DIR);
@@ -420,6 +453,10 @@ export default function accordionLive(pi: ExtensionAPI): void {
 	let reqSeq = 0;
 	let epoch = 0; // bumped on every new GUI connection; invalidates in-flight requests
 	const pending = new Map<number, (r: PlanResult) => void>();
+	// reqIds of paid completions currently in flight (admission control — see the completeRequest
+	// handler). Bounds concurrent billable model calls and rejects duplicate reqIds. Cleared on a
+	// fresh GUI connection (a superseded client's completions are discarded by the reply guard).
+	const inFlightCompletions = new Set<number>();
 	// Last plan the GUI DELIVERED (issue #58). Cached — including a genuinely empty plan
 	// (empty = "conductor wants no folds", so caching it prevents wrongly re-applying an
 	// older non-empty plan) — so a timed-out `context` can apply it instead of shipping the
@@ -1018,16 +1055,56 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			&& cookie.split(";").some((c) => c.trim() === `${accordionCookieName()}=${webToken}`);
 	}
 
+	// Same-origin upgrade: the browser-served UI steering its OWN session. Its Origin's
+	// host:port equals the Host header it was served from. A cross-site attacker's page has a
+	// different origin, so it can never match. (The served UI also carries the token/cookie, so
+	// this is belt-and-suspenders — but it keeps the served flow working even if the cookie is
+	// briefly absent.)
+	function isSameOriginUpgrade(req: http.IncomingMessage, origin: string): boolean {
+		const host = req.headers["host"];
+		if (typeof host !== "string" || host === "") return false;
+		try { return new URL(origin).host === host; } catch { return false; }
+	}
+
 	function verifyWsUpgrade(info: { req: http.IncomingMessage }, cb: (res: boolean, code?: number, message?: string) => void): void {
-		const peer = info.req.socket.remoteAddress;
-		if (isLoopbackPeer(peer)) { cb(true); return; }
-		// Off-loopback peer: require the per-session token. The browser-served page
-		// forwards it on the upgrade URL (?token=…) on first load; on a later reload
-		// without ?token=… the browser still sends the HttpOnly accordion_token cookie,
-		// which we accept here so the same source of truth authorizes both halves.
-		const u = new URL(info.req.url || "/", "http://accordion.local");
-		const token = u.searchParams.get("token");
-		if (webToken && (token === webToken || hasAccordionCookie(info.req))) { cb(true); return; }
+		const req = info.req;
+		const peer = req.socket.remoteAddress;
+
+		// Parse the upgrade target DEFENSIVELY and ONCE, up front. A malformed request target
+		// (e.g. an authority-form target with an out-of-range port like `http://x:999999/`) makes
+		// the WHATWG URL parser throw — and `ws`'s callback-style verifyClient does NOT catch a
+		// synchronous throw, so it would escape as an uncaught exception and kill the whole pi
+		// process, from an UNAUTHENTICATED peer, before any token check. Reject 400 instead.
+		let token: string | null = null;
+		try {
+			token = new URL(req.url || "/", "http://accordion.local").searchParams.get("token");
+		} catch {
+			cb(false, 400, "bad request target");
+			return;
+		}
+		const hasToken = !!webToken && (token === webToken || hasAccordionCookie(req));
+		const origin = req.headers["origin"];
+
+		if (isLoopbackPeer(peer)) {
+			// CSWSH defense. WebSockets are NOT subject to CORS, so a malicious web page in the
+			// user's browser could open ws://127.0.0.1:<port>, receive the session backlog, become
+			// the active client, submit plans, toggle armed state, and trigger paid completions.
+			// Loopback therefore stays tokenless ONLY for:
+			//   • native clients that send NO browser Origin, and
+			//   • the trusted Tauri webview / same-origin served UI (their Origin is fixed / matches
+			//     the served Host — a cross-site attacker cannot forge either).
+			// Any OTHER browser Origin must present the token (which a CSWSH attacker cannot read).
+			if (typeof origin !== "string" || origin === "") { cb(true); return; } // native, no Origin
+			if (isTrustedNativeWebviewOrigin(origin) || isSameOriginUpgrade(req, origin)) { cb(true); return; }
+			if (hasToken) { cb(true); return; }
+			cb(false, 403, "cross-origin WebSocket blocked — open Accordion via the /accordion Browser link (it carries the session token)");
+			return;
+		}
+
+		// Off-loopback peer: require the per-session token. The browser-served page forwards it on
+		// the upgrade URL (?token=…) on first load; on a later reload without ?token=… the browser
+		// still sends the HttpOnly accordion_token cookie, accepted above via hasAccordionCookie.
+		if (hasToken) { cb(true); return; }
 		cb(false, 401, "unauthorized — open Accordion via the /accordion Browser link (it carries the session token)");
 	}
 
@@ -1053,7 +1130,7 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			httpServer = http.createServer(handleHttp);
 			// Attach the WS server to the HTTP server (NOT { port: 0 }) so the upgrade
 			// shares the port. verifyWsUpgrade gates non-loopback peers (see above).
-			wss = new WebSocketServer({ server: httpServer, verifyClient: verifyWsUpgrade });
+			wss = new WebSocketServer({ server: httpServer, verifyClient: verifyWsUpgrade, maxPayload: MAX_WS_PAYLOAD_BYTES });
 			httpServer.on("error", (err: NodeJS.ErrnoException) => {
 				// e.g. a fixed --accordion-port already in use (EADDRINUSE): run headless
 				// (passthrough), but — unlike before — record and log WHY, so `/accordion`
@@ -1099,6 +1176,7 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			epoch++;
 			sentCount = 0; // re-sync the whole context to the freshly-connected GUI
 			reqSeq = 0;
+			inFlightCompletions.clear(); // a superseded client's completions are discarded (reply guard)
 			lastPlan = null; // a new view starts with no known plan; never apply the old one to it
 			armed = false; // a fresh client is DISARMED until it declares otherwise over the wire
 			send(ws, { type: "hello", protocolVersion: PROTOCOL_VERSION, sessionId, meta });
@@ -1190,6 +1268,19 @@ export default function accordionLive(pi: ExtensionAPI): void {
 							reply({ type: "completeResult", reqId: req.reqId, ok: false, error: "missing or empty prompt" });
 							return;
 						}
+						// Admission control (unbounded paid completions). These checks run synchronously
+						// before the first `await`, so back-to-back completeRequest events cannot race past
+						// the caps. Reject a reqId already in flight (dedupe retries/replays) and any request
+						// beyond the concurrency ceiling; each accepted request is a billable model call.
+						if (inFlightCompletions.has(req.reqId)) {
+							reply({ type: "completeResult", reqId: req.reqId, ok: false, error: "duplicate completion request already in flight" });
+							return;
+						}
+						if (inFlightCompletions.size >= MAX_CONCURRENT_COMPLETIONS) {
+							reply({ type: "completeResult", reqId: req.reqId, ok: false, error: `too many concurrent completions in flight (max ${MAX_CONCURRENT_COMPLETIONS})` });
+							return;
+						}
+						inFlightCompletions.add(req.reqId);
 						try {
 							const ctx = latestCtx;
 							const m = latestModel ?? ctx?.model;
@@ -1243,6 +1334,10 @@ export default function accordionLive(pi: ExtensionAPI): void {
 						} catch (err: unknown) {
 							const errMsg = err instanceof Error ? err.message : String(err);
 							reply({ type: "completeResult", reqId: req.reqId, ok: false, error: errMsg });
+						} finally {
+							// Always release the concurrency slot — success, provider error, or a client that
+							// dropped mid-flight (its reply is discarded by the guard, but the slot must free).
+							inFlightCompletions.delete(req.reqId);
 						}
 					})();
 				}

--- a/extension/accordion.ts
+++ b/extension/accordion.ts
@@ -138,6 +138,12 @@ const RECALL_TIMEOUT_MS = 2000;
 // unauthenticated loopback peer stream ~100 MiB per message straight into JSON.parse. Real
 // plans/backlogs are kilobytes; 8 MiB is a comfortable ceiling far below the default.
 const MAX_WS_PAYLOAD_BYTES = 8 * 1024 * 1024;
+// Maximum time/body accepted while proving that a loopback browser Origin is another live
+// Accordion server (the browser multi-session A→B path). This is upgrade-time I/O only, never
+// on the model context hook; the bounds prevent a dead/unrelated local port from hanging auth.
+const SIBLING_ORIGIN_PROBE_MS = 750;
+const SIBLING_ORIGIN_META_MAX_BYTES = 16 * 1024;
+const MAX_PENDING_SIBLING_ORIGIN_PROBES = 8;
 // Cap on concurrently in-flight paid provider completions (`completeRequest`). Each accepted
 // request launches a real, billable model call; without a ceiling a client (or a hijacked
 // socket) can fan out unbounded spend. The legitimate handoff/compaction path issues one at a
@@ -437,13 +443,12 @@ export default function accordionLive(pi: ExtensionAPI): void {
 	// build of the Accordion app on the same ephemeral port (feat/browser-served-extension).
 	// One server per pi session; closed alongside `wss` at shutdown.
 	let httpServer: http.Server | null = null;
-	// Per-session token gating the HTTP static-file surface AND (when bound off-loopback)
-	// the WS upgrade for non-loopback peers. Generated once when the server starts.
-	// A loopback peer (the desktop Tauri app, or a same-machine browser) dials tokenless
-	// and keeps working unchanged; a NON-loopback peer — only reachable when the bind host
-	// is 0.0.0.0 or a specific interface — must present this token on the upgrade. The
-	// browser-served page already carries it in its URL (?token=…), so the real user never
-	// types it; the gate keeps a network port-scanner from steering the agent's context.
+	// Per-session token gating the HTTP surface and browser WS upgrades. Generated once when
+	// the server starts. Trusted native/Tauri loopback clients remain tokenless; browser clients
+	// present the token explicitly or via a same-origin cookie. The sole browser exception is a
+	// loopback Origin currently serving Accordion's `/__accordion/meta` contract, enabling the
+	// local session switcher without trusting arbitrary or stale ports. Every off-loopback browser
+	// requires the token.
 	let webToken = "";
 	let client: WebSocket | null = null; // the GUI (one driver at a time in M1)
 	let sessionId = "";
@@ -453,10 +458,12 @@ export default function accordionLive(pi: ExtensionAPI): void {
 	let reqSeq = 0;
 	let epoch = 0; // bumped on every new GUI connection; invalidates in-flight requests
 	const pending = new Map<number, (r: PlanResult) => void>();
-	// reqIds of paid completions currently in flight (admission control — see the completeRequest
-	// handler). Bounds concurrent billable model calls and rejects duplicate reqIds. Cleared on a
-	// fresh GUI connection (a superseded client's completions are discarded by the reply guard).
-	const inFlightCompletions = new Set<number>();
+	// Globally active paid provider calls. Each admission gets a unique token which stays here until
+	// THAT exact call settles. This is deliberately independent of the active GUI connection: a
+	// reconnect suppresses the old reply but does not cancel the upstream provider work, so clearing
+	// this set on reconnect would make the advertised concurrency ceiling bypassable.
+	const activeCompletionCalls = new Set<symbol>();
+	let pendingSiblingOriginProbes = 0;
 	// Last plan the GUI DELIVERED (issue #58). Cached — including a genuinely empty plan
 	// (empty = "conductor wants no folds", so caching it prevents wrongly re-applying an
 	// older non-empty plan) — so a timed-out `context` can apply it instead of shipping the
@@ -1035,13 +1042,10 @@ export default function accordionLive(pi: ExtensionAPI): void {
 	}
 
 	/**
-	 * Gate the WS upgrade by peer address. A loopback peer (the desktop app, or a
-	 * same-machine browser) connects tokenless — unchanged from the original design.
-	 * A NON-loopback peer — only reachable when the bind host is 0.0.0.0 or a specific
-	 * interface — must present the per-session `webToken`, which the browser-served page
-	 * already carries in its URL (?token=…) and forwards on the upgrade. This keeps
-	 * remote reachability safe by default: the token the user already has unlocks
-	 * steering for them, while a port-scanner on the network is refused.
+	 * Gate the WS upgrade by peer address, Origin, and authentication source. Trusted native/
+	 * Tauri loopback clients may connect tokenless. Browser clients present the per-session
+	 * `webToken` explicitly, or through a cookie accepted only for the exact served Origin.
+	 * Off-loopback peers always require one of those browser-authenticated paths.
 	 */
 	// The static-file surface (isWebAuthed) accepts the token via query OR the
 	// port-qualified accordion cookie (see accordionCookieName). The WS upgrade must accept
@@ -1055,15 +1059,120 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			&& cookie.split(";").some((c) => c.trim() === `${accordionCookieName()}=${webToken}`);
 	}
 
-	// Same-origin upgrade: the browser-served UI steering its OWN session. Its Origin's
-	// host:port equals the Host header it was served from. A cross-site attacker's page has a
-	// different origin, so it can never match. (The served UI also carries the token/cookie, so
-	// this is belt-and-suspenders — but it keeps the served flow working even if the cookie is
-	// briefly absent.)
-	function isSameOriginUpgrade(req: http.IncomingMessage, origin: string): boolean {
+	/**
+	 * Cookie authentication is ambient browser authority, unlike an explicit `?token=` bearer.
+	 * Accept it only when the page Origin exactly matches the upgrade Host. Cookies are host-scoped,
+	 * NOT port-scoped: without this check, a hostile page on 127.0.0.1:3000 automatically carries
+	 * Accordion's HttpOnly cookie when it opens 127.0.0.1:<accordion-port>.
+	 *
+	 * On a loopback peer, additionally require a literal loopback hostname. Merely comparing two
+	 * attacker-controlled strings (`Origin.host === Host`) is vulnerable to DNS rebinding: an
+	 * attacker can serve evil.example:<port>, rebind it to 127.0.0.1, and keep matching headers.
+	 */
+	function isCookieAuthorizedUpgrade(req: http.IncomingMessage, origin: string, loopbackPeer: boolean): boolean {
 		const host = req.headers["host"];
 		if (typeof host !== "string" || host === "") return false;
-		try { return new URL(origin).host === host; } catch { return false; }
+		try {
+			const u = new URL(origin);
+			if (u.protocol !== "http:" && u.protocol !== "https:") return false;
+			if (u.host.toLowerCase() !== host.trim().toLowerCase()) return false;
+			if (!loopbackPeer) return true;
+			const hostname = u.hostname.toLowerCase();
+			return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+		} catch {
+			return false;
+		}
+	}
+
+	/**
+	 * Browser-served loopback mode intentionally lets a page served by session A switch to
+	 * sibling session B. It cannot possess B's per-session token, and its Origin port is A rather
+	 * than B, so ordinary same-origin cookie auth cannot authorize that dial. Preserve the feature
+	 * without reopening arbitrary cross-port CSWSH: accept only a literal loopback Origin whose
+	 * server currently answers Accordion's loopback-only `/__accordion/meta` contract. A live probe
+	 * proves current port ownership, unlike a registry heartbeat which can be stale or refer to the
+	 * same numeric port on another bind interface. A public DNS-rebound hostname fails before I/O.
+	 */
+	function isKnownAccordionLoopbackOrigin(origin: string): Promise<boolean> {
+		let u: URL;
+		try { u = new URL(origin); } catch { return Promise.resolve(false); }
+		// The extension serves plain HTTP. HTTPS loopback Origins belong to a reverse proxy and
+		// must use the explicit bearer/cookie path rather than this tokenless sibling exception.
+		if (u.protocol !== "http:") return Promise.resolve(false);
+		const hostname = u.hostname.toLowerCase();
+		if (hostname !== "localhost" && hostname !== "127.0.0.1" && hostname !== "[::1]") return Promise.resolve(false);
+		const originPort = Number(u.port || 80);
+		if (!Number.isSafeInteger(originPort) || originPort <= 0 || originPort > 65535) return Promise.resolve(false);
+		if (pendingSiblingOriginProbes >= MAX_PENDING_SIBLING_ORIGIN_PROBES) return Promise.resolve(false);
+		const requestHost = hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+		pendingSiblingOriginProbes++;
+
+		return new Promise((resolve) => {
+			let settled = false;
+			let request: http.ClientRequest | null = null;
+			let deadline: ReturnType<typeof setTimeout> | null = null;
+			const finish = (ok: boolean): void => {
+				if (settled) return;
+				settled = true;
+				pendingSiblingOriginProbes--;
+				if (deadline) clearTimeout(deadline);
+				resolve(ok);
+			};
+			deadline = setTimeout(() => {
+				request?.destroy();
+				finish(false);
+			}, SIBLING_ORIGIN_PROBE_MS);
+			request = http.get(
+				{ hostname: requestHost, port: originPort, path: "/__accordion/meta" },
+				(response) => {
+					if (response.statusCode !== 200) {
+						// Authentication is already decided; do not drain an attacker-controlled endless
+						// body after clearing our deadline. Tear the response/socket down immediately.
+						response.destroy();
+						finish(false);
+						return;
+					}
+					const chunks: Buffer[] = [];
+					let bodyBytes = 0;
+					response.on("data", (chunk: Buffer) => {
+						bodyBytes += chunk.length;
+						if (bodyBytes > SIBLING_ORIGIN_META_MAX_BYTES) {
+							response.destroy();
+							finish(false);
+							return;
+						}
+						chunks.push(chunk);
+					});
+					response.on("end", () => {
+						if (settled) return;
+						try {
+							const meta = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+								served?: unknown;
+								sessionId?: unknown;
+								protocolVersion?: unknown;
+							};
+							if (meta.served !== true || typeof meta.sessionId !== "string" || meta.protocolVersion !== PROTOCOL_VERSION) {
+								finish(false);
+								return;
+							}
+							// The live response is a current-ownership proof; the matching live registry entry
+							// prevents an unrelated local HTTP service from authorizing itself by imitating the
+							// public JSON shape. Same-user native malware can read/write this registry, but that
+							// actor is already inside the intentional no-Origin native trust boundary.
+							void listLiveSessions().then(
+								(sessions) => finish(sessions.some((s) => s.sessionId === meta.sessionId && s.port === originPort)),
+								() => finish(false),
+							);
+						} catch {
+							finish(false);
+						}
+					});
+					response.on("aborted", () => finish(false));
+					response.on("error", () => finish(false));
+				},
+			);
+			request.on("error", () => finish(false));
+		});
 	}
 
 	function verifyWsUpgrade(info: { req: http.IncomingMessage }, cb: (res: boolean, code?: number, message?: string) => void): void {
@@ -1082,50 +1191,59 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			cb(false, 400, "bad request target");
 			return;
 		}
-		const hasToken = !!webToken && (token === webToken || hasAccordionCookie(req));
+		// Keep explicit bearer and ambient-cookie authority separate. Possession of the query token
+		// may authorize any Origin; a cookie is accepted only from the served origin below.
+		const hasQueryToken = !!webToken && token === webToken;
+		const hasCookie = !!webToken && hasAccordionCookie(req);
 		const origin = req.headers["origin"];
+		const loopbackPeer = isLoopbackPeer(peer);
+		const cookieAuthorized =
+			typeof origin === "string" && origin !== "" && hasCookie && isCookieAuthorizedUpgrade(req, origin, loopbackPeer);
 
-		if (isLoopbackPeer(peer)) {
+		if (loopbackPeer) {
 			// CSWSH defense. WebSockets are NOT subject to CORS, so a malicious web page in the
 			// user's browser could open ws://127.0.0.1:<port>, receive the session backlog, become
 			// the active client, submit plans, toggle armed state, and trigger paid completions.
 			// Loopback therefore stays tokenless ONLY for:
 			//   • native clients that send NO browser Origin, and
-			//   • the trusted Tauri webview / same-origin served UI (their Origin is fixed / matches
-			//     the served Host — a cross-site attacker cannot forge either).
-			// Any OTHER browser Origin must present the token (which a CSWSH attacker cannot read).
+			//   • the trusted Tauri webview.
+			// A browser-served UI must present its explicit query token or a same-origin cookie.
 			if (typeof origin !== "string" || origin === "") { cb(true); return; } // native, no Origin
-			if (isTrustedNativeWebviewOrigin(origin) || isSameOriginUpgrade(req, origin)) { cb(true); return; }
-			if (hasToken) { cb(true); return; }
-			cb(false, 403, "cross-origin WebSocket blocked — open Accordion via the /accordion Browser link (it carries the session token)");
+			if (isTrustedNativeWebviewOrigin(origin)) { cb(true); return; }
+			if (hasQueryToken || cookieAuthorized) { cb(true); return; }
+			// Cross-session browser switch: authorize only another live Accordion loopback Origin.
+			void isKnownAccordionLoopbackOrigin(origin).then(
+				(ok) => cb(
+					ok,
+					ok ? undefined : 403,
+					ok ? undefined : "cross-origin WebSocket blocked — open Accordion via the /accordion Browser link (it carries the session token)",
+				),
+				() => cb(false, 403, "cross-origin WebSocket blocked — session origin could not be verified"),
+			);
 			return;
 		}
 
 		// Off-loopback peer: require the per-session token. The browser-served page forwards it on
 		// the upgrade URL (?token=…) on first load; on a later reload without ?token=… the browser
-		// still sends the HttpOnly accordion_token cookie, accepted above via hasAccordionCookie.
-		if (hasToken) { cb(true); return; }
+		// still sends the HttpOnly accordion_token cookie, accepted only for its exact served Origin.
+		if (hasQueryToken || cookieAuthorized) { cb(true); return; }
 		cb(false, 401, "unauthorized — open Accordion via the /accordion Browser link (it carries the session token)");
 	}
 
 	function startServer(): void {
 		if (wss || httpServer) return;
 		bindError = null; // fresh attempt — clear any failure a prior call recorded
-		// Per-session token for the HTTP static surface AND (when bound off-loopback) the
-		// WS upgrade for non-loopback peers — see verifyWsUpgrade for the auth split: a
-		// loopback peer (the desktop app, or a same-machine browser) dials tokenless and
-		// must keep working; a NON-loopback peer — only reachable when the bind host is
-		// 0.0.0.0 or a specific interface — must present this token, which the browser-
-		// served page already carries in its URL (?token=…). Without it anyone on the
-		// network could connect to the steering WS and fold/unfold/pin the agent's context.
+		// Per-session token for the HTTP surface and browser WS upgrades. Native/Tauri loopback
+		// clients and verified live sibling Accordion Origins are the only tokenless paths;
+		// ordinary browsers authenticate explicitly or with an exact-origin cookie.
 		webToken = crypto.randomBytes(16).toString("hex");
 		const bindHost = resolveBindHost(pi);
 		const bindPort = resolveBindPort(pi);
 		try {
 			// One HTTP server hosts BOTH halves on the SAME port:
 			//   • HTTP GETs → handleHttp (the browser build, token-gated)
-			//   • WS upgrades → the WebSocketServer below (loopback tokenless;
-			//     off-loopback token-gated via verifyWsUpgrade)
+			//   • WS upgrades → the WebSocketServer below (native/Tauri + verified sibling
+			//     Origins tokenless; other browser origins token/cookie-gated via verifyWsUpgrade)
 			// port 0 ⇒ OS assigns a free ephemeral port (one server per pi session).
 			httpServer = http.createServer(handleHttp);
 			// Attach the WS server to the HTTP server (NOT { port: 0 }) so the upgrade
@@ -1171,12 +1289,14 @@ export default function accordionLive(pi: ExtensionAPI): void {
 			return;
 		}
 		wss.on("connection", (ws: WebSocket) => {
+			// Duplicate request ids are scoped to one connection generation. The global spend bound
+			// above is separate because superseded provider calls continue until they actually settle.
+			const connectionCompletionIds = new Set<number>();
 			flushPending(); // supersede any prior GUI: its in-flight requests pass through
 			client = ws;
 			epoch++;
 			sentCount = 0; // re-sync the whole context to the freshly-connected GUI
 			reqSeq = 0;
-			inFlightCompletions.clear(); // a superseded client's completions are discarded (reply guard)
 			lastPlan = null; // a new view starts with no known plan; never apply the old one to it
 			armed = false; // a fresh client is DISARMED until it declares otherwise over the wire
 			send(ws, { type: "hello", protocolVersion: PROTOCOL_VERSION, sessionId, meta });
@@ -1251,7 +1371,7 @@ export default function accordionLive(pi: ExtensionAPI): void {
 						});
 					}
 				}
-				if (msg?.type === "completeRequest" && typeof msg.reqId === "number") {
+				if (msg?.type === "completeRequest" && Number.isSafeInteger(msg.reqId) && msg.reqId >= 0) {
 					// Out-of-band: fire async and NEVER block the message handler or any hook.
 					// Dynamic import so the module is resolved lazily — at pi load time pi's jiti
 					// alias table maps "@earendil-works/pi-ai" to its bundled copy; the smoke test
@@ -1263,6 +1383,11 @@ export default function accordionLive(pi: ExtensionAPI): void {
 							// Only send if this GUI is still the active client (reconnect guard).
 							if (capturedWs === client && capturedWs.readyState === 1) send(capturedWs, r);
 						};
+						// An exact in-flight duplicate on this connection is a replay, not a second request.
+						// Ignore it and let the original eventual result settle the one GUI promise keyed by
+						// reqId. Sending an error with the same id would reject/delete the ORIGINAL promise
+						// while its paid provider call continued in the background.
+						if (connectionCompletionIds.has(req.reqId)) return;
 						// Validate prompt before doing any async work.
 						if (typeof req.prompt !== "string" || req.prompt.length === 0) {
 							reply({ type: "completeResult", reqId: req.reqId, ok: false, error: "missing or empty prompt" });
@@ -1270,17 +1395,15 @@ export default function accordionLive(pi: ExtensionAPI): void {
 						}
 						// Admission control (unbounded paid completions). These checks run synchronously
 						// before the first `await`, so back-to-back completeRequest events cannot race past
-						// the caps. Reject a reqId already in flight (dedupe retries/replays) and any request
-						// beyond the concurrency ceiling; each accepted request is a billable model call.
-						if (inFlightCompletions.has(req.reqId)) {
-							reply({ type: "completeResult", reqId: req.reqId, ok: false, error: "duplicate completion request already in flight" });
-							return;
-						}
-						if (inFlightCompletions.size >= MAX_CONCURRENT_COMPLETIONS) {
+						// the cap. It is GLOBAL across reconnects because superseding a socket does not stop
+						// the billable upstream work. Each accepted request owns a unique cleanup token.
+						if (activeCompletionCalls.size >= MAX_CONCURRENT_COMPLETIONS) {
 							reply({ type: "completeResult", reqId: req.reqId, ok: false, error: `too many concurrent completions in flight (max ${MAX_CONCURRENT_COMPLETIONS})` });
 							return;
 						}
-						inFlightCompletions.add(req.reqId);
+						const callToken = Symbol(`completion:${req.reqId}`);
+						activeCompletionCalls.add(callToken);
+						connectionCompletionIds.add(req.reqId);
 						try {
 							const ctx = latestCtx;
 							const m = latestModel ?? ctx?.model;
@@ -1335,9 +1458,10 @@ export default function accordionLive(pi: ExtensionAPI): void {
 							const errMsg = err instanceof Error ? err.message : String(err);
 							reply({ type: "completeResult", reqId: req.reqId, ok: false, error: errMsg });
 						} finally {
-							// Always release the concurrency slot — success, provider error, or a client that
-							// dropped mid-flight (its reply is discarded by the guard, but the slot must free).
-							inFlightCompletions.delete(req.reqId);
+							// Release exactly THIS call's global token. A reconnect/new call may reuse reqId;
+							// deleting by numeric id would let an old completion erase the new call's slot.
+							activeCompletionCalls.delete(callToken);
+							connectionCompletionIds.delete(req.reqId);
 						}
 					})();
 				}

--- a/extension/smoke.mjs
+++ b/extension/smoke.mjs
@@ -13,6 +13,7 @@ import { createJiti } from "jiti";
 import { WebSocket } from "ws";
 import * as fs from "node:fs";
 import * as http from "node:http";
+import * as net from "node:net";
 import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -1484,7 +1485,132 @@ if (!(armedSmoke.nextDisarmedMs !== null && armedSmoke.nextDisarmedMs < 900))
 	}
 }
 
+// ── WS auth hardening (private security review of the devmain promotion) ─────
+// Covers the three fixes:
+//   A. a malformed WS upgrade target is rejected 400 (not an uncaught crash)
+//   B. loopback CSWSH defense: a browser Origin with no token is rejected, while a
+//      tokenless dial with NO Origin (native/Tauri path) and a trusted Tauri Origin pass
+//   C. an oversized inbound frame is rejected (maxPayload), and paid completions are
+//      bounded (duplicate reqId + concurrency ceiling both refused)
+let wsHardeningOk = true;
+{
+	const browserLine2 = notifications.map((n) => n.message).reverse().find((m) => m.includes("Browser: http"));
+	const TOKEN2 = browserLine2 && (browserLine2.match(/token=([0-9a-f]+)/) || [])[1];
+	if (!TOKEN2) { fails.push("ws-hardening: could not recover the session token from notifications"); wsHardeningOk = false; }
+
+	// ── A. malformed upgrade target → 400, no crash ──────────────────────────
+	// A raw upgrade whose request-target is authority-form with an out-of-range port makes
+	// `new URL()` throw. `ws`'s verifyClient does NOT catch a synchronous throw, so without the
+	// fix this is an uncaught exception that kills the process (this smoke run runs the server
+	// IN-PROCESS, so a regression would crash the whole run rather than just fail an assert).
+	const rawUpgrade = (requestTarget) =>
+		new Promise((resolve) => {
+			const s = net.connect(PORT, "127.0.0.1", () => {
+				s.write(
+					`GET ${requestTarget} HTTP/1.1\r\n` +
+						`Host: 127.0.0.1:${PORT}\r\n` +
+						`Upgrade: websocket\r\nConnection: Upgrade\r\n` +
+						`Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n`,
+				);
+			});
+			let buf = "";
+			const finish = () => { try { s.destroy(); } catch { /* ignore */ } resolve(buf.split("\r\n")[0] || "(no response)"); };
+			s.on("data", (d) => { buf += d.toString(); if (buf.includes("\r\n")) finish(); });
+			s.on("error", () => resolve("(socket error)"));
+			setTimeout(finish, 1500);
+		});
+	const malformedStatus = await rawUpgrade("http://x:999999/");
+	if (!/\b400\b/.test(malformedStatus))
+		{ fails.push(`ws-hardening A: malformed upgrade target not rejected 400 — got: ${JSON.stringify(malformedStatus)}`); wsHardeningOk = false; }
+	// Prove the server survived the malformed upgrade (would be unreachable if it had crashed).
+	const aliveAfter = await new Promise((resolve) => {
+		const r = http.get({ host: "127.0.0.1", port: PORT, path: "/__accordion/meta" }, (res) => { res.resume(); resolve(res.statusCode); });
+		r.on("error", () => resolve(0));
+	});
+	if (aliveAfter !== 200)
+		{ fails.push(`ws-hardening A: server did not survive the malformed upgrade (meta returned ${aliveAfter})`); wsHardeningOk = false; }
+
+	// ── B. loopback CSWSH / Origin split ─────────────────────────────────────
+	const dialWs = (opts, suffix = "") =>
+		new Promise((resolve) => {
+			let settled = false;
+			const w = new WebSocket(`ws://127.0.0.1:${PORT}${suffix}`, opts);
+			const done = (r) => { if (settled) return; settled = true; try { w.close(); } catch { /* ignore */ } resolve(r); };
+			w.on("open", () => done({ open: true }));
+			w.on("unexpected-response", (_rq, rs) => done({ open: false, status: rs.statusCode }));
+			w.on("error", (e) => done({ open: false, error: String((e && e.message) || e) }));
+			setTimeout(() => done({ open: false, timeout: true }), 1500);
+		});
+	const evilNoToken = await dialWs({ origin: "http://evil.example" });
+	if (evilNoToken.open || evilNoToken.status !== 403)
+		{ fails.push(`ws-hardening B: loopback + hostile Origin + no token was NOT rejected 403 — got: ${JSON.stringify(evilNoToken)}`); wsHardeningOk = false; }
+	const noOrigin = await dialWs({});
+	if (!noOrigin.open)
+		{ fails.push(`ws-hardening B: tokenless loopback dial with NO Origin (Tauri/native path) was rejected — got: ${JSON.stringify(noOrigin)}`); wsHardeningOk = false; }
+	const tauriOrigin = await dialWs({ origin: "http://tauri.localhost" });
+	if (!tauriOrigin.open)
+		{ fails.push(`ws-hardening B: trusted Tauri webview Origin was rejected — got: ${JSON.stringify(tauriOrigin)}`); wsHardeningOk = false; }
+	if (TOKEN2) {
+		const evilWithToken = await dialWs({ origin: "http://evil.example" }, `/?token=${TOKEN2}`);
+		if (!evilWithToken.open)
+			{ fails.push(`ws-hardening B: hostile Origin WITH a valid token was rejected (token must override) — got: ${JSON.stringify(evilWithToken)}`); wsHardeningOk = false; }
+	}
+
+	// ── C1. oversized inbound frame → rejected (maxPayload), server survives ──
+	const oversized = await new Promise((resolve) => {
+		const w = new WebSocket(`ws://127.0.0.1:${PORT}`);
+		w.on("open", () => { try { w.send(Buffer.alloc(9 * 1024 * 1024, 0x61)); } catch { /* ignore */ } });
+		w.on("close", (code) => resolve({ code }));
+		w.on("error", () => { /* the close (1009) is what we assert */ });
+		setTimeout(() => resolve({ code: null, timeout: true }), 4000);
+	});
+	if (oversized.code !== 1009)
+		{ fails.push(`ws-hardening C1: oversized (>8 MiB) frame not rejected with close 1009 — got: ${JSON.stringify(oversized)}`); wsHardeningOk = false; }
+
+	// ── C2. paid completions bounded: duplicate reqId + concurrency ceiling ──
+	// Drive `latestCtx` to a stub whose getApiKeyAndHeaders never resolves on its own, so each
+	// admitted completion parks in-flight holding its slot. Then a duplicate reqId and a request
+	// past the ceiling must both be refused; an admitted one reaches the auth step (proving the
+	// happy path still works). Finally release the stubs so nothing hangs the run.
+	const heldResolvers = [];
+	const holdCtx = {
+		ui: { setStatus() {}, notify() {}, theme: { fg: (_c, s) => s } },
+		model: { id: "test/hold-model", contextWindow: 2000 },
+		getContextUsage: () => ({ tokens: 1, contextWindow: 2000 }),
+		modelRegistry: { getApiKeyAndHeaders: () => new Promise((res) => heldResolvers.push(res)) },
+	};
+	const wsC = new WebSocket(`ws://127.0.0.1:${PORT}`);
+	await new Promise((res, rej) => { wsC.on("open", res); wsC.on("error", rej); });
+	const completeResults = [];
+	wsC.on("message", (data) => {
+		let m = null; try { m = JSON.parse(data.toString()); } catch { return; }
+		if (m && m.type === "completeResult") completeResults.push(m);
+	});
+	handlers.context({ messages: [] }, holdCtx); // sets latestCtx=holdCtx synchronously (before any await)
+	await new Promise((r) => setTimeout(r, 80));
+	// Fill the concurrency ceiling (MAX_CONCURRENT_COMPLETIONS = 4): reqIds 101..104 park in flight.
+	for (const id of [101, 102, 103, 104]) wsC.send(JSON.stringify({ type: "completeRequest", reqId: id, prompt: "hold" }));
+	await new Promise((r) => setTimeout(r, 200)); // let all four register as in-flight
+	wsC.send(JSON.stringify({ type: "completeRequest", reqId: 101, prompt: "dup" })); // duplicate reqId
+	wsC.send(JSON.stringify({ type: "completeRequest", reqId: 105, prompt: "over" })); // over the ceiling
+	await waitFor(() => completeResults.some((r) => r.reqId === 101 && /duplicate/i.test(r.error || "")) && completeResults.some((r) => r.reqId === 105 && /concurrent/i.test(r.error || "")), 2000, "completion caps").catch(() => {});
+	const dupRej = completeResults.find((r) => r.reqId === 101 && r.ok === false && /duplicate/i.test(r.error || ""));
+	const capRej = completeResults.find((r) => r.reqId === 105 && r.ok === false && /concurrent/i.test(r.error || ""));
+	if (!dupRej) { fails.push(`ws-hardening C2: duplicate in-flight completion reqId was NOT rejected — got: ${JSON.stringify(completeResults)}`); wsHardeningOk = false; }
+	if (!capRej) { fails.push(`ws-hardening C2: over-concurrency completion was NOT rejected — got: ${JSON.stringify(completeResults)}`); wsHardeningOk = false; }
+	// Release the parked stubs (resolve the auth as a failure) so the four in-flight completions
+	// finish, free their slots, and the run can exit. Their reply proves they were ADMITTED past
+	// the caps and reached the auth step — the happy path is intact.
+	for (const res of heldResolvers) res({ ok: false, error: "test-teardown" });
+	await waitFor(() => completeResults.filter((r) => r.reqId >= 101 && r.reqId <= 104 && /test-teardown/.test(r.error || "")).length >= 4, 2000, "admitted completions drained").catch(() => {});
+	const admitted = completeResults.filter((r) => r.reqId >= 101 && r.reqId <= 104 && /test-teardown/.test(r.error || "")).length;
+	if (admitted < 4) { fails.push(`ws-hardening C2: expected 4 admitted completions to reach the auth step, got ${admitted}`); wsHardeningOk = false; }
+	try { wsC.close(); } catch { /* ignore */ }
+	await new Promise((r) => setTimeout(r, 50));
+}
+
 // ── assertions ───────────────────────────────────────────────────────────────
+if (!wsHardeningOk) { /* individual failures already pushed above */ }
 if (!seen.hello) fails.push("never received hello");
 if (!seen.flushOnAttach) fails.push("GUI received no history flush on attach (would stay empty until first message — the bug)");
 if (seen.flushBlocks < 4) fails.push(`attach flush carried too few blocks: got ${seen.flushBlocks}, expected >=4`);
@@ -1538,6 +1664,7 @@ console.log(
 							`passthrough acks (applied/empty-plan/timeout-stale/timeout-raw) ✓  /__accordion/meta planOutcomes ✓  ` +
 							`port-qualified cookie (collision guard) ✓  parseBindPort/displayHostFor unit tests ✓  ` +
 							`ack counts reflect applied-not-submitted ✓  bind failure surfaced ✓  invalid --accordion-port warns ✓  ` +
-							`specific-interface bind warns ✓`,
+							`specific-interface bind warns ✓  ` +
+							`ws-hardening (malformed-target 400 / loopback CSWSH Origin split / oversized-frame 1009 / completion dup+concurrency caps) ✓`,
 );
 process.exit(0);

--- a/extension/smoke.mjs
+++ b/extension/smoke.mjs
@@ -1488,10 +1488,10 @@ if (!(armedSmoke.nextDisarmedMs !== null && armedSmoke.nextDisarmedMs < 900))
 // ── WS auth hardening (private security review of the devmain promotion) ─────
 // Covers the three fixes:
 //   A. a malformed WS upgrade target is rejected 400 (not an uncaught crash)
-//   B. loopback CSWSH defense: a browser Origin with no token is rejected, while a
-//      tokenless dial with NO Origin (native/Tauri path) and a trusted Tauri Origin pass
+//   B. loopback CSWSH defense: hostile, DNS-rebound, and cross-port-cookie Origins are
+//      rejected, while native/Tauri and explicitly authenticated served-UI paths pass
 //   C. an oversized inbound frame is rejected (maxPayload), and paid completions are
-//      bounded (duplicate reqId + concurrency ceiling both refused)
+//      bounded globally across reconnects (duplicates are coalesced onto the original)
 let wsHardeningOk = true;
 {
 	const browserLine2 = notifications.map((n) => n.message).reverse().find((m) => m.includes("Browser: http"));
@@ -1503,12 +1503,14 @@ let wsHardeningOk = true;
 	// `new URL()` throw. `ws`'s verifyClient does NOT catch a synchronous throw, so without the
 	// fix this is an uncaught exception that kills the process (this smoke run runs the server
 	// IN-PROCESS, so a regression would crash the whole run rather than just fail an assert).
-	const rawUpgrade = (requestTarget) =>
+	const rawUpgrade = (requestTarget, { host = `127.0.0.1:${PORT}`, origin = null, cookie = null } = {}) =>
 		new Promise((resolve) => {
 			const s = net.connect(PORT, "127.0.0.1", () => {
 				s.write(
 					`GET ${requestTarget} HTTP/1.1\r\n` +
-						`Host: 127.0.0.1:${PORT}\r\n` +
+						`Host: ${host}\r\n` +
+						(origin ? `Origin: ${origin}\r\n` : "") +
+						(cookie ? `Cookie: ${cookie}\r\n` : "") +
 						`Upgrade: websocket\r\nConnection: Upgrade\r\n` +
 						`Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n`,
 				);
@@ -1551,6 +1553,92 @@ let wsHardeningOk = true;
 	if (!tauriOrigin.open)
 		{ fails.push(`ws-hardening B: trusted Tauri webview Origin was rejected — got: ${JSON.stringify(tauriOrigin)}`); wsHardeningOk = false; }
 	if (TOKEN2) {
+		// Matching attacker-controlled Origin/Host is NOT proof of same-origin trust: under DNS
+		// rebinding the TCP peer is loopback while both strings remain the attacker's hostname.
+		const rebound = await rawUpgrade("/", {
+			host: `evil.example:${PORT}`,
+			origin: `http://evil.example:${PORT}`,
+		});
+		if (!/\b403\b/.test(rebound))
+			{ fails.push(`ws-hardening B: DNS-rebound matching Origin/Host was not rejected 403 — got: ${JSON.stringify(rebound)}`); wsHardeningOk = false; }
+
+		// A terminal non-200 probe response must be DESTROYED, not drained after the verifier's
+		// deadline clears: this server deliberately never ends its body. The upgrade still rejects
+		// promptly, and close() below proves the probe did not leave the response socket hanging.
+		const endlessServer = http.createServer((_req, res) => { res.writeHead(403); res.write("never-ending"); });
+		await new Promise((resolve, reject) => {
+			endlessServer.once("error", reject);
+			endlessServer.listen(0, "127.0.0.1", resolve);
+		});
+		const endlessAddress = endlessServer.address();
+		const endlessPort = endlessAddress && typeof endlessAddress === "object" ? endlessAddress.port : 0;
+		const endlessStatus = await rawUpgrade("/", { origin: `http://127.0.0.1:${endlessPort}` });
+		if (!/\b403\b/.test(endlessStatus))
+			{ fails.push(`ws-hardening B: non-ending failed sibling probe did not reject promptly — got: ${JSON.stringify(endlessStatus)}`); wsHardeningOk = false; }
+		await new Promise((resolve) => endlessServer.close(resolve));
+
+		// Cookies cross ports. Even a local service that FORGES the public /meta JSON shape must
+		// not inherit authority without a matching live registry identity.
+		const unrelatedServer = http.createServer((_req, res) => {
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ served: true, sessionId: "forged-local-service", protocolVersion: entry.protocolVersion }));
+		});
+		await new Promise((resolve, reject) => {
+			unrelatedServer.once("error", reject);
+			unrelatedServer.listen(0, "127.0.0.1", resolve);
+		});
+		const unrelatedAddress = unrelatedServer.address();
+		const unrelatedPort = unrelatedAddress && typeof unrelatedAddress === "object" ? unrelatedAddress.port : 0;
+		const crossPortCookie = await rawUpgrade("/", {
+			origin: `http://127.0.0.1:${unrelatedPort}`,
+			cookie: `accordion_token_p${PORT}=${TOKEN2}`,
+		});
+		await new Promise((resolve) => unrelatedServer.close(resolve));
+		if (!/\b403\b/.test(crossPortCookie))
+			{ fails.push(`ws-hardening B: different-port Origin with ambient cookie was not rejected 403 — got: ${JSON.stringify(crossPortCookie)}`); wsHardeningOk = false; }
+
+		// But a page CURRENTLY served by another Accordion server is the intentional loopback
+		// multi-session switch path. Prove current ownership through the sibling's live /meta
+		// response, then close it and prove the same stale Origin immediately loses authority.
+		const siblingServer = http.createServer((req, res) => {
+			if (req.url === "/__accordion/meta") {
+				res.writeHead(200, { "Content-Type": "application/json" });
+				res.end(JSON.stringify({ served: true, sessionId: "s-origin-smoke", protocolVersion: entry.protocolVersion }));
+				return;
+			}
+			res.writeHead(404); res.end();
+		});
+		await new Promise((resolve, reject) => {
+			siblingServer.once("error", reject);
+			siblingServer.listen(0, "127.0.0.1", resolve);
+		});
+		const siblingAddress = siblingServer.address();
+		const siblingPort = siblingAddress && typeof siblingAddress === "object" ? siblingAddress.port : 0;
+		const siblingEntryPath = path.join(SESSIONS_DIR, "s-origin-smoke.json");
+		fs.writeFileSync(siblingEntryPath, JSON.stringify({
+			...entry,
+			sessionId: "s-origin-smoke",
+			port: siblingPort,
+			startedAt: Date.now(),
+			heartbeatAt: Date.now(),
+		}));
+		const siblingOrigin = await rawUpgrade("/", { origin: `http://127.0.0.1:${siblingPort}` });
+		if (!/\b101\b/.test(siblingOrigin))
+			{ fails.push(`ws-hardening B: live sibling Accordion Origin was rejected — got: ${JSON.stringify(siblingOrigin)}`); wsHardeningOk = false; }
+		await new Promise((resolve) => siblingServer.close(resolve));
+		try { fs.unlinkSync(siblingEntryPath); } catch { /* best-effort test cleanup */ }
+		const staleSiblingOrigin = await rawUpgrade("/", { origin: `http://127.0.0.1:${siblingPort}` });
+		if (!/\b403\b/.test(staleSiblingOrigin))
+			{ fails.push(`ws-hardening B: stopped sibling Origin retained authority — got: ${JSON.stringify(staleSiblingOrigin)}`); wsHardeningOk = false; }
+
+		// The legitimate tokenless reload path remains: exact served Origin + its cookie.
+		const servedCookie = await rawUpgrade("/", {
+			origin: `http://127.0.0.1:${PORT}`,
+			cookie: `accordion_token_p${PORT}=${TOKEN2}`,
+		});
+		if (!/\b101\b/.test(servedCookie))
+			{ fails.push(`ws-hardening B: exact served Origin with cookie was rejected — got: ${JSON.stringify(servedCookie)}`); wsHardeningOk = false; }
+
 		const evilWithToken = await dialWs({ origin: "http://evil.example" }, `/?token=${TOKEN2}`);
 		if (!evilWithToken.open)
 			{ fails.push(`ws-hardening B: hostile Origin WITH a valid token was rejected (token must override) — got: ${JSON.stringify(evilWithToken)}`); wsHardeningOk = false; }
@@ -1567,11 +1655,11 @@ let wsHardeningOk = true;
 	if (oversized.code !== 1009)
 		{ fails.push(`ws-hardening C1: oversized (>8 MiB) frame not rejected with close 1009 — got: ${JSON.stringify(oversized)}`); wsHardeningOk = false; }
 
-	// ── C2. paid completions bounded: duplicate reqId + concurrency ceiling ──
+	// ── C2. paid completions bounded across reconnect; duplicates coalesce ──
 	// Drive `latestCtx` to a stub whose getApiKeyAndHeaders never resolves on its own, so each
-	// admitted completion parks in-flight holding its slot. Then a duplicate reqId and a request
-	// past the ceiling must both be refused; an admitted one reaches the auth step (proving the
-	// happy path still works). Finally release the stubs so nothing hangs the run.
+	// admitted completion parks in-flight holding its slot. A duplicate must NOT launch another
+	// provider call or reject the original promise; a reconnect must NOT clear the four global
+	// slots. Finally release the stubs and prove a real settlement opens capacity again.
 	const heldResolvers = [];
 	const holdCtx = {
 		ui: { setStatus() {}, notify() {}, theme: { fg: (_c, s) => s } },
@@ -1588,24 +1676,60 @@ let wsHardeningOk = true;
 	});
 	handlers.context({ messages: [] }, holdCtx); // sets latestCtx=holdCtx synchronously (before any await)
 	await new Promise((r) => setTimeout(r, 80));
+	// First isolate duplicate semantics on one live socket: one provider call, no duplicate error,
+	// and exactly one eventual result under the original correlation id.
+	wsC.send(JSON.stringify({ type: "completeRequest", reqId: 100, prompt: "original" }));
+	await waitFor(() => heldResolvers.length === 1, 2000, "original completion admitted").catch(() => {});
+	wsC.send(JSON.stringify({ type: "completeRequest", reqId: 100, prompt: "duplicate" }));
+	await new Promise((r) => setTimeout(r, 50));
+	if (heldResolvers.length !== 1) { fails.push(`ws-hardening C2: duplicate reqId launched another provider call (auth waits=${heldResolvers.length})`); wsHardeningOk = false; }
+	if (completeResults.some((r) => r.reqId === 100)) { fails.push("ws-hardening C2: duplicate reqId emitted a result before the original settled"); wsHardeningOk = false; }
+	if (heldResolvers[0]) heldResolvers[0]({ ok: false, error: "duplicate-original-result" });
+	await waitFor(() => completeResults.filter((r) => r.reqId === 100 && /duplicate-original-result/.test(r.error || "")).length === 1, 2000, "original duplicate-correlated result").catch(() => {});
+	if (completeResults.filter((r) => r.reqId === 100).length !== 1) { fails.push(`ws-hardening C2: duplicate correlation produced ${completeResults.filter((r) => r.reqId === 100).length} results instead of one`); wsHardeningOk = false; }
+	heldResolvers.length = 0;
+
 	// Fill the concurrency ceiling (MAX_CONCURRENT_COMPLETIONS = 4): reqIds 101..104 park in flight.
 	for (const id of [101, 102, 103, 104]) wsC.send(JSON.stringify({ type: "completeRequest", reqId: id, prompt: "hold" }));
-	await new Promise((r) => setTimeout(r, 200)); // let all four register as in-flight
-	wsC.send(JSON.stringify({ type: "completeRequest", reqId: 101, prompt: "dup" })); // duplicate reqId
+	await waitFor(() => heldResolvers.length === 4, 2000, "four completions admitted").catch(() => {});
+	wsC.send(JSON.stringify({ type: "completeRequest", reqId: 101, prompt: "dup" })); // ignored/coalesced
 	wsC.send(JSON.stringify({ type: "completeRequest", reqId: 105, prompt: "over" })); // over the ceiling
-	await waitFor(() => completeResults.some((r) => r.reqId === 101 && /duplicate/i.test(r.error || "")) && completeResults.some((r) => r.reqId === 105 && /concurrent/i.test(r.error || "")), 2000, "completion caps").catch(() => {});
-	const dupRej = completeResults.find((r) => r.reqId === 101 && r.ok === false && /duplicate/i.test(r.error || ""));
+	await waitFor(() => completeResults.some((r) => r.reqId === 105 && /concurrent/i.test(r.error || "")), 2000, "completion cap").catch(() => {});
 	const capRej = completeResults.find((r) => r.reqId === 105 && r.ok === false && /concurrent/i.test(r.error || ""));
-	if (!dupRej) { fails.push(`ws-hardening C2: duplicate in-flight completion reqId was NOT rejected — got: ${JSON.stringify(completeResults)}`); wsHardeningOk = false; }
+	if (heldResolvers.length !== 4) { fails.push(`ws-hardening C2: duplicate reqId launched another provider call (auth waits=${heldResolvers.length})`); wsHardeningOk = false; }
+	if (completeResults.some((r) => r.reqId === 101 && /duplicate/i.test(r.error || ""))) { fails.push("ws-hardening C2: duplicate reqId incorrectly rejected the original correlated request"); wsHardeningOk = false; }
 	if (!capRej) { fails.push(`ws-hardening C2: over-concurrency completion was NOT rejected — got: ${JSON.stringify(completeResults)}`); wsHardeningOk = false; }
-	// Release the parked stubs (resolve the auth as a failure) so the four in-flight completions
-	// finish, free their slots, and the run can exit. Their reply proves they were ADMITTED past
-	// the caps and reached the auth step — the happy path is intact.
+
+	// Supersede the GUI while the four provider calls are still parked. Their replies will be
+	// discarded, but their GLOBAL paid-call slots must remain occupied until actual settlement.
+	const wsC2 = new WebSocket(`ws://127.0.0.1:${PORT}`);
+	await new Promise((res, rej) => { wsC2.on("open", res); wsC2.on("error", rej); });
+	const reconnectResults = [];
+	wsC2.on("message", (data) => {
+		let m = null; try { m = JSON.parse(data.toString()); } catch { return; }
+		if (m && m.type === "completeResult") reconnectResults.push(m);
+	});
+	wsC2.send(JSON.stringify({ type: "completeRequest", reqId: 201, prompt: "must-still-be-capped" }));
+	await waitFor(() => reconnectResults.some((r) => r.reqId === 201 && /concurrent/i.test(r.error || "")), 2000, "reconnect-preserved completion cap").catch(() => {});
+	if (!reconnectResults.some((r) => r.reqId === 201 && /concurrent/i.test(r.error || ""))) {
+		fails.push(`ws-hardening C2: reconnect cleared live paid-call slots — got: ${JSON.stringify(reconnectResults)}`);
+		wsHardeningOk = false;
+	}
+	if (heldResolvers.length !== 4) { fails.push(`ws-hardening C2: reconnect admitted a fifth provider call (auth waits=${heldResolvers.length})`); wsHardeningOk = false; }
+	// Release the parked stubs (resolve auth as a failure) so the four superseded completions
+	// actually settle and free their global slots. The four queued resolvers already prove those
+	// requests were admitted to the auth step; their replies are correctly suppressed after swap.
 	for (const res of heldResolvers) res({ ok: false, error: "test-teardown" });
-	await waitFor(() => completeResults.filter((r) => r.reqId >= 101 && r.reqId <= 104 && /test-teardown/.test(r.error || "")).length >= 4, 2000, "admitted completions drained").catch(() => {});
-	const admitted = completeResults.filter((r) => r.reqId >= 101 && r.reqId <= 104 && /test-teardown/.test(r.error || "")).length;
-	if (admitted < 4) { fails.push(`ws-hardening C2: expected 4 admitted completions to reach the auth step, got ${admitted}`); wsHardeningOk = false; }
+	// The old replies are intentionally suppressed after reconnect. Once their actual promises
+	// settle, one new request must reach auth, proving `finally` released the global tokens.
+	await new Promise((r) => setTimeout(r, 100));
+	wsC2.send(JSON.stringify({ type: "completeRequest", reqId: 202, prompt: "after-settlement" }));
+	await waitFor(() => heldResolvers.length === 5, 2000, "completion slot released after settlement").catch(() => {});
+	if (heldResolvers.length !== 5) { fails.push("ws-hardening C2: settled provider calls did not release global capacity"); wsHardeningOk = false; }
+	else heldResolvers[4]({ ok: false, error: "test-teardown-new-client" });
+	await waitFor(() => reconnectResults.some((r) => r.reqId === 202 && /test-teardown-new-client/.test(r.error || "")), 2000, "new completion drained").catch(() => {});
 	try { wsC.close(); } catch { /* ignore */ }
+	try { wsC2.close(); } catch { /* ignore */ }
 	await new Promise((r) => setTimeout(r, 50));
 }
 


### PR DESCRIPTION
## What changed

This follow-up targets #72's `fix/ws-auth-hardening` branch and addresses the issues from the static review on that PR.

- Removes generic tokenless `Origin.host === Host` authorization, which was vulnerable to DNS rebinding.
- Separates explicit query-token authority from ambient cookie authority. A cookie is accepted only for its exact served Origin, so unrelated same-host/different-port pages cannot inherit WS access.
- Preserves loopback browser multi-session switching without trusting arbitrary ports: a tokenless sibling Origin must be a literal loopback address, answer the live Accordion `/__accordion/meta` contract, and match a current live registry `sessionId` + port.
- Bounds sibling-Origin verification with an absolute 750 ms deadline, a 16 KiB byte cap, immediate response teardown on failure, and an eight-probe global ceiling.
- Makes paid-completion accounting global across reconnects using unique call tokens. Request-id deduplication is scoped per connection, and duplicate replays coalesce onto the original result instead of rejecting its promise.
- Rejects non-safe-integer completion request IDs.

## Why

#72's original same-origin exception allowed matching attacker-controlled Origin/Host values after DNS rebinding. Its host-scoped cookie was also accepted from hostile pages on other ports. Separately, reconnecting cleared completion bookkeeping while upstream provider calls continued, allowing the four-call spend ceiling to be bypassed and old `finally` cleanup to erase newer slots that reused the same numeric request ID.

The loopback sibling proof is deliberately two-part. A live `/meta` response proves current ownership of the exact Origin port; the registry identity match prevents an unrelated local HTTP service from authorizing itself by imitating the public JSON shape. Same-user native processes remain inside the existing intentional no-Origin trust boundary.

## Regression coverage added

`extension/smoke.mjs` now covers:

- DNS-rebound matching Origin/Host rejection;
- hostile cross-port cookie rejection;
- forged `/meta` without registry identity rejection;
- live sibling Accordion Origin acceptance and immediate rejection after shutdown/removal;
- non-ending failed-probe teardown;
- exact-origin cookie and explicit-token success paths;
- duplicate completion coalescing with one correlated result;
- reconnect preserving the global completion ceiling;
- capacity reopening only after the actual provider promises settle.

## Validation

- `node --check extension/smoke.mjs`
- `git diff --check`
- Independent static review of the final auth and completion-accounting paths

Per the requested review constraint, I did **not** build the app, run the smoke suite, or perform live Pi/Tauri testing.