### PR TITLE
fix(app): harden transcript loading and the unauthenticated WS pump

### DIFF
--- a/app/src/lib/engine/parse.test.ts
+++ b/app/src/lib/engine/parse.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "./parse";
+import { estTokens, BLOCK_OVERHEAD } from "./tokens";
+
+// parse() turns raw pi / Claude Code JSONL into typed Blocks. These tests pin the
+// current behavior: format sniffing, assistant-message splitting, call/result
+// linkage, turn counting, and the empty-block drop rule.
+
+/** Join JSON objects (or pre-rendered strings) into a JSONL document. */
+const jsonl = (...lines: (object | string)[]): string =>
+	lines.map((l) => (typeof l === "string" ? l : JSON.stringify(l))).join("\n");
+
+// ---- pi entry builders ------------------------------------------------------
+const piSession = (extra: object = {}) => ({ type: "session", id: "s0", ...extra });
+const piUser = (id: string, content: unknown) => ({
+	type: "message",
+	id,
+	message: { role: "user", content },
+});
+const piAssistant = (id: string, content: unknown[], model = "test-model") => ({
+	type: "message",
+	id,
+	message: { role: "assistant", model, content },
+});
+const piToolResult = (id: string, o: object) => ({
+	type: "message",
+	id,
+	message: { role: "toolResult", ...o },
+});
+
+// ---- Claude entry builders --------------------------------------------------
+const ccUser = (uuid: string, content: unknown) => ({
+	uuid,
+	type: "user",
+	message: { role: "user", content },
+});
+const ccAssistant = (uuid: string, content: unknown[], model = "claude-test") => ({
+	uuid,
+	type: "assistant",
+	message: { role: "assistant", model, content },
+});
+
+describe("format detection", () => {
+	it("detects pi from a leading session entry and captures cwd/title", () => {
+		const s = parse(jsonl(piSession({ cwd: "/proj", title: "My Session" }), piUser("m1", "hello")));
+		expect(s.meta.format).toBe("pi");
+		expect(s.meta.cwd).toBe("/proj");
+		expect(s.meta.title).toBe("My Session");
+	});
+
+	it("detects Claude from a uuid + user/assistant entry (not necessarily first line)", () => {
+		const s = parse(jsonl({ type: "summary", summary: "irrelevant" }, ccUser("u1", "hi")));
+		expect(s.meta.format).toBe("claude");
+	});
+
+	it("detects Claude behind an arbitrarily long run of leading non-message lines", () => {
+		// Real CC transcripts can open with many uuid-less meta rows (summaries, file-history
+		// snapshots) before the first message — detection must scan past them all.
+		const leading = Array.from({ length: 30 }, (_, i) => ({ type: "summary", summary: `s${i}` }));
+		const s = parse(jsonl(...leading, ccUser("u1", "hi")));
+		expect(s.meta.format).toBe("claude");
+	});
+
+	it("throws on unrecognized (valid JSON, wrong shape) input", () => {
+		expect(() => parse(jsonl({ foo: 1 }, { bar: 2 }))).toThrow(/Unrecognized session format/);
+	});
+
+	it("throws on an empty string (no entries → unknown format)", () => {
+		expect(() => parse("")).toThrow(/Unrecognized session format/);
+	});
+});
+
+describe("malformed-line tolerance", () => {
+	it("silently skips a broken JSON line; surrounding valid entries still parse", () => {
+		const raw = jsonl(piSession(), piUser("m1", "first"), "{this is not json", piUser("m2", "second"));
+		const s = parse(raw);
+		expect(s.blocks.map((b) => b.text)).toEqual(["first", "second"]);
+		// the broken line never became an entry, so it isn't counted in lineCount either
+		expect(s.lineCount).toBe(3);
+	});
+});
+
+describe("pi parsing", () => {
+	it("splits one assistant message into thinking / text / tool_call blocks sharing an id prefix", () => {
+		const s = parse(
+			jsonl(
+				piSession(),
+				piUser("m1", "go"),
+				piAssistant("a1", [
+					{ type: "thinking", thinking: "hmm" },
+					{ type: "text", text: "answer" },
+					{ type: "toolCall", id: "call_1", name: "grep", arguments: { q: "x" } },
+				]),
+			),
+		);
+		const [user, think, text, call] = s.blocks;
+		expect(s.blocks).toHaveLength(4);
+		expect([think.kind, text.kind, call.kind]).toEqual(["thinking", "text", "tool_call"]);
+		// shared source-message prefix before ":", positional suffix after
+		expect([think.id, text.id, call.id]).toEqual(["a1:0", "a1:1", "a1:2"]);
+		// global order increments across the whole session
+		expect([user.order, think.order, text.order, call.order]).toEqual([0, 1, 2, 3]);
+		// tool_call payload: "<name> <json args>" plus linkage fields
+		expect(call.text).toBe('grep {"q":"x"}');
+		expect(call.toolName).toBe("grep");
+		expect(call.callId).toBe("call_1");
+		// model is stamped on assistant blocks and hoisted into meta
+		expect(think.model).toBe("test-model");
+		expect(s.meta.model).toBe("test-model");
+	});
+
+	it("links a toolResult back to its call via callId and propagates isError", () => {
+		const s = parse(
+			jsonl(
+				piSession(),
+				piUser("m1", "go"),
+				piAssistant("a1", [{ type: "toolCall", id: "call_1", name: "grep", arguments: {} }]),
+				piToolResult("r1", {
+					toolCallId: "call_1",
+					toolName: "grep",
+					content: [{ type: "text", text: "found it" }],
+					isError: true,
+				}),
+			),
+		);
+		const result = s.blocks.at(-1)!;
+		expect(result.kind).toBe("tool_result");
+		expect(result.id).toBe("r1:r");
+		expect(result.callId).toBe("call_1");
+		expect(result.toolName).toBe("grep");
+		expect(result.text).toBe("found it");
+		expect(result.isError).toBe(true);
+	});
+
+	it("defaults toolResult name to 'tool' and isError to false when absent", () => {
+		const s = parse(
+			jsonl(piSession(), piUser("m1", "go"), piToolResult("r1", { toolCallId: "c9", content: "ok" })),
+		);
+		const result = s.blocks.at(-1)!;
+		expect(result.toolName).toBe("tool");
+		expect(result.isError).toBe(false);
+	});
+
+	it("increments the turn on each user message; assistant blocks inherit the current turn", () => {
+		const s = parse(
+			jsonl(
+				piSession(),
+				piUser("m1", "first ask"),
+				piAssistant("a1", [{ type: "text", text: "reply one" }]),
+				piUser("m2", "second ask"),
+				piAssistant("a2", [{ type: "text", text: "reply two" }]),
+			),
+		);
+		expect(s.blocks.map((b) => [b.kind, b.turn])).toEqual([
+			["user", 1],
+			["text", 1],
+			["user", 2],
+			["text", 2],
+		]);
+	});
+
+	it("drops empty non-result blocks but KEEPS an empty tool_result", () => {
+		const s = parse(
+			jsonl(
+				piSession(),
+				piUser("m1", "go"),
+				piAssistant("a1", [{ type: "text", text: "" }]), // dropped
+				piToolResult("r1", { toolCallId: "c1", content: "" }), // kept
+			),
+		);
+		expect(s.blocks.map((b) => b.kind)).toEqual(["user", "tool_result"]);
+		const empty = s.blocks[1];
+		expect(empty.text).toBe("");
+		// a dropped block never consumed an order slot
+		expect(empty.order).toBe(1);
+		expect(empty.tokens).toBe(BLOCK_OVERHEAD); // estTokens("") === 0
+	});
+
+	it("records a native compaction entry as a 'compaction' tool_result with a 400-char summary slice", () => {
+		const s = parse(jsonl(piSession(), { type: "compaction", id: "c1", summary: "x".repeat(500) }));
+		const b = s.blocks[0];
+		expect(b.kind).toBe("tool_result");
+		expect(b.id).toBe("c1:c");
+		expect(b.toolName).toBe("compaction");
+		expect(b.turn).toBe(0); // preamble — no user turn yet
+		expect(b.text).toBe("⤺ native compaction: " + "x".repeat(400));
+		expect(b.callId).toBeUndefined(); // a result-like marker with no paired call
+	});
+
+	it("stamps tokens = estTokens(text) + BLOCK_OVERHEAD and counts skipped entry types", () => {
+		const text = "some user instruction of a reasonable length";
+		const s = parse(jsonl(piSession(), { type: "model_change", id: "x1" }, piUser("m1", text)));
+		expect(s.blocks[0].tokens).toBe(estTokens(text) + BLOCK_OVERHEAD);
+		expect(s.skipped).toBe(1); // the model_change entry
+		expect(s.lineCount).toBe(3);
+	});
+
+	it("defaults the title to 'pi session' when the session entry has none", () => {
+		const s = parse(jsonl(piSession(), piUser("m1", "hi")));
+		expect(s.meta.title).toBe("pi session");
+	});
+});
+
+describe("Claude Code parsing", () => {
+	it("backfills tool_result toolName from the earlier tool_use, falling back to 'tool'", () => {
+		const s = parse(
+			jsonl(
+				ccUser("u1", "run it"),
+				ccAssistant("a1", [{ type: "tool_use", id: "tu1", name: "Bash", input: { cmd: "ls" } }]),
+				ccUser("u2", [
+					{ type: "tool_result", tool_use_id: "tu1", content: "out" },
+					{ type: "tool_result", tool_use_id: "unknown-id", content: "??", is_error: true },
+				]),
+			),
+		);
+		const results = s.blocks.filter((b) => b.kind === "tool_result");
+		expect(results).toHaveLength(2);
+		expect(results[0].toolName).toBe("Bash"); // backfilled from the tool_use map
+		expect(results[0].callId).toBe("tu1");
+		expect(results[0].isError).toBe(false);
+		expect(results[1].toolName).toBe("tool"); // no map entry → fallback
+		expect(results[1].isError).toBe(true);
+	});
+
+	it("emits both blocks from a mixed user message (tool_result + text) and increments the turn once", () => {
+		const s = parse(
+			jsonl(
+				ccUser("u1", "start"),
+				ccAssistant("a1", [{ type: "tool_use", id: "tu1", name: "Read", input: {} }]),
+				ccUser("u2", [
+					{ type: "tool_result", tool_use_id: "tu1", content: [{ type: "text", text: "file body" }] },
+					{ type: "text", text: "now do the next thing" },
+				]),
+			),
+		);
+		expect(s.blocks.map((b) => b.kind)).toEqual(["user", "tool_call", "tool_result", "user"]);
+		const [, , result, user2] = s.blocks;
+		expect(result.text).toBe("file body");
+		expect(user2.text).toBe("now do the next thing");
+		// results are pushed BEFORE the turn bump, so they stay on the previous turn
+		expect(result.turn).toBe(1);
+		expect(user2.turn).toBe(2);
+	});
+
+	it("does NOT increment the turn for a user message that is only tool_results", () => {
+		const s = parse(
+			jsonl(
+				ccUser("u1", "start"),
+				ccAssistant("a1", [{ type: "tool_use", id: "tu1", name: "Read", input: {} }]),
+				ccUser("u2", [{ type: "tool_result", tool_use_id: "tu1", content: "res" }]),
+				ccUser("u3", "real follow-up"),
+			),
+		);
+		const lastUser = s.blocks.at(-1)!;
+		expect(lastUser.turn).toBe(2); // tool-result-only message did not consume a turn
+	});
+
+	it("splits assistant content (thinking/text/tool_use) with shared uuid prefix, like pi", () => {
+		const s = parse(
+			jsonl(
+				ccUser("u1", "go"),
+				ccAssistant("a1", [
+					{ type: "thinking", thinking: "let me see" },
+					{ type: "text", text: "done" },
+				]),
+			),
+		);
+		expect(s.blocks.map((b) => [b.kind, b.id])).toEqual([
+			["user", "u1:u"],
+			["thinking", "a1:0"],
+			["text", "a1:1"],
+		]);
+		expect(s.meta.model).toBe("claude-test");
+	});
+
+	it("picks up title from ai-title entries, cwd from the first entry carrying one, and defaults the title", () => {
+		const titled = parse(jsonl({ ...ccUser("u1", "hi"), cwd: "/work" }, { type: "ai-title", aiTitle: "Fix the parser" }));
+		expect(titled.meta.title).toBe("Fix the parser");
+		expect(titled.meta.cwd).toBe("/work");
+
+		const untitled = parse(jsonl(ccUser("u1", "hi")));
+		expect(untitled.meta.title).toBe("Claude Code session");
+	});
+});

--- a/app/src/lib/engine/parse.ts
+++ b/app/src/lib/engine/parse.ts
@@ -26,7 +26,9 @@ function parseLines(raw: string): any[] {
 function detectFormat(entries: any[]): SessionMeta["format"] {
 	if (!entries.length) return "unknown";
 	if (entries[0]?.type === "session") return "pi";
-	for (const e of entries.slice(0, 12)) {
+	// Scan ALL entries: Claude Code transcripts can open with an arbitrarily long run of
+	// non-message lines (summary/meta rows without a uuid) before the first real message.
+	for (const e of entries) {
 		if (e?.uuid && (e.type === "user" || e.type === "assistant")) return "claude";
 	}
 	return "unknown";

--- a/app/src/lib/engine/tokens.test.ts
+++ b/app/src/lib/engine/tokens.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { estTokens, clip, firstLine, BLOCK_OVERHEAD } from "./tokens";
+
+// tokens.ts is the engine's single (deliberately crude) token model: ~4 chars per
+// token plus a flat per-block overhead. Everything downstream — budget bar, fold
+// boundary, digest accounting — reads these numbers, so we pin the exact arithmetic.
+
+describe("estTokens", () => {
+	it("returns 0 for the empty string", () => {
+		expect(estTokens("")).toBe(0);
+	});
+
+	it("estimates ceil(length / 4)", () => {
+		expect(estTokens("abcd")).toBe(1); // exactly one 4-char token
+		expect(estTokens("abcde")).toBe(2); // 5 chars rounds UP, never down
+		expect(estTokens("x".repeat(400))).toBe(100);
+		expect(estTokens("x".repeat(401))).toBe(101);
+	});
+
+	it("counts raw characters, not words (whitespace costs too)", () => {
+		expect(estTokens("        ")).toBe(2); // 8 spaces / 4
+	});
+});
+
+describe("BLOCK_OVERHEAD", () => {
+	it("is the flat 4-token per-block structural cost", () => {
+		expect(BLOCK_OVERHEAD).toBe(4);
+	});
+});
+
+describe("clip", () => {
+	it("collapses all internal whitespace runs (incl. newlines/tabs) to single spaces and trims", () => {
+		expect(clip("  a   b\n\tc  ", 100)).toBe("a b c");
+	});
+
+	it("returns the normalized string untouched when it fits within n", () => {
+		expect(clip("hello", 5)).toBe("hello"); // length === n → no ellipsis
+	});
+
+	it("clips to at most n chars, ending in a single ellipsis", () => {
+		const out = clip("abcdefghij", 6);
+		expect(out).toBe("abcde…"); // slice(0, n-1) + "…"
+		expect(out.length).toBe(6);
+	});
+
+	it("trims trailing whitespace before appending the ellipsis (no 'word …')", () => {
+		expect(clip("abcd efgh", 6)).toBe("abcd…"); // 5th char is a space → trimmed off
+	});
+
+	it("guards n = 0 (and n = 1) to a floor of 1, yielding a lone ellipsis for long input", () => {
+		expect(clip("hello", 0)).toBe("…");
+		expect(clip("hello", 1)).toBe("…");
+		expect(clip("h", 0)).toBe("h"); // 1-char input fits the floored budget of 1
+	});
+});
+
+describe("firstLine", () => {
+	it("returns the first NON-BLANK line, trimmed", () => {
+		expect(firstLine("\n   \n  hello world  \nsecond line")).toBe("hello world");
+	});
+
+	it("returns the empty string when every line is blank (or input is empty)", () => {
+		expect(firstLine("")).toBe("");
+		expect(firstLine("\n  \n\t\n")).toBe("");
+	});
+
+	it("clips the chosen line to the given max length with an ellipsis", () => {
+		const out = firstLine("abcdefghijklmnop\nrest", 10);
+		expect(out).toBe("abcdefghi…");
+		expect(out.length).toBe(10);
+	});
+
+	it("defaults the max length to 100", () => {
+		const long = "z".repeat(150);
+		const out = firstLine(long);
+		expect(out.length).toBe(100);
+		expect(out.endsWith("…")).toBe(true);
+		// and a 100-char line passes through whole
+		expect(firstLine("y".repeat(100))).toBe("y".repeat(100));
+	});
+});

--- a/app/src/lib/live/claudeDiscovery.svelte.ts
+++ b/app/src/lib/live/claudeDiscovery.svelte.ts
@@ -9,6 +9,7 @@
  * stays a silent no-op and the sidebar section is simply empty.
  */
 import { isClaudeSession, type ClaudeCodeSession } from "./claude";
+import { isTauriEnv } from "../session.svelte";
 
 export const claudeDiscovery = $state<{
 	sessions: ClaudeCodeSession[];
@@ -38,7 +39,9 @@ async function refreshClaude(): Promise<void> {
 }
 
 export function startClaudeDiscovery(): void {
-	if (_timer !== null) return; // idempotent — already running
+	// Same internal guard as startDiscovery/startConductorDiscovery: outside Tauri the
+	// native command doesn't exist — don't spin an interval of failing dynamic imports.
+	if (!isTauriEnv || _timer !== null) return; // idempotent — already running
 	void refreshClaude();
 	_timer = setInterval(() => void refreshClaude(), 3000);
 }

--- a/app/src/lib/live/liveClient.malformed.test.ts
+++ b/app/src/lib/live/liveClient.malformed.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { connectLive, disconnectLive, live } from "./liveClient.svelte";
+import { session } from "../session.svelte";
+import { PROTOCOL_VERSION } from "./protocol";
+
+/*
+ * Malformed-frame hardening. The live WS is deliberately unauthenticated (tokenless
+ * Tauri dial), so any local process can put a frame on the wire. isServerMessage only
+ * vets the `type` tag — these tests pin that a hello without a real `meta` object and
+ * a sync without a real `blocks` array are absorbed gracefully instead of throwing
+ * mid-pump and stranding the client half-connected.
+ *
+ * Same FakeWebSocket pattern as liveClient.test.ts / conductorClient.test.ts.
+ */
+
+class FakeWebSocket {
+	static CONNECTING = 0;
+	static OPEN = 1;
+	static CLOSED = 3;
+	static last: FakeWebSocket | null = null;
+
+	readyState = FakeWebSocket.CONNECTING;
+	onopen: (() => void) | null = null;
+	onmessage: ((ev: { data: string }) => void) | null = null;
+	onerror: (() => void) | null = null;
+	onclose: (() => void) | null = null;
+	sent: string[] = [];
+
+	constructor(public url: string) {
+		FakeWebSocket.last = this;
+	}
+	send(data: string): void {
+		this.sent.push(data);
+	}
+	close(): void {
+		this.readyState = FakeWebSocket.CLOSED;
+		this.onclose?.();
+	}
+	// --- test drivers ---
+	open(): void {
+		this.readyState = FakeWebSocket.OPEN;
+		this.onopen?.();
+	}
+	emit(obj: unknown): void {
+		this.onmessage?.({ data: JSON.stringify(obj) });
+	}
+	frames(): any[] {
+		return this.sent.map((s) => JSON.parse(s));
+	}
+	framesOfType(t: string): any[] {
+		return this.frames().filter((f) => f.type === t);
+	}
+}
+
+let savedWS: unknown;
+let savedWindow: unknown;
+let hadWindow: boolean;
+
+beforeEach(() => {
+	savedWS = (globalThis as any).WebSocket;
+	hadWindow = "window" in globalThis;
+	savedWindow = (globalThis as any).window;
+	(globalThis as any).WebSocket = FakeWebSocket;
+	(globalThis as any).window = (globalThis as any).window ?? {};
+	FakeWebSocket.last = null;
+});
+
+afterEach(() => {
+	disconnectLive();
+	(globalThis as any).WebSocket = savedWS;
+	if (hadWindow) (globalThis as any).window = savedWindow;
+	else delete (globalThis as any).window;
+});
+
+function connectAndOpen(): FakeWebSocket {
+	connectLive(1234);
+	const ws = FakeWebSocket.last!;
+	ws.open();
+	return ws;
+}
+
+describe("liveClient — malformed frames from the unauthenticated WS", () => {
+	it("absorbs a hello with no meta object: connects with fallback meta instead of throwing", () => {
+		const ws = connectAndOpen();
+		expect(() =>
+			ws.emit({ type: "hello", protocolVersion: PROTOCOL_VERSION, sessionId: "s-x" }),
+		).not.toThrow();
+		expect(live.status).toBe("connected");
+		expect(session.store).not.toBeNull();
+		expect(session.store!.meta.title).toBe("live pi session");
+		expect(session.store!.meta.cwd).toBe("");
+	});
+
+	it("absorbs a hello whose meta is a non-object", () => {
+		const ws = connectAndOpen();
+		expect(() =>
+			ws.emit({ type: "hello", protocolVersion: PROTOCOL_VERSION, sessionId: "s-x", meta: 42 }),
+		).not.toThrow();
+		expect(live.status).toBe("connected");
+		expect(session.store!.meta.title).toBe("live pi session");
+	});
+
+	it("absorbs a sync with a non-array blocks field and still replies with a plan", () => {
+		const ws = connectAndOpen();
+		ws.emit({
+			type: "hello",
+			protocolVersion: PROTOCOL_VERSION,
+			sessionId: "s-x",
+			meta: { title: "t", cwd: "/tmp", model: "m", contextWindow: 1000 },
+		});
+		ws.sent.length = 0;
+		expect(() => ws.emit({ type: "sync", reqId: 7, full: false, blocks: "nope" })).not.toThrow();
+		// The pump survived: no blocks were added, and the plan reply still went out —
+		// a throw before the reply would leave the extension waiting for a plan timeout.
+		expect(session.store!.blocks).toHaveLength(0);
+		const plans = ws.framesOfType("plan");
+		expect(plans).toHaveLength(1);
+		expect(plans[0].reqId).toBe(7);
+	});
+
+	it("drops malformed ELEMENTS of a sync blocks array, keeps the valid ones, still replies", () => {
+		const ws = connectAndOpen();
+		ws.emit({
+			type: "hello",
+			protocolVersion: PROTOCOL_VERSION,
+			sessionId: "s-x",
+			meta: { title: "t", cwd: "/tmp", model: "m", contextWindow: 1000 },
+		});
+		ws.sent.length = 0;
+		const good = { id: "u:1", kind: "user", turn: 1, order: 0, text: "hi", tokens: 5 };
+		expect(() =>
+			ws.emit({
+				type: "sync",
+				reqId: 8,
+				full: false,
+				blocks: [null, {}, { id: "x", kind: "user" }, { ...good, kind: "nonsense" }, good],
+			}),
+		).not.toThrow();
+		expect(session.store!.blocks.map((b) => b.id)).toEqual(["u:1"]);
+		const plans = ws.framesOfType("plan");
+		expect(plans).toHaveLength(1);
+		expect(plans[0].reqId).toBe(8);
+	});
+});

--- a/app/src/lib/live/liveClient.svelte.ts
+++ b/app/src/lib/live/liveClient.svelte.ts
@@ -16,7 +16,7 @@ import { wireToBlock } from "./mapping";
 import { computeFoldOps, computeGroupOps, computeRecallOps, resolveUnfold, resolveRecall } from "./plan";
 import { folding, setFolding } from "./folding.svelte";
 import { activeRemoteRunner } from "./conductorClient.svelte";
-import { DEFAULT_PORT, PROTOCOL_VERSION, isServerMessage, type ServerMessage, type PlanMessage, type FoldOp, type GroupOp, type RecallOp, type UnfoldResultMessage, type RecallResultMessage, type CompleteRequestMessage, type ArmedMessage, type PassthroughCause } from "./protocol";
+import { DEFAULT_PORT, PROTOCOL_VERSION, isServerMessage, isWireBlock, type ServerMessage, type HelloMessage, type PlanMessage, type FoldOp, type GroupOp, type RecallOp, type UnfoldResultMessage, type RecallResultMessage, type CompleteRequestMessage, type ArmedMessage, type PassthroughCause } from "./protocol";
 import { ghostStart, ghostEnd, ghostClearAll } from "./ghostState.svelte";
 import type { CompletionRequest, CompletionResult } from "$conductors/contract";
 
@@ -279,6 +279,11 @@ export function connectLive(port: number = DEFAULT_PORT, opts: { host?: string; 
 		if (!isServerMessage(parsed)) return; // ignore anything off-protocol
 		const msg: ServerMessage = parsed;
 		if (msg.type === "hello") {
+			// The WS is deliberately unauthenticated (tokenless Tauri dial), so any local
+			// process can send a frame. isServerMessage only vets the `type` tag — guard the
+			// nested shape here rather than letting a malformed frame throw mid-pump and
+			// strand the client half-connected.
+			const meta: Partial<HelloMessage["meta"]> = msg.meta && typeof msg.meta === "object" ? msg.meta : {};
 			if (msg.protocolVersion !== PROTOCOL_VERSION) {
 				// Refuse a version mismatch loudly rather than driving the session with a wire
 				// shape one side does not understand (in M2 that would silently corrupt the fold
@@ -310,7 +315,7 @@ export function connectLive(port: number = DEFAULT_PORT, opts: { host?: string; 
 			budgetLive = false;
 			session.store?.dispose(); // abort the outgoing store's conductor (in-flight host.complete) before discarding it
 			session.store = new AccordionStore({
-				meta: { format: "pi", title: msg.meta.title || "live pi session", cwd: msg.meta.cwd || "", model: msg.meta.model || "" },
+				meta: { format: "pi", title: meta.title || "live pi session", cwd: meta.cwd || "", model: meta.model || "" },
 				blocks: [],
 				lineCount: 0,
 				skipped: 0,
@@ -320,9 +325,9 @@ export function connectLive(port: number = DEFAULT_PORT, opts: { host?: string; 
 			// there is no active model link.
 			session.store.completer = sendCompletion;
 			session.store.wireAttached = true; // live wire up → view mirrors the wire (issue #13)
-			if (typeof msg.meta.contextWindow === "number" && msg.meta.contextWindow > 0) {
-				session.store.setContextWindow(msg.meta.contextWindow);
-				session.store.setBudget(msg.meta.contextWindow);
+			if (typeof meta.contextWindow === "number" && meta.contextWindow > 0) {
+				session.store.setContextWindow(meta.contextWindow);
+				session.store.setBudget(meta.contextWindow);
 				budgetLive = true;
 			}
 		} else if (msg.type === "sync") {
@@ -372,7 +377,10 @@ export function connectLive(port: number = DEFAULT_PORT, opts: { host?: string; 
 			// keeps a birth-folding conductor from folding already-seen protected-tail content and
 			// sticking it in the sticky `birthFolded` exemption forever. A normal incremental append
 			// (`full:false`) omits the flag, so genuinely new blocks stay birth-foldable as before.
-			session.store.appendBlocks(msg.blocks.map(wireToBlock), { sent: msg.full });
+			// Same unauthenticated-WS caution as the hello path: a sync without a real blocks
+			// array — or with malformed elements — must not throw mid-pump (the plan reply
+			// below still runs) or corrupt the store's token accounting.
+			session.store.appendBlocks((Array.isArray(msg.blocks) ? msg.blocks : []).filter(isWireBlock).map(wireToBlock), { sent: msg.full });
 			const plan = computePlan();
 			const reply: PlanMessage = { type: "plan", reqId: msg.reqId, ops: plan.ops, groups: plan.groups, recalls: plan.recalls };
 			try {

--- a/app/src/lib/live/protocol.ts
+++ b/app/src/lib/live/protocol.ts
@@ -472,3 +472,25 @@ export function isServerMessage(v: unknown): v is ServerMessage {
 	const t = (v as any).type;
 	return t === "hello" || t === "sync" || t === "stream" || t === "unfoldRequest" || t === "recallRequest" || t === "completeResult" || t === "armedAck" || t === "passthrough";
 }
+
+const WIRE_KINDS = new Set(["user", "text", "thinking", "tool_call", "tool_result"]);
+
+/**
+ * Element-level guard for `SyncMessage.blocks`. `isServerMessage` vets only the `type`
+ * tag, and the WS is deliberately unauthenticated — a malformed element must be dropped
+ * at the pump, not thrown from `wireToBlock` (a mid-pump throw stalls the plan reply and
+ * the extension waits out its timeout) nor fed into the store as NaN token accounting.
+ */
+export function isWireBlock(v: unknown): v is WireBlock {
+	if (!v || typeof v !== "object") return false;
+	const b = v as Record<string, unknown>;
+	return (
+		typeof b.id === "string" &&
+		typeof b.kind === "string" &&
+		WIRE_KINDS.has(b.kind) &&
+		typeof b.turn === "number" &&
+		typeof b.order === "number" &&
+		typeof b.text === "string" &&
+		typeof b.tokens === "number"
+	);
+}

--- a/app/src/lib/session.svelte.ts
+++ b/app/src/lib/session.svelte.ts
@@ -44,8 +44,11 @@ export async function loadSample() {
 		if (!res.ok) throw new Error(`fetch failed (${res.status})`);
 		const text = await res.text();
 		if (token !== _loadToken) return; // a newer selection superseded this sample load — drop it
+		// Parse BEFORE disposing (same as _load): the SPA fallback can serve index.html with
+		// res.ok for a missing sample, and parse() must not leave a disposed store rendered.
+		const parsed = parse(text);
 		session.store?.dispose(); // abort the outgoing store's conductor (in-flight host.complete) before discarding it
-		session.store = new AccordionStore(parse(text));
+		session.store = new AccordionStore(parsed);
 		session.filePath = null;
 		session.readOnly = false;
 		_expose();
@@ -129,10 +132,13 @@ export async function loadFilePath(path: string): Promise<void> {
 async function _load(path: string, readFn: (p: string) => Promise<string>, token: number) {
 	const text = await readFn(path);
 	if (token !== _loadToken) return; // a newer selection superseded this load — drop it
+	// Parse BEFORE disposing: parse() throws on unrecognized/empty input (e.g. a transcript
+	// caught mid-rewrite on the tail poll), and the current store must survive a bad read.
+	const parsed = parse(text);
 	const prevBudget = session.store?.budget;
 	const prevProtect = session.store?.protectTokens;
 	session.store?.dispose(); // abort the outgoing store's conductor (in-flight host.complete) before discarding it
-	session.store = new AccordionStore(parse(text));
+	session.store = new AccordionStore(parsed);
 	if (prevBudget !== undefined) session.store.setBudget(prevBudget);
 	if (prevProtect !== undefined) session.store.setProtect(prevProtect);
 	session.filePath = path;
@@ -163,9 +169,18 @@ function _startPolling(path: string, readFn: (p: string) => Promise<string>, tok
 			const text = await readFn(path);
 			if (token !== _loadToken) return; // this poll belongs to a file/session that was superseded
 			if (text.length !== _lastLen) {
-				await _load(path, readFn, token);
+				try {
+					await _load(path, readFn, token);
+				} catch {
+					// Transient parse failure — the transcript was likely caught mid-rewrite
+					// (truncated/partial JSONL). The current store is intact (_load parses
+					// before disposing); keep tailing. _lastLen is only advanced on success,
+					// so the very next tick retries the read.
+				}
 			}
 		} catch {
+			// The READ itself failed (file gone, permission, native command error) — stop
+			// tailing; there is nothing to retry against.
 			if (token === _loadToken) _stopPolling();
 		}
 	}, 1500);


### PR DESCRIPTION
## What

Three small, independent robustness fixes plus test coverage for two previously-untested engine modules. Branched off and targeted at `devmain`.

### Loading resilience
- **`session._load` / `loadSample` parse before dispose.** `parse()` throws on unrecognized/empty input — a `~/.claude` transcript caught mid-rewrite by the 1.5s tail poll, or the SPA fallback serving `index.html` with `res.ok` for a missing sample. The old order disposed the current store *first*, so a bad read left `session.store` pointing at a disposed store with tailing silently dead.
- **`_startPolling` no longer kills tailing permanently on a transient parse failure.** The store is now intact after a bad read (parse-before-dispose), and `_lastLen` only advances on success, so the next tick retries. Only a failed *read* (file gone, permission) stops the poll.
- **`engine/parse` `detectFormat` scans all entries** for the Claude signature instead of only the first 12 — real CC transcripts can open with a long run of uuid-less summary/meta rows, which made legitimate transcripts unopenable (and, via the load bug above, fail silently on the poll path).

### Unauthenticated-WS hardening
The live WS is deliberately unauthenticated (tokenless Tauri dial), and `isServerMessage` vets only the `type` tag, so any local process can send a shape-invalid frame.
- **`liveClient` guards `hello.meta`** and adds an **element-level `isWireBlock` filter on `sync.blocks`.** Previously a malformed frame could throw mid-pump — stranding the client half-connected (hello) or stalling the extension's plan-reply until its timeout (sync) — or feed `NaN` token accounting into the store.
- **`claudeDiscovery` gains the same internal `isTauriEnv` guard** its two sibling discoveries already have, instead of relying on the sole caller to check.

## Tests
- New `parse.test.ts` (19) and `tokens.test.ts` (13) — both modules had **zero** direct tests; `parse` was only ever exercised as a fixture loader. Pins format sniffing (incl. the long-leading-meta Claude case), malformed-line tolerance, assistant-message splitting, callId linkage, turn counting, the empty-block drop rule, compaction entries, and token stamping.
- New `liveClient.malformed.test.ts` (4) pinning the malformed-frame behavior (missing/non-object meta, non-array blocks, malformed block elements).

## Verification
- `cd app && npx svelte-check` → **0 errors / 0 warnings**
- `cd app && npm run test` → **983 passing** (50 files)
- `cd extension && node smoke.mjs` → **PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)