### PR TITLE
feat(#93): show the system prompt — never foldable, counted in totals

### DIFF
--- a/app/src/lib/engine/store.svelte.ts
+++ b/app/src/lib/engine/store.svelte.ts
@@ -70,6 +70,10 @@ export class AccordionStore {
 	 *  forever (no offline calibration in v1). In live mode this arrives ONLY via the wire's `config`
 	 *  event (host-set, see `commandSink`'s doc comment) — never a local action a UI can trigger. */
 	calibration = $state(1);
+	/** The current effective system prompt (issue #93) — mirrors `truth.systemPrompt`. `null` until
+	 *  a live host's first `context` hook captures one; a demo/CC/file (local-mode) session never
+	 *  calls `setSystemPrompt`, so it stays `null` forever — an honest absence, not a placeholder. */
+	systemPrompt = $state<{ text: string; tokens: number } | null>(null);
 	/** Bumped on every truth event — the reactive redraw signal the forwarded reads depend on. */
 	version = $state(0);
 
@@ -105,6 +109,7 @@ export class AccordionStore {
 		this.contextWindow = this.truth.contextWindow;
 		this.protectTokens = this.truth.protectTokens;
 		this.calibration = this.truth.calibration;
+		this.systemPrompt = this.truth.systemPrompt;
 		this._locks = this.truth.locks;
 		this._holder = this.truth.lockHolder;
 		this._activeTail = this.truth.activeTailTokens;
@@ -140,6 +145,7 @@ export class AccordionStore {
 				if (e.contextWindow !== undefined) this.contextWindow = e.contextWindow;
 				if (e.protectTokens !== undefined) this.protectTokens = e.protectTokens;
 				if (e.calibration !== undefined) this.calibration = e.calibration;
+				if (e.systemPrompt !== undefined) this.systemPrompt = e.systemPrompt;
 				break;
 			case "locks":
 				this.syncOverlay();

--- a/app/src/lib/engine/store.test.ts
+++ b/app/src/lib/engine/store.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { AccordionStore } from "./store.svelte";
 import type { Block, ParsedSession } from "./types";
+import { Truth } from "$core/truth";
 
 // A protected block is NEVER folded — by the auto-folder OR the user. This is the
 // safety pillar; these tests lock it so it can't silently regress.
@@ -181,5 +182,33 @@ describe("local-only mutators refuse to run while a command sink is installed", 
 		expect(() => {
 			s.wireAttached = true;
 		}).not.toThrow();
+	});
+});
+
+// Issue #93: like `calibration`, `systemPrompt` is HOST-SET ONLY — there is no store-side setter a
+// UI action can call. It arrives purely as a mirrored read: seeded from the wrapped Truth at
+// construction, then kept in sync via the "config" case of `applyTruthEvent` whenever the Truth
+// underneath (a replica in live mode, replaying a wire event) emits one.
+describe("systemPrompt mirrors the wrapped Truth's config dial", () => {
+	it("seeds null when the Truth has no captured system prompt yet", () => {
+		const s = makeStore(2);
+		expect(s.systemPrompt).toBe(null);
+	});
+
+	it("seeds from an existingTruth that already has one captured (replica hydration path)", () => {
+		const parsed: ParsedSession = { meta: { format: "pi", title: "t", cwd: "", model: "" }, blocks: [], lineCount: 0, skipped: 0 };
+		const truth = new Truth(parsed);
+		truth.setSystemPrompt("You are a helpful assistant.", 8);
+		const s = new AccordionStore(parsed, truth);
+		expect(s.systemPrompt).toEqual({ text: "You are a helpful assistant.", tokens: 8 });
+	});
+
+	it("updates reactively when the underlying Truth emits a systemPrompt config event", () => {
+		const parsed: ParsedSession = { meta: { format: "pi", title: "t", cwd: "", model: "" }, blocks: [], lineCount: 0, skipped: 0 };
+		const truth = new Truth(parsed);
+		const s = new AccordionStore(parsed, truth);
+		expect(s.systemPrompt).toBe(null);
+		truth.setSystemPrompt("captured mid-session", 3); // mirrors a replica replaying an `applyWireEvent` config case
+		expect(s.systemPrompt).toEqual({ text: "captured mid-session", tokens: 3 });
 	});
 });

--- a/app/src/lib/ui/map/ContextMap.svelte
+++ b/app/src/lib/ui/map/ContextMap.svelte
@@ -109,6 +109,10 @@
 	// mutator and NEVER touches `group.folded`. Only the explicit "Unfold to context"
 	// button changes the wire. Mutated immutably (reassign a new Set) so `displayRows`
 	// re-derives.
+	// Issue #93: local expand/collapse for the system-prompt panel — it has no block id, so it has no
+	// Inspector route of its own; a self-contained toggle is the whole UI for it.
+	let spExpanded = $state(false);
+
 	let peeked = $state(new Set<string>());
 	function enterPeek(gid: string) {
 		const next = new Set(peeked);
@@ -1195,6 +1199,27 @@
 					</div>
 				</section>
 				{/if}
+				{#if store.systemPrompt}
+				<!-- Issue #93: the system prompt. Never a Block — no id, so nothing here can ever
+				     select/fold/pin/group it. Visually related to .box.prot (same accent-dim border
+				     language, "this box is structurally special") but deliberately distinct from it
+				     (dashed, dimmer fill) since a protected tail and the system prompt mean different
+				     things. Its tokens are already counted into the hero readout via
+				     Truth.liveTokens()/fullTokens() — no separate total shown here. -->
+				<section class="box sysprompt">
+					<header class="sp-head">
+						<Icon name="terminal" size={12} />
+						<span class="sp-label">System prompt</span>
+						<span class="sp-tok mono tnum">
+							{#if notAnchored}<span class="approx" aria-hidden="true">≈</span>{/if}{k(store.calTokens(store.systemPrompt.tokens))} tok
+						</span>
+						<button class="sp-toggle" onclick={() => (spExpanded = !spExpanded)}>{spExpanded ? "Hide" : "View"}</button>
+					</header>
+					{#if spExpanded}
+						<pre class="sp-text">{store.systemPrompt.text}</pre>
+					{/if}
+				</section>
+				{/if}
 			</div>
 		{:else}
 			<!-- TRANSCRIPT: the concretion. Blocks in conversation order, full text when live,
@@ -1640,6 +1665,57 @@
 		border: 3px solid var(--accent-dim);
 		background: var(--panel);
 		box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent), var(--shadow-1);
+	}
+	/* the system-prompt panel (issue #93): riffs on .box.prot's "structurally special" accent-dim
+	   border language for family resemblance, but dashed + the plain .box fill (not .box.prot's
+	   brighter one) so it reads as a DIFFERENT kind of special — never confused with the protected
+	   tail. Never a Block: no fold/pin/group affordance lives here, ever. */
+	.box.sysprompt {
+		border: 2px dashed var(--accent-dim);
+		background: var(--panel-2);
+		gap: var(--sp-2);
+	}
+	.sp-head {
+		display: flex;
+		align-items: center;
+		gap: var(--sp-2);
+		color: var(--muted);
+	}
+	.sp-label {
+		font-size: var(--fs-sm);
+		font-weight: 600;
+		flex: 1;
+	}
+	.sp-tok {
+		font-size: var(--fs-xs);
+		color: var(--faint);
+	}
+	.sp-toggle {
+		font-size: var(--fs-xs);
+		color: var(--muted);
+		background: transparent;
+		border: 1px solid var(--line);
+		border-radius: var(--radius-sm);
+		padding: 2px var(--sp-2);
+		cursor: pointer;
+	}
+	.sp-toggle:hover {
+		color: var(--text);
+		border-color: var(--accent-dim);
+	}
+	.sp-text {
+		margin: 0;
+		max-height: 320px;
+		overflow: auto;
+		white-space: pre-wrap;
+		word-break: break-word;
+		font-family: var(--mono);
+		font-size: var(--fs-xs);
+		color: var(--text);
+		background: var(--panel);
+		border: 1px solid var(--line);
+		border-radius: var(--radius-sm);
+		padding: var(--sp-2);
 	}
 
 	/* canvas-fill: flex wrapper for TileCanvas inside a box (fills the space after the rail). */

--- a/conductors/ws/thermocline/remote-sdk.mjs
+++ b/conductors/ws/thermocline/remote-sdk.mjs
@@ -404,6 +404,17 @@ var Truth = class _Truth {
   contextWindowTok = null;
   protectTokensTarget = 2e4;
   /**
+   * The current effective system prompt (issue #93), captured by the HOST ONLY from
+   * `ExtensionContext.getSystemPrompt()` on every `context` hook firing (never at `session_start`,
+   * which can race pi's own `resources_discover`-driven rebuild — see `extension/accordion.ts`'s
+   * `refreshFromCtx`). `null` until the first capture — cold start, and every read-only/demo/CC/file
+   * session forever (no live host ever calls the setter). Deliberately NOT a `Block`: it has no
+   * index, so `canFold`/`isProtected`/grouping/pin never see it — structurally, not just policy,
+   * exempt from folding. See `systemPrompt` getter and `setSystemPrompt`.
+   */
+  systemPromptText = null;
+  systemPromptTokensVal = 0;
+  /**
    * Provider-anchored calibration multiplier (issue #11, ADR 0025): `k = realTokens /
    * estimatedTokens` for the same request, snapped by the HOST ONLY (`setCalibration`, called from
    * the extension after pairing an assistant reply's real usage against the wire estimate that
@@ -513,6 +524,9 @@ var Truth = class _Truth {
     this.birthFolded = new Set(s.birthFolded);
     this.carriedSent = new Set(s.carriedSent);
     this.calibrationMul = Number.isFinite(s.calibration) && s.calibration > 0 ? s.calibration : 1;
+    const sp = s.systemPrompt;
+    this.systemPromptText = sp && typeof sp.text === "string" && Number.isFinite(sp.tokens) && sp.tokens >= 0 ? sp.text : null;
+    this.systemPromptTokensVal = this.systemPromptText === null ? 0 : Math.round(sp.tokens);
     this.lastChangedRev.clear();
     this.revCounter = s.rev;
     this.pfiCache = { rev: -1, value: 0 };
@@ -546,6 +560,8 @@ var Truth = class _Truth {
     next.holderLabel = prev.holderLabel;
     next.activeTailTok = prev.activeTailTok;
     next.calibrationMul = prev.calibrationMul;
+    next.systemPromptText = prev.systemPromptText;
+    next.systemPromptTokensVal = prev.systemPromptTokensVal;
     for (const b of next.blockLog) {
       const old = prev.get(b.id);
       if (!old) continue;
@@ -607,6 +623,10 @@ var Truth = class _Truth {
   get contextWindow() {
     return this.contextWindowTok;
   }
+  /** The current effective system prompt, or `null` if none has been captured yet. See the private field's doc. */
+  get systemPrompt() {
+    return this.systemPromptText === null ? null : { text: this.systemPromptText, tokens: this.systemPromptTokensVal };
+  }
   /** The current provider-anchored calibration multiplier (default 1). See `calibrationMul`'s doc. */
   get calibration() {
     return this.calibrationMul;
@@ -621,10 +641,12 @@ var Truth = class _Truth {
    * "convention" note on `TruthStats` for why calibrating every conductor read surface (rather than
    * leaving per-block reads raw) is the coherent choice. `protectedFromIndex()` does NOT call this
    * helper — it converts the TARGET into raw-estimate space with one division instead (see that
-   * method's doc for why). One multiplier necessarily SMEARS the fixed system-prompt/tool-schema
-   * overhead (which belongs to no block) proportionally across every block rather than carrying it
-   * as its own line item — `real = base + k·est` would be the honest affine model; this ships the
-   * pure multiplier knowingly (ADR 0025's Deferred section).
+   * method's doc for why). One multiplier necessarily SMEARS the fixed tool-schema overhead (which
+   * belongs to no block) proportionally across every block rather than carrying it as its own line
+   * item — `real = base + k·est` would be the honest affine model; this ships the pure multiplier
+   * knowingly (ADR 0025's Deferred section). As of issue #93, the system prompt is no longer part of
+   * that smear: `liveTokens()`/`fullTokens()` include it directly, so only tool-call-schema overhead
+   * remains folded into `k` (see `liveTokens()`'s doc and ADR 0025's addendum).
    */
   calTokens(n) {
     return Math.round(n * this.calibrationMul);
@@ -699,13 +721,22 @@ var Truth = class _Truth {
   foldedTokensOf(b) {
     return b.subst !== void 0 ? substTokens(b.subst) : digestTokens(b);
   }
+  /**
+   * Issue #93: includes the system prompt's raw token estimate (0 when uncaptured — every CC/demo/
+   * file session, and a live session before its first `context` hook). This un-smears the system
+   * prompt out of `extension/accordion.ts`'s calibration pairing (`pendingWireEst`), which reads this
+   * method directly — ADR 0025's documented "smearing caveat" previously absorbed the system prompt's
+   * real cost into `k` because `est` excluded it while `real` (provider usage) never did. Tool-schema
+   * overhead (also belonging to no block) remains smeared; only the system prompt's contribution is
+   * now a real, separately-estimated term. See the ADR's issue-#93 addendum.
+   */
   liveTokens() {
-    let n = 0;
+    let n = this.systemPromptTokensVal;
     for (const b of this.blockLog) n += this.effTokens(b);
     return n;
   }
   fullTokens() {
-    let n = 0;
+    let n = this.systemPromptTokensVal;
     for (const b of this.blockLog) n += b.tokens;
     return n;
   }
@@ -1090,6 +1121,21 @@ var Truth = class _Truth {
     this.contextWindowTok = n;
     const rev = ++this.revCounter;
     this.emit({ type: "config", contextWindow: this.contextWindowTok, rev });
+  }
+  /**
+   * HOST-ONLY (issue #93): set the current effective system prompt. Called from
+   * `extension/accordion.ts`'s `refreshFromCtx` on every `context` hook firing, only when the value
+   * actually changed (the caller diffs against `this.systemPrompt` first) — so in the common case
+   * this fires once near session start and never again. No `housekeep()` call: unlike `budget`/
+   * `protectTokens`/`calibration`, the system prompt occupies no block index and can never move
+   * `protectedFromIndex()`, so there is nothing to heal.
+   */
+  setSystemPrompt(text, tokens) {
+    if (typeof text !== "string" || !Number.isFinite(tokens) || tokens < 0) return;
+    this.systemPromptText = text;
+    this.systemPromptTokensVal = Math.round(tokens);
+    const rev = ++this.revCounter;
+    this.emit({ type: "config", systemPrompt: { text: this.systemPromptText, tokens: this.systemPromptTokensVal }, rev });
   }
   setProtect(n) {
     if (this.isLocked("tail-size")) return;
@@ -1655,6 +1701,9 @@ function hydrateSnapshot(meta, state) {
     // Optional on the wire (v18, same treatment as v15's `carriedSent` above); default to the
     // cold-start value `1` for a peer/test literal that omits it — the host serializer always emits it.
     calibration: state.calibration ?? 1,
+    // Optional AND nullable on the wire (v19, issue #93); default `null` for a peer/test literal
+    // that omits it — the host serializer always emits the field (as `null` before first capture).
+    systemPrompt: state.systemPrompt ?? null,
     rev: state.rev
   });
   return truth;
@@ -1672,6 +1721,7 @@ function applyWireEvent(truth, ev) {
       if (ev.contextWindow !== void 0 && ev.contextWindow !== null) truth.setContextWindow(ev.contextWindow);
       if (ev.protectTokens !== void 0) truth.setProtect(ev.protectTokens);
       if (ev.calibration !== void 0) truth.setCalibration(ev.calibration);
+      if (ev.systemPrompt !== void 0) truth.setSystemPrompt(ev.systemPrompt.text, ev.systemPrompt.tokens);
       return;
     case "locks":
       if (ev.locks.length) truth.setLocks(ev.locks, ev.holder ?? "", ev.tailTokens);
@@ -1763,7 +1813,7 @@ function recallHostEvent(ids, by, rev) {
 }
 
 // core/protocol.ts
-var PROTOCOL_VERSION = 18;
+var PROTOCOL_VERSION = 19;
 var SERVER_TYPES = /* @__PURE__ */ new Set([
   "hello",
   "snapshot",
@@ -1903,6 +1953,9 @@ function runRemoteConductor(conductor, opts) {
         },
         stats() {
           return replica.stats();
+        },
+        systemPrompt() {
+          return replica.systemPrompt;
         },
         countTokens(text) {
           return replica.calTokens(estTokens(text));

--- a/core/conductor/contract.ts
+++ b/core/conductor/contract.ts
@@ -153,6 +153,12 @@ export interface ConductorHost {
 	/** Aggregate readout of the current state. CALIBRATED — see `TruthStats`'s doc comment. */
 	stats(): TruthStats;
 	/**
+	 * The current effective system prompt, or `null` if none has been captured yet (issue #93).
+	 * Read-only — there is no `Op` kind for it, so it can never be a legal `propose()` target; it is a
+	 * scalar `Truth` fact, not a `Block`.
+	 */
+	systemPrompt(): { text: string; tokens: number } | null;
+	/**
 	 * Synchronous token estimate using the host's tokenizer, CALIBRATED (issue #11 stage 2, ADR 0025)
 	 * against the session's current `Truth.calibration` — same convention as `ViewBlock.tokens` /
 	 * `stats()`, so a conductor mixing this with either in one comparison (e.g. reserving output room

--- a/core/conductor/hostAdapter.test.ts
+++ b/core/conductor/hostAdapter.test.ts
@@ -167,6 +167,16 @@ describe("hostEventsFromTruthEvent — TruthEvent → HostEvent[] mapping", () =
 		expect(captured).toEqual([{ type: "state-changed", changes: [{ what: "protect", by: "you" }], rev: t.rev }]);
 	});
 
+	it("config (calibration) / config (systemPrompt) → NO HostEvent (both DISPLAY-only, invisible to a conductor)", () => {
+		const t = bulk(seq(2, 1000));
+		let captured: HostEvent[] = [];
+		t.onEvent((e) => (captured = hostEventsFromTruthEvent(t, e)));
+		t.setCalibration(1.5);
+		expect(captured).toEqual([]);
+		t.setSystemPrompt("a captured prompt", 5);
+		expect(captured).toEqual([]);
+	});
+
 	it("reset → resync", () => {
 		const t = bulk(seq(2, 1000));
 		t.setProtect(0);

--- a/core/conductor/hostAdapter.ts
+++ b/core/conductor/hostAdapter.ts
@@ -104,11 +104,12 @@ export function hostEventsFromTruthEvent(truth: Truth, e: TruthEvent): HostEvent
 		return changes.length ? [{ type: "state-changed", changes, rev: e.rev }] : [];
 	}
 	if (e.type === "config") {
-		// `calibration` (v18, issue #11 stage 1) is DISPLAY-only and must stay invisible to a
-		// conductor — it carries no `budget`/`protectTokens`/`contextWindow` field, so without this
-		// guard it would fall through to the `budget !== undefined ? "budget" : "protect"` default and
-		// get mislabeled a "protect" change, waking every subscribed conductor on every calibration
-		// snap (once per model reply) for a dial it was never meant to see.
+		// `calibration` (v18, issue #11 stage 1) and `systemPrompt` (v19, issue #93) are both
+		// DISPLAY-only (a conductor reads `systemPrompt` via `ConductorHost.systemPrompt()` directly
+		// instead) and must stay invisible as a `state-changed` notification — neither carries a
+		// `budget`/`protectTokens`/`contextWindow` field, so without this guard either would fall
+		// through to the `budget !== undefined ? "budget" : "protect"` default and get mislabeled a
+		// "protect" change, waking every subscribed conductor for a dial it was never meant to see.
 		if (e.budget === undefined && e.protectTokens === undefined && e.contextWindow === undefined) return [];
 		const what: StateChange["what"] = e.budget !== undefined ? "budget" : "protect";
 		return [{ type: "state-changed", changes: [{ what, by: "you" }], rev: e.rev }];

--- a/core/conductor/liveHost.test.ts
+++ b/core/conductor/liveHost.test.ts
@@ -145,6 +145,25 @@ describe("select — eager locks + attach broadcast", () => {
 	});
 });
 
+// Issue #93: LiveConductorHost.systemPrompt() is a thin pass-through to the live Truth's own
+// scalar — null with no live Truth, and the captured value once `Truth.setSystemPrompt` has run.
+describe("systemPrompt() — pass-through to the live Truth", () => {
+	it("returns null when there is no live Truth", () => {
+		const h = makeDeps(null);
+		const host = new LiveConductorHost(h.deps);
+		expect(host.systemPrompt()).toBeNull();
+	});
+
+	it("returns null before capture, and the captured value once Truth.setSystemPrompt has run", () => {
+		const t = bulk(textSeq(2));
+		const h = makeDeps(t);
+		const host = new LiveConductorHost(h.deps);
+		expect(host.systemPrompt()).toBeNull();
+		t.setSystemPrompt("You are a helpful assistant.", 8);
+		expect(host.systemPrompt()).toEqual({ text: "You are a helpful assistant.", tokens: 8 });
+	});
+});
+
 // ── fix 2: transactional attach — a failed create()/attach() must never strand a lock ──────────
 describe("select — a throwing create() never acquires a lock (fix 2a)", () => {
 	it("leaves Truth completely unlocked and nothing advertised active when the factory throws", () => {

--- a/core/conductor/liveHost.ts
+++ b/core/conductor/liveHost.ts
@@ -210,6 +210,9 @@ export class LiveConductorHost implements ConductorHost {
 	stats(): TruthStats {
 		return this.deps.truth()?.stats() ?? ZERO_STATS;
 	}
+	systemPrompt(): { text: string; tokens: number } | null {
+		return this.deps.truth()?.systemPrompt ?? null;
+	}
 	countTokens(text: string): number {
 		// Calibrated (issue #11 stage 2, ADR 0025) — see `ConductorHost.countTokens`'s doc. Falls back
 		// to the raw estimate when there is no live Truth (mirrors `ZERO_STATS`'s uncalibrated `stats()`
@@ -272,6 +275,7 @@ export class LiveConductorHost implements ConductorHost {
 			groups: () => this.groups(),
 			textOf: (id) => this.textOf(id),
 			stats: () => this.stats(),
+			systemPrompt: () => this.systemPrompt(),
 			countTokens: (text) => this.countTokens(text),
 			digestOf: (id) => this.digestOf(id),
 			complete: (req) => this.complete(req),

--- a/core/conductor/remote.ts
+++ b/core/conductor/remote.ts
@@ -229,6 +229,9 @@ export function runRemoteConductor(conductor: Conductor, opts: RemoteConductorOp
 				stats() {
 					return replica!.stats();
 				},
+				systemPrompt() {
+					return replica!.systemPrompt;
+				},
 				countTokens(text: string): number {
 					// Calibrated (issue #11 stage 2, ADR 0025) — see `ConductorHost.countTokens`'s doc. The
 					// replica carries the same `calibration` the host does (replicated via `config` events),

--- a/core/conductor/testhost.ts
+++ b/core/conductor/testhost.ts
@@ -60,6 +60,9 @@ export class TestHost implements ConductorHost {
 	stats(): TruthStats {
 		return this.truth.stats();
 	}
+	systemPrompt(): { text: string; tokens: number } | null {
+		return this.truth.systemPrompt;
+	}
 	countTokens(text: string): number {
 		// Calibrated (issue #11 stage 2, ADR 0025) — see `ConductorHost.countTokens`'s doc.
 		return this.truth.calTokens(estTokens(text));

--- a/core/events.ts
+++ b/core/events.ts
@@ -16,9 +16,18 @@ export type TruthEvent =
 	| { type: "appended"; blocks: Block[]; rev: number }
 	/** An `apply` transaction changed overlay/group state. `results` is the per-op outcome. */
 	| { type: "ops-applied"; by: Actor; results: OpResult[]; rev: number }
-	/** A config dial moved (budget / contextWindow / protectTokens / calibration). Only the changed
-	 *  field(s). `calibration` (v18) is HOST-set only — see `Truth.setCalibration`. */
-	| { type: "config"; budget?: number; contextWindow?: number | null; protectTokens?: number; calibration?: number; rev: number }
+	/** A config dial moved (budget / contextWindow / protectTokens / calibration / systemPrompt). Only
+	 *  the changed field(s). `calibration` (v18) is HOST-set only — see `Truth.setCalibration`.
+	 *  `systemPrompt` (v19, issue #93) is HOST-set only — see `Truth.setSystemPrompt`. */
+	| {
+			type: "config";
+			budget?: number;
+			contextWindow?: number | null;
+			protectTokens?: number;
+			calibration?: number;
+			systemPrompt?: { text: string; tokens: number };
+			rev: number;
+	  }
 	/** The involvement lock-set changed (setLocks / clearLocks). */
 	| { type: "locks"; locks: readonly LockName[]; holder: string | null; tailTokens: number; rev: number }
 	/** The sent cursor advanced (a plan actually reached the model). */

--- a/core/protocol.test.ts
+++ b/core/protocol.test.ts
@@ -35,8 +35,8 @@ import type {
 } from "./protocol";
 
 describe("PROTOCOL_VERSION", () => {
-	it("is bumped to 18 for provider-anchored token calibration (issue #11 stage 1, ADR 0025)", () => {
-		expect(PROTOCOL_VERSION).toBe(18);
+	it("is bumped to 19 for system prompt visibility (issue #93)", () => {
+		expect(PROTOCOL_VERSION).toBe(19);
 	});
 });
 
@@ -239,6 +239,41 @@ describe("v17 — notice message guard", () => {
 
 	it("rejects an unrecognized type (guards don't merely check for a `text` field)", () => {
 		expect(isServerMessage({ type: "notic", text: "typo'd type" })).toBe(false);
+	});
+});
+
+// ── v19: system prompt visibility (issue #93) ─────────────────────────────────
+describe("v19 — systemPrompt on SnapshotState / config WireEvent", () => {
+	const baseState = {
+		blocks: [],
+		overlay: [],
+		groups: [],
+		budget: 70_000,
+		contextWindow: null,
+		protectTokens: 20_000,
+		locks: [],
+		lockHolder: null,
+		tailTokens: 0,
+		sentThroughOrder: -1,
+		wireAttached: false,
+		foldingEnabled: false,
+		birthFolded: [],
+		rev: 0,
+	};
+
+	it("accepts a snapshot whose state carries a captured systemPrompt", () => {
+		const msg = { type: "snapshot" as const, state: { ...baseState, systemPrompt: { text: "You are helpful.", tokens: 4 } } };
+		expect(isServerMessage(msg)).toBe(true);
+	});
+
+	it("accepts a snapshot whose state carries systemPrompt: null (not yet captured)", () => {
+		const msg = { type: "snapshot" as const, state: { ...baseState, systemPrompt: null } };
+		expect(isServerMessage(msg)).toBe(true);
+	});
+
+	it("accepts a snapshot whose state OMITS systemPrompt entirely (pre-v19 literal, backward-compatible shape)", () => {
+		const msg = { type: "snapshot" as const, state: baseState };
+		expect(isServerMessage(msg)).toBe(true);
 	});
 });
 

--- a/core/protocol.ts
+++ b/core/protocol.ts
@@ -97,13 +97,26 @@
  *    client can never set it (only `extension/accordion.ts`'s own hook code calls
  *    `Truth.setCalibration`). Bumped so a pre-v18 peer (which has none of this vocabulary) cannot
  *    pair with a v18 host/client that assumes it.
+ *  - v19: system prompt visibility (issue #93). `SnapshotState` gains optional, nullable
+ *    `systemPrompt: { text, tokens } | null`; the `config` `WireEvent` gains the same optional
+ *    field; `ConductorHost` (`core/conductor/contract.ts`) gains a read-only `systemPrompt()`
+ *    accessor. Deliberately NOT a `Block` — no new `Op` kind, never foldable/groupable/pinnable,
+ *    structurally exempt rather than policy-exempt. `systemPrompt` is HOST-SET ONLY, same
+ *    treatment as `calibration` — there is no new `WireCommand` kind, only
+ *    `extension/accordion.ts`'s own `context`-hook code calls `Truth.setSystemPrompt`. Also
+ *    changes calibration PAIRING behavior: `Truth.liveTokens()`/`fullTokens()` (which
+ *    `pendingWireEst` reads directly) now include the system prompt's raw estimate, un-smearing it
+ *    out of the calibration multiplier `k` per ADR 0025's documented "smearing caveat" — `k` will
+ *    visibly shift (expected downward) on a session's first post-upgrade observation. Bumped so a
+ *    pre-v19 peer (which has none of this vocabulary) cannot pair with a v19 host/client that
+ *    assumes it.
  */
 import type { Actor, Group, Override } from "./types";
 import type { LockName } from "./locks";
 import { sanitizeOps, type Op, type OpResult } from "./ops";
 
 /** Bump on any breaking change to the message shapes below. */
-export const PROTOCOL_VERSION = 18;
+export const PROTOCOL_VERSION = 19;
 
 /**
  * The DOOR: a fixed, well-known loopback port that exactly ONE extension binds at a time as an
@@ -261,6 +274,14 @@ export interface SnapshotState {
 	 * back to the safe default, never a decision-affecting silent divergence.
 	 */
 	calibration?: number;
+	/**
+	 * The current effective system prompt (`Truth.systemPrompt`, v19, issue #93) — see the protocol
+	 * History note above. Optional AND nullable: a peer/test literal without the field still
+	 * type-checks (the v19 bump is the real cross-version gate, same treatment as `calibration`), and
+	 * a live session legitimately has `null` before its first `context` hook captures a value. A
+	 * hydrating replica defaults an absent field to `null` (same as an explicit `null`).
+	 */
+	systemPrompt?: { text: string; tokens: number } | null;
 	rev: number;
 }
 
@@ -281,7 +302,15 @@ export interface SnapshotState {
 export type WireEvent =
 	| { kind: "appended"; blocks: WireBlock[]; rev: number }
 	| { kind: "ops"; by: Actor; ops: Op[]; rev: number }
-	| { kind: "config"; budget?: number; contextWindow?: number | null; protectTokens?: number; calibration?: number; rev: number }
+	| {
+			kind: "config";
+			budget?: number;
+			contextWindow?: number | null;
+			protectTokens?: number;
+			calibration?: number;
+			systemPrompt?: { text: string; tokens: number };
+			rev: number;
+	  }
 	| { kind: "locks"; locks: LockName[]; holder: string | null; tailTokens: number; rev: number }
 	| { kind: "sent"; throughOrder: number; rev: number }
 	| { kind: "reset"; by: Actor; rev: number };

--- a/core/replica.test.ts
+++ b/core/replica.test.ts
@@ -105,6 +105,55 @@ describe("replica — carriedSent round trip (protocol v15)", () => {
 	});
 });
 
+// Issue #93: the system prompt is a scalar Truth fact (never a Block), captured host-side and
+// pushed to every replica over the same config-dial wire shape `calibration`/`contextWindow` use.
+// Unlike birthFolded/carriedSent, losing it on a stale peer is NOT a decision-affecting divergence
+// (it never feeds canFold/protectedFromIndex) — but it must still round-trip byte-identical so a
+// replica's displayed token total and panel content agree with the host's.
+describe("replica — systemPrompt round trip (protocol v19)", () => {
+	it("serializeSnapshot → hydrateSnapshot preserves the captured system prompt", () => {
+		const host = live();
+		host.append(seq(2, 1000));
+		host.setSystemPrompt("You are a helpful assistant.", 8);
+
+		const state = serializeSnapshot(host, false);
+		expect(state.systemPrompt).toEqual({ text: "You are a helpful assistant.", tokens: 8 });
+
+		const replica = hydrateSnapshot(META, state);
+		expect(replica.systemPrompt).toEqual({ text: "You are a helpful assistant.", tokens: 8 });
+		expect(replica.stats().fullTokens).toBe(host.stats().fullTokens);
+	});
+
+	it("a snapshot literal omitting systemPrompt (pre-v19 peer) hydrates to null, not undefined/poisoned", () => {
+		const host = live();
+		host.append(seq(2, 1000));
+		const state = serializeSnapshot(host, false);
+		const { systemPrompt: _drop, ...stale } = state;
+		const replica = hydrateSnapshot(META, stale as typeof state);
+		expect(replica.systemPrompt).toBe(null);
+	});
+
+	it("a config WireEvent carrying only systemPrompt replays onto a replica without touching other dials", () => {
+		const host = live();
+		host.append(seq(2, 1000));
+		const events: WireEvent[] = [];
+		const off = host.onEvent((e) => {
+			const w = wireEventFromTruthEvent(e);
+			if (w) events.push(w);
+		});
+		host.setSystemPrompt("prompt text", 3);
+		off();
+		const cfgEv = events.find((e) => e.kind === "config");
+
+		const replica = live();
+		replica.append(seq(2, 1000));
+		const budget0 = replica.budget;
+		applyWireEvent(replica, cfgEv!);
+		expect(replica.systemPrompt).toEqual({ text: "prompt text", tokens: 3 });
+		expect(replica.budget).toBe(budget0);
+	});
+});
+
 // Model-window budget clamp fix: a mid-session swap to a smaller-window model must shrink an
 // oversized budget, but the clamp policy lives in the extension's call sites (a plain follow-up
 // `setBudget` after `setContextWindow`), NOT inside `Truth.setContextWindow` itself — merging both

--- a/core/replica.ts
+++ b/core/replica.ts
@@ -60,6 +60,7 @@ export function serializeSnapshot(truth: Truth, foldingEnabled: boolean): Snapsh
 		birthFolded: [...truth.birthFoldedIds],
 		carriedSent: [...truth.carriedSentIds],
 		calibration: truth.calibration,
+		systemPrompt: truth.systemPrompt,
 		rev: truth.rev,
 	};
 }
@@ -100,6 +101,9 @@ export function hydrateSnapshot(meta: SessionMeta, state: SnapshotState): Truth 
 		// Optional on the wire (v18, same treatment as v15's `carriedSent` above); default to the
 		// cold-start value `1` for a peer/test literal that omits it — the host serializer always emits it.
 		calibration: state.calibration ?? 1,
+		// Optional AND nullable on the wire (v19, issue #93); default `null` for a peer/test literal
+		// that omits it — the host serializer always emits the field (as `null` before first capture).
+		systemPrompt: state.systemPrompt ?? null,
 		rev: state.rev,
 	});
 	return truth;
@@ -142,7 +146,15 @@ export function wireEventFromTruthEvent(e: TruthEvent): WireEvent | null {
 			return { kind: "ops", by: e.by, ops, rev: e.rev };
 		}
 		case "config":
-			return { kind: "config", budget: e.budget, contextWindow: e.contextWindow, protectTokens: e.protectTokens, calibration: e.calibration, rev: e.rev };
+			return {
+				kind: "config",
+				budget: e.budget,
+				contextWindow: e.contextWindow,
+				protectTokens: e.protectTokens,
+				calibration: e.calibration,
+				systemPrompt: e.systemPrompt,
+				rev: e.rev,
+			};
 		case "locks":
 			return { kind: "locks", locks: e.locks.slice(), holder: e.holder, tailTokens: e.tailTokens, rev: e.rev };
 		case "sent":
@@ -167,6 +179,7 @@ export function applyWireEvent(truth: Truth, ev: WireEvent): void {
 			if (ev.contextWindow !== undefined && ev.contextWindow !== null) truth.setContextWindow(ev.contextWindow);
 			if (ev.protectTokens !== undefined) truth.setProtect(ev.protectTokens);
 			if (ev.calibration !== undefined) truth.setCalibration(ev.calibration);
+			if (ev.systemPrompt !== undefined) truth.setSystemPrompt(ev.systemPrompt.text, ev.systemPrompt.tokens);
 			return;
 		case "locks":
 			if (ev.locks.length) truth.setLocks(ev.locks, ev.holder ?? "", ev.tailTokens);

--- a/core/truth.test.ts
+++ b/core/truth.test.ts
@@ -1203,3 +1203,150 @@ describe("Truth — calibration (issue #11 stage 1)", () => {
 		expect(replica.protectTokens).toBe(protect0);
 	});
 });
+
+// Issue #93: the system prompt as a scalar Truth fact — never a Block (no id, so no fold/pin/group
+// affordance can ever target it), captured/pushed via the same config-dial shape as `calibration`/
+// `contextWindow`, and folded into `liveTokens()`/`fullTokens()` (un-smearing it out of ADR 0025's
+// calibration pairing — see that ADR's issue-#93 addendum).
+describe("Truth — systemPrompt (issue #93)", () => {
+	it("defaults to null", () => {
+		const t = bulk(seq(2, 1000));
+		expect(t.systemPrompt).toBe(null);
+	});
+
+	it("setSystemPrompt sets it, bumps rev, and emits a config event", () => {
+		const t = bulk(seq(2, 1000));
+		const events: any[] = [];
+		t.onEvent((e) => events.push(e));
+		const rev0 = t.rev;
+
+		t.setSystemPrompt("You are a helpful assistant.", 8);
+		expect(t.systemPrompt).toEqual({ text: "You are a helpful assistant.", tokens: 8 });
+		expect(t.rev).toBe(rev0 + 1);
+		expect(events.at(-1)).toMatchObject({ type: "config", systemPrompt: { text: "You are a helpful assistant.", tokens: 8 } });
+
+		// A second call overwrites outright — no merge, no history.
+		t.setSystemPrompt("New prompt.", 3);
+		expect(t.systemPrompt).toEqual({ text: "New prompt.", tokens: 3 });
+		expect(t.rev).toBe(rev0 + 2);
+	});
+
+	it("refuses non-string text / non-finite / negative tokens — no poison, no rev bump, no event", () => {
+		const t = bulk(seq(2, 1000));
+		const rev0 = t.rev;
+		const events: any[] = [];
+		t.onEvent((e) => events.push(e));
+
+		t.setSystemPrompt(123 as unknown as string, 5);
+		t.setSystemPrompt("ok", NaN);
+		t.setSystemPrompt("ok", Infinity);
+		t.setSystemPrompt("ok", -1);
+		expect(t.systemPrompt).toBe(null); // unchanged, not poisoned
+		expect(t.rev).toBe(rev0);
+		expect(events.length).toBe(0);
+
+		t.setSystemPrompt("a real one", 4); // a real value still applies
+		expect(t.systemPrompt).toEqual({ text: "a real one", tokens: 4 });
+	});
+
+	it("liveTokens()/fullTokens() include the raw system-prompt estimate (un-smearing); blockCount is unaffected", () => {
+		const t = bulk(seq(4, 1000));
+		t.setProtect(0);
+		const before = t.stats();
+		expect(before.fullTokens).toBe(4000);
+		expect(before.liveTokens).toBe(4000);
+
+		t.setSystemPrompt("x".repeat(2000), 500);
+		const after = t.stats();
+		expect(after.fullTokens).toBe(4500);
+		expect(after.liveTokens).toBe(4500);
+		expect(after.blockCount).toBe(4); // block-only — untouched
+	});
+
+	it("is a no-op contribution when uncaptured (every CC/demo/file session)", () => {
+		const t = bulk(seq(3, 1000));
+		expect(t.systemPrompt).toBe(null);
+		expect(t.stats().liveTokens).toBe(3000);
+		expect(t.stats().fullTokens).toBe(3000);
+	});
+
+	it("computeProtectedFromIndex is unaffected — it walks raw block tokens directly, never through liveTokens()/fullTokens()", () => {
+		const withSp = bulk(seq(5, 1000));
+		withSp.setProtect(2500);
+		const pfiBefore = withSp.protectedFromIndex();
+		withSp.setSystemPrompt("x".repeat(40_000), 10_000); // a huge system prompt
+		expect(withSp.protectedFromIndex()).toBe(pfiBefore); // the tail boundary did not move
+	});
+
+	it("survives rebuildFrom (carried like calibration/budget), and a fresh build (prev === null) stays null", () => {
+		const host = live();
+		host.append(seq(3, 1000));
+		host.setSystemPrompt("captured prompt", 4);
+
+		const fresh = seq(3, 1000);
+		const next = Truth.rebuildFrom(host, { meta: META, blocks: fresh, lineCount: 0, skipped: 0 });
+		expect(next.systemPrompt).toEqual({ text: "captured prompt", tokens: 4 });
+
+		const firstBuild = Truth.rebuildFrom(null, { meta: META, blocks: fresh, lineCount: 0, skipped: 0 });
+		expect(firstBuild.systemPrompt).toBe(null); // not polluted by ANY prior state
+	});
+
+	it("round-trips through serializeSnapshot → hydrateSnapshot (replica replay parity)", () => {
+		const host = live();
+		host.append(seq(2, 1000));
+		host.setSystemPrompt("a prompt", 3);
+
+		const state = serializeSnapshot(host, false);
+		expect(state.systemPrompt).toEqual({ text: "a prompt", tokens: 3 });
+
+		const replica = hydrateSnapshot(META, state);
+		expect(replica.systemPrompt).toEqual({ text: "a prompt", tokens: 3 });
+		expect(replica.rev).toBe(host.rev);
+
+		// A stale-format peer that omits `systemPrompt` (pre-v19) falls back to null rather than
+		// forking on `undefined` — never a decision-affecting divergence.
+		const stale = hydrateSnapshot(META, { ...state, systemPrompt: undefined });
+		expect(stale.systemPrompt).toBe(null);
+	});
+
+	it("adoptSnapshot self-validates a malformed shape (bad text/tokens type) to null, same guard shape as calibration", () => {
+		const host = live();
+		host.append(seq(2, 1000));
+		const state = serializeSnapshot(host, false);
+
+		const badTokens = hydrateSnapshot(META, { ...state, systemPrompt: { text: "ok", tokens: NaN } });
+		expect(badTokens.systemPrompt).toBe(null);
+
+		const badText = hydrateSnapshot(META, { ...state, systemPrompt: { text: 5 as unknown as string, tokens: 3 } });
+		expect(badText.systemPrompt).toBe(null);
+
+		const negativeTokens = hydrateSnapshot(META, { ...state, systemPrompt: { text: "ok", tokens: -1 } });
+		expect(negativeTokens.systemPrompt).toBe(null);
+	});
+
+	it("a config event carrying ONLY systemPrompt replays via applyWireEvent without touching the other dials", () => {
+		const host = live();
+		host.append(seq(2, 1000));
+		const budget0 = host.budget;
+		const protect0 = host.protectTokens;
+
+		const events: WireEvent[] = [];
+		const off = host.onEvent((e) => {
+			const w = wireEventFromTruthEvent(e);
+			if (w) events.push(w);
+		});
+		host.setSystemPrompt("a prompt", 3);
+		off();
+		const cfgEv = events.find((e) => e.kind === "config");
+		expect(cfgEv).toMatchObject({ kind: "config", systemPrompt: { text: "a prompt", tokens: 3 } });
+		expect((cfgEv as any).budget).toBeUndefined();
+		expect((cfgEv as any).protectTokens).toBeUndefined();
+
+		const replica = live();
+		replica.append(seq(2, 1000));
+		applyWireEvent(replica, cfgEv!);
+		expect(replica.systemPrompt).toEqual({ text: "a prompt", tokens: 3 });
+		expect(replica.budget).toBe(budget0);
+		expect(replica.protectTokens).toBe(protect0);
+	});
+});

--- a/core/truth.ts
+++ b/core/truth.ts
@@ -150,6 +150,17 @@ export class Truth {
 	private contextWindowTok: number | null = null;
 	private protectTokensTarget = 20_000;
 	/**
+	 * The current effective system prompt (issue #93), captured by the HOST ONLY from
+	 * `ExtensionContext.getSystemPrompt()` on every `context` hook firing (never at `session_start`,
+	 * which can race pi's own `resources_discover`-driven rebuild — see `extension/accordion.ts`'s
+	 * `refreshFromCtx`). `null` until the first capture — cold start, and every read-only/demo/CC/file
+	 * session forever (no live host ever calls the setter). Deliberately NOT a `Block`: it has no
+	 * index, so `canFold`/`isProtected`/grouping/pin never see it — structurally, not just policy,
+	 * exempt from folding. See `systemPrompt` getter and `setSystemPrompt`.
+	 */
+	private systemPromptText: string | null = null;
+	private systemPromptTokensVal = 0;
+	/**
 	 * Provider-anchored calibration multiplier (issue #11, ADR 0025): `k = realTokens /
 	 * estimatedTokens` for the same request, snapped by the HOST ONLY (`setCalibration`, called from
 	 * the extension after pairing an assistant reply's real usage against the wire estimate that
@@ -270,6 +281,7 @@ export class Truth {
 		birthFolded: readonly string[];
 		carriedSent: readonly string[];
 		calibration: number;
+		systemPrompt: { text: string; tokens: number } | null;
 		rev: number;
 	}): void {
 		this.blockLog = s.blocks.slice();
@@ -286,6 +298,12 @@ export class Truth {
 		this.birthFolded = new Set(s.birthFolded);
 		this.carriedSent = new Set(s.carriedSent);
 		this.calibrationMul = Number.isFinite(s.calibration) && s.calibration > 0 ? s.calibration : 1;
+		// Self-validated exactly like `calibration` above — a malformed shape (bad `text`/`tokens` type,
+		// e.g. from a hand-built test literal or a corrupted wire frame) falls back to unset rather than
+		// poisoning `liveTokens()`/`fullTokens()` with NaN.
+		const sp = s.systemPrompt;
+		this.systemPromptText = sp && typeof sp.text === "string" && Number.isFinite(sp.tokens) && sp.tokens >= 0 ? sp.text : null;
+		this.systemPromptTokensVal = this.systemPromptText === null ? 0 : Math.round(sp!.tokens);
 		this.lastChangedRev.clear();
 		this.revCounter = s.rev;
 		// Rev-keyed read caches are stamped stale so they recompute against the adopted rev.
@@ -321,6 +339,12 @@ export class Truth {
 		next.holderLabel = prev.holderLabel;
 		next.activeTailTok = prev.activeTailTok;
 		next.calibrationMul = prev.calibrationMul;
+		// Issue #93: carried, unlike `contextWindow` — the system prompt IS a preserved captured fact,
+		// not a live re-derived one. `refreshFromCtx` runs before a rebuild can be triggered (it's called
+		// at the top of the `context` hook, before `ingestMessages`), so without this carry `next` would
+		// go stale until the extension's own post-build re-apply catches up on the NEXT hook tick.
+		next.systemPromptText = prev.systemPromptText;
+		next.systemPromptTokensVal = prev.systemPromptTokensVal;
 		for (const b of next.blockLog) {
 			const old = prev.get(b.id);
 			if (!old) continue;
@@ -414,6 +438,10 @@ export class Truth {
 	get contextWindow(): number | null {
 		return this.contextWindowTok;
 	}
+	/** The current effective system prompt, or `null` if none has been captured yet. See the private field's doc. */
+	get systemPrompt(): { text: string; tokens: number } | null {
+		return this.systemPromptText === null ? null : { text: this.systemPromptText, tokens: this.systemPromptTokensVal };
+	}
 	/** The current provider-anchored calibration multiplier (default 1). See `calibrationMul`'s doc. */
 	get calibration(): number {
 		return this.calibrationMul;
@@ -428,10 +456,12 @@ export class Truth {
 	 * "convention" note on `TruthStats` for why calibrating every conductor read surface (rather than
 	 * leaving per-block reads raw) is the coherent choice. `protectedFromIndex()` does NOT call this
 	 * helper — it converts the TARGET into raw-estimate space with one division instead (see that
-	 * method's doc for why). One multiplier necessarily SMEARS the fixed system-prompt/tool-schema
-	 * overhead (which belongs to no block) proportionally across every block rather than carrying it
-	 * as its own line item — `real = base + k·est` would be the honest affine model; this ships the
-	 * pure multiplier knowingly (ADR 0025's Deferred section).
+	 * method's doc for why). One multiplier necessarily SMEARS the fixed tool-schema overhead (which
+	 * belongs to no block) proportionally across every block rather than carrying it as its own line
+	 * item — `real = base + k·est` would be the honest affine model; this ships the pure multiplier
+	 * knowingly (ADR 0025's Deferred section). As of issue #93, the system prompt is no longer part of
+	 * that smear: `liveTokens()`/`fullTokens()` include it directly, so only tool-call-schema overhead
+	 * remains folded into `k` (see `liveTokens()`'s doc and ADR 0025's addendum).
 	 */
 	calTokens(n: number): number {
 		return Math.round(n * this.calibrationMul);
@@ -508,13 +538,22 @@ export class Truth {
 	foldedTokensOf(b: Block): number {
 		return b.subst !== undefined ? substTokens(b.subst) : digestTokens(b);
 	}
+	/**
+	 * Issue #93: includes the system prompt's raw token estimate (0 when uncaptured — every CC/demo/
+	 * file session, and a live session before its first `context` hook). This un-smears the system
+	 * prompt out of `extension/accordion.ts`'s calibration pairing (`pendingWireEst`), which reads this
+	 * method directly — ADR 0025's documented "smearing caveat" previously absorbed the system prompt's
+	 * real cost into `k` because `est` excluded it while `real` (provider usage) never did. Tool-schema
+	 * overhead (also belonging to no block) remains smeared; only the system prompt's contribution is
+	 * now a real, separately-estimated term. See the ADR's issue-#93 addendum.
+	 */
 	liveTokens(): number {
-		let n = 0;
+		let n = this.systemPromptTokensVal;
 		for (const b of this.blockLog) n += this.effTokens(b);
 		return n;
 	}
 	fullTokens(): number {
-		let n = 0;
+		let n = this.systemPromptTokensVal;
 		for (const b of this.blockLog) n += b.tokens;
 		return n;
 	}
@@ -936,6 +975,21 @@ export class Truth {
 		this.contextWindowTok = n;
 		const rev = ++this.revCounter;
 		this.emit({ type: "config", contextWindow: this.contextWindowTok, rev });
+	}
+	/**
+	 * HOST-ONLY (issue #93): set the current effective system prompt. Called from
+	 * `extension/accordion.ts`'s `refreshFromCtx` on every `context` hook firing, only when the value
+	 * actually changed (the caller diffs against `this.systemPrompt` first) — so in the common case
+	 * this fires once near session start and never again. No `housekeep()` call: unlike `budget`/
+	 * `protectTokens`/`calibration`, the system prompt occupies no block index and can never move
+	 * `protectedFromIndex()`, so there is nothing to heal.
+	 */
+	setSystemPrompt(text: string, tokens: number): void {
+		if (typeof text !== "string" || !Number.isFinite(tokens) || tokens < 0) return;
+		this.systemPromptText = text;
+		this.systemPromptTokensVal = Math.round(tokens);
+		const rev = ++this.revCounter;
+		this.emit({ type: "config", systemPrompt: { text: this.systemPromptText, tokens: this.systemPromptTokensVal }, rev });
 	}
 	setProtect(n: number): void {
 		// The human can no longer resize the tail under the `tail-size` lock (the holder owns it).

--- a/docs/adr/0025-token-calibration.md
+++ b/docs/adr/0025-token-calibration.md
@@ -1,8 +1,9 @@
 # ADR 0025 — Provider-anchored token calibration
 
 **Status:** accepted, stage 1 + stage 2 shipped (plumbing + display, then decision math; see the
-Stage 2 section below)
-**Date:** 2026-07-24 (stage 1) / 2026-07-24 (stage 2)
+Stage 2 section below); system-prompt un-smearing addendum shipped alongside issue #93 (see the
+Addendum section below)
+**Date:** 2026-07-24 (stage 1) / 2026-07-24 (stage 2) / 2026-07-24 (issue #93 addendum)
 **Builds on:** [ADR 0021](0021-truth-in-the-extension.md) (the Truth that owns every config dial in
 the pi extension process, and whose `context` hook is the one place the departing wire and pi's own
 `getContextUsage()` are both in scope), [ADR 0011](0011-conductor-involvement-locks.md) (the config-
@@ -184,7 +185,9 @@ each — never a per-block calibration inside `liveTokens()`/`fullTokens()` them
 raw accessors every other internal caller (`effTokens`, group accounting, `serializeWire`) still needs
 untouched. `budget`/`protectTokens`/`contextWindow`/`protectedFromIndex`/`blockCount` are unconverted
 (the first three are literal dial values under the convention above; the last two are already
-calibration-aware or structural facts, not token sums).
+calibration-aware or structural facts, not token sums). Issue #93's addendum (below) adds the system
+prompt's raw estimate into what `liveTokens()`/`fullTokens()` sum — the calibration mechanism here is
+otherwise unchanged, it's just summing one more raw quantity before the single `calTokens` call.
 
 ### The app: closing the hero/bar/flag disagreement stage 1 accepted
 
@@ -207,11 +210,11 @@ itself untouched) so a tile's visual weight matches its calibrated readout.
   (once per model reply) even though no block actually changed size — this was called out as an
   expected stage-2 consequence in the original version of this ADR, and stage 2 confirms it: it is the
   direct, intended effect of sizing the tail in real tokens rather than raw estimate tokens.
-- **Smearing is still real and visible per-block.** Unchanged from stage 1 — a single multiplier
-  cannot separate "this block is genuinely bigger than we estimated" from "the system prompt is bigger
-  than we estimated." Stage 2 makes the smeared number load-bearing for MORE decisions (the protected
-  boundary, a conductor's trigger) than stage 1 did (display only), so this caveat now matters more,
-  not less.
+- **Smearing is still real and visible per-block — for tool-call schemas.** Stage 2 makes the smeared
+  number load-bearing for MORE decisions (the protected boundary, a conductor's trigger) than stage 1
+  did (display only), so this caveat matters. The issue-#93 addendum (below) removed the system
+  prompt's contribution to this smear; a single multiplier still cannot separate "this block is
+  genuinely bigger than we estimated" from "the tool-call schemas are bigger than we estimated."
 - **One-turn lag, still present.** `k` reflects the LAST completed request — a session whose content
   shape just changed sharply sees the new `k`, and therefore the new protected-boundary/trigger
   behavior, only after that shift's own reply lands.
@@ -228,3 +231,31 @@ itself untouched) so a tile's visual weight matches its calibrated readout.
   far; the pure multiplier remains a documented simplification, not a placeholder.
 - **Smoothing / outlier rejection.** Once there is an affine fit to smooth, raw-snap-per-observation
   stops being the obviously-simplest option; revisit together with the affine work, not before.
+
+## Addendum (issue #93) — the system prompt is un-smeared from `k`
+
+Issue #93 made the system prompt a captured, visible fact (`Truth.systemPrompt`, `extension/
+accordion.ts`'s `refreshFromCtx` reading `ExtensionContext.getSystemPrompt()` on every `context` hook).
+That gave this ADR's "smearing caveat" a real fix for one of its two named terms.
+
+**Before:** `est` (`Truth.liveTokens()`/`fullTokens()`, what `pendingWireEst` records) summed block
+tokens only. `real` (the paired provider usage) always included the system prompt. `k = real/est`
+therefore absorbed the system prompt's actual cost, smeared proportionally across every block —
+exactly the "Smearing is still real and visible per-block" consequence stage 2 called out.
+
+**After:** `liveTokens()`/`fullTokens()` now add the system prompt's own raw `estTokens` estimate
+before summing blocks. `pendingWireEst` inherits this automatically (it reads `truth.liveTokens()`/
+`fullTokens()` directly, no separate change needed at its call site). `k` no longer needs to correct
+for a term it now has independently: only tool-call-schema overhead (the other, still-unaddressed
+"belongs to no block" term named in the original smearing caveat) remains folded into the multiplier.
+
+**Consequence:** `k` will visibly shift — expected downward — on a session's first calibration
+observation after upgrade, since a real, previously-hidden source of numerator inflation is now
+accounted for directly rather than smeared. This is a one-time, expected transition, not drift to
+investigate. Sessions with a large system prompt relative to their block content see the bigger shift;
+a session with a tiny or empty system prompt sees essentially none.
+
+**Scope note:** this is not the affine fit from Deferred above — `k` is still a single, un-clamped,
+un-smoothed multiplier (the Update Rule section is unchanged). It is a partial, mechanical
+un-smearing of ONE known-named fixed-cost term, made tractable only because issue #93 needed the
+system prompt's own token estimate captured anyway — not a step toward `base` as a fitted parameter.

--- a/extension/accordion.ts
+++ b/extension/accordion.ts
@@ -55,6 +55,7 @@ import type { ExtensionAPI, ExtensionContext, ExtensionCommandContext } from "@e
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 
 import { Truth } from "../core/truth";
+import { estTokens } from "../core/tokens";
 import { linearize, messageInfo, contentFingerprint, wireToBlock, type PiMessage } from "../core/wire";
 import { serializeSnapshot, wireEventFromTruthEvent } from "../core/replica";
 import { resolveUnfold, resolveRecall } from "../core/agentView";
@@ -505,6 +506,12 @@ export default function accordionLive(pi: ExtensionAPI, dependencies: RuntimeDep
 	let model = "";
 	let tokens: number | null = null;
 	let contextWindow: number | null = null;
+	// Issue #93: module-level cache of the most recently captured system prompt, same shape as
+	// `contextWindow` above and for the same reason — `refreshFromCtx` runs before `truth` may be
+	// null/about to be rebuilt (`ingestMessages` → `buildTruth`), so the captured value must survive
+	// that gap and get re-applied once a fresh `Truth` exists (see `buildTruth`'s re-apply).
+	let systemPromptText: string | null = null;
+	let systemPromptTokens = 0;
 	let heartbeat: ReturnType<typeof setInterval> | null = null;
 	// Set iff the HTTP server's bind failed (e.g. an unexpected EADDRINUSE on the ephemeral port).
 	// Previously the "error" listener discarded the error entirely, so `port` stayed 0
@@ -962,6 +969,21 @@ export default function accordionLive(pi: ExtensionAPI, dependencies: RuntimeDep
 			if (truth && contextWindow != null && truth.contextWindow !== contextWindow) {
 				truth.setContextWindow(contextWindow);
 				clampBudgetToWindow(truth, contextWindow);
+			}
+			// Issue #93: capture the CURRENT effective system prompt on every hook tick (never at
+			// `session_start` — that races pi's own `resources_discover`-driven rebuild, see
+			// `ExtensionContext.getSystemPrompt`'s call site history). `getSystemPrompt` is a cheap field
+			// read, not a rebuild, and reflects any per-turn `before_agent_start` override already
+			// applied — the effective prompt is NOT guaranteed static across a session (pi can rebuild it
+			// on a model/tool-set change), so this diffs on every tick rather than capturing once.
+			// Optionally-typed cast: guards a version-skewed pi host that predates this API.
+			const sp = (ctx as { getSystemPrompt?: () => string }).getSystemPrompt?.();
+			if (typeof sp === "string") {
+				systemPromptText = sp;
+				systemPromptTokens = estTokens(sp);
+			}
+			if (truth && systemPromptText !== null && truth.systemPrompt?.text !== systemPromptText) {
+				truth.setSystemPrompt(systemPromptText, systemPromptTokens);
 			}
 		} catch {
 			/* optional APIs */
@@ -2087,6 +2109,12 @@ export default function accordionLive(pi: ExtensionAPI, dependencies: RuntimeDep
 			if (!prev) t.setBudget(contextWindow);
 			else clampBudgetToWindow(t, contextWindow);
 		}
+		// Issue #93: re-apply the captured system prompt, same shape as `contextWindow` above. Covers
+		// the very-first-hook case (`refreshFromCtx` ran while `truth` was still null, so its own
+		// apply-if-changed branch was skipped) and is a harmless no-op confirmation on a later rebuild
+		// (`Truth.rebuildFrom` already carried `prev`'s identical value). Placed BEFORE `onEvent`
+		// subscribes below, so this call's own `config` event — if any — never double-broadcasts.
+		if (systemPromptText !== null) t.setSystemPrompt(systemPromptText, systemPromptTokens);
 		// One subscription drives BOTH the client fan-out (replayable events) and the in-process
 		// conductor's HostEvent stream — the same TruthEvent, projected two ways.
 		unsubTruth = t.onEvent((e) => {
@@ -2218,11 +2246,14 @@ export default function accordionLive(pi: ExtensionAPI, dependencies: RuntimeDep
 	 * compaction gap) and isolates exactly the one request `pendingWireEst` describes, rather than
 	 * blending in `ctx.getContextUsage()`'s own trailing-message estimate.
 	 *
-	 * SMEARING CAVEAT: `est` is Truth's own block-token accounting, which — by design — excludes the
-	 * system prompt and tool-call schemas (neither belongs to any block). `real` includes them. One
-	 * multiplier therefore distributes that fixed overhead PROPORTIONALLY across every block rather
-	 * than carrying it as its own line item — `real = base + k·est` would be the honest affine model;
-	 * we ship the pure multiplier knowingly (stage 1 scope; see ADR 0025 for the stage-2 plan).
+	 * SMEARING CAVEAT: `est` is Truth's own block-token accounting, which — by design — excludes
+	 * tool-call schemas (they belong to no block). `real` includes them. One multiplier therefore
+	 * distributes that fixed overhead PROPORTIONALLY across every block rather than carrying it as its
+	 * own line item — `real = base + k·est` would be the honest affine model; we ship the pure
+	 * multiplier knowingly (stage 1 scope; see ADR 0025 for the stage-2 plan). UPDATED (issue #93):
+	 * `est` (`truth.liveTokens()`/`fullTokens()`) now ALSO includes the system prompt's own raw
+	 * estimate, so as of the un-smearing fix, the system prompt is no longer part of this caveat —
+	 * only tool-call-schema overhead remains smeared into `k`. See ADR 0025's issue-#93 addendum.
 	 */
 	function maybeObserveCalibration(msg: unknown): void {
 		if (!truth) return;

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -3556,6 +3556,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"

--- a/extension/smoke.mjs
+++ b/extension/smoke.mjs
@@ -1140,6 +1140,52 @@ if (unfoldTool && foldCodeStr) {
 	}
 }
 
+// Issue #93: the one true end-to-end path for system-prompt capture — a REAL `ExtensionContext`
+// (well, this file's mock of one, but exercising the REAL `accordion.ts` hook code, not TestHost)
+// exposing `getSystemPrompt()`, fired through the real `context` hook, landing on the real live
+// Truth, and reaching a real client over the real WS wire as part of a real `snapshot` message.
+// ALSO proves the ADR 0025 un-smearing effect with a CONTROLLED A/B pair, both run here (not
+// compared against leftover calibration state from earlier in this file, which reflects DIFFERENT
+// fabricated real-usage values and would make any before/after comparison meaningless): the exact
+// SAME fabricated real usage is paired twice, once BEFORE the system prompt is captured and once
+// immediately AFTER — the only thing that changes between the two is `pendingWireEst` gaining the
+// system prompt's raw tokens, so `k` must shift DOWN, exactly the "expected downward" consequence
+// the ADR's addendum documents.
+{
+	const SMOKE_SYSTEM_PROMPT = "You are Accordion's smoke-test system prompt." + "x".repeat(4000); // large enough for its token cost to move k measurably
+	const PROBE_USAGE = { input: 5000, output: 999_999, cacheRead: 100, cacheWrite: 50 }; // real = 5150, output excluded — SAME for both probes below
+
+	// Probe 1 (baseline, no system prompt captured yet).
+	await Promise.resolve(handlers.context({ messages: messagesPlus }, ctx));
+	handlers.message_end({ message: { role: "assistant", content: [{ type: "text", text: "probe A" }], responseId: "resp-sp-probe-a", timestamp: T0 + 11, stopReason: "stop", usage: PROBE_USAGE } }, ctx);
+	a.inbox.snapshot.length = 0;
+	a.ws.send(JSON.stringify({ type: "resnapshot" }));
+	await waitFor(() => a.inbox.snapshot.length > 0, 2000, "baseline snapshot before system-prompt capture").catch(
+		() => fails.push("issue #93: baseline resnapshot before system-prompt capture produced no snapshot"),
+	);
+	const kBefore = a.inbox.snapshot.at(-1)?.state?.calibration;
+	if (typeof kBefore !== "number") fails.push("issue #93: expected a calibration observation on the baseline snapshot");
+
+	// Probe 2 (system prompt now captured — same messages, same real usage, larger estimate).
+	ctx.getSystemPrompt = () => SMOKE_SYSTEM_PROMPT;
+	await Promise.resolve(handlers.context({ messages: messagesPlus }, ctx)); // captures the prompt AND records the new (larger) pendingWireEst
+	handlers.message_end({ message: { role: "assistant", content: [{ type: "text", text: "probe B" }], responseId: "resp-sp-probe-b", timestamp: T0 + 12, stopReason: "stop", usage: PROBE_USAGE } }, ctx);
+	a.inbox.snapshot.length = 0;
+	a.ws.send(JSON.stringify({ type: "resnapshot" }));
+	await waitFor(() => a.inbox.snapshot.length > 0, 2000, "snapshot after system-prompt capture").catch(
+		() => fails.push("issue #93: resnapshot after system-prompt capture produced no snapshot"),
+	);
+	const snap = a.inbox.snapshot.at(-1);
+	const sp = snap?.state?.systemPrompt;
+	if (!sp || sp.text !== SMOKE_SYSTEM_PROMPT) fails.push(`issue #93: snapshot.state.systemPrompt.text expected ${JSON.stringify(SMOKE_SYSTEM_PROMPT)}, got ${JSON.stringify(sp)}`);
+	if (!sp || typeof sp.tokens !== "number" || sp.tokens <= 0) fails.push(`issue #93: snapshot.state.systemPrompt.tokens expected a positive number, got ${JSON.stringify(sp?.tokens)}`);
+
+	const kAfter = snap?.state?.calibration;
+	if (typeof kAfter !== "number") fails.push("issue #93: expected a calibration observation on the snapshot after system-prompt capture");
+	else if (typeof kBefore === "number" && kAfter >= kBefore)
+		fails.push(`issue #93 (ADR 0025 un-smearing): expected calibration to shift DOWN once the system prompt is included in pendingWireEst (before=${kBefore}, after=${kAfter})`);
+}
+
 a.ws.close();
 b.ws.close();
 await new Promise((r) => setTimeout(r, 50));


### PR DESCRIPTION
## Summary

Closes #93. Accordion's whole pitch is "see what the agent sees," but the system prompt — part of every model call, potentially thousands of tokens — was completely invisible: not rendered anywhere, not counted in any budget/token total.

- `Truth.systemPrompt` is a new scalar config dial, same shape as `contextWindow`/`budget`/`calibration` (private field + getter + setter that bumps `rev` and emits a `config` event) — **not a `Block`**, so it's structurally exempt from fold/pin/group rather than merely policy-exempt.
- Captured by `extension/accordion.ts` via `ExtensionContext.getSystemPrompt()` on every `context` hook firing (not `session_start`, which races pi's own `resources_discover`-driven prompt rebuild — verified against pi's own source). Diffs against the currently-stored value before writing, so in the common case this fires once near session start and stays silent for the rest of the session; per-turn drift (a model/tool-set change) is still caught rather than assumed away.
- `Truth.liveTokens()`/`fullTokens()` now include the system prompt's raw estimate. This un-smears it out of ADR 0025's documented calibration-pairing gap (`pendingWireEst` previously excluded the system prompt while real provider usage always included it, so the calibration multiplier `k` silently absorbed that cost into every block). Full addendum added to ADR 0025 explaining the expected one-time downward shift in `k`.
- Protocol bumped to v19: `SnapshotState`/`WireEvent` gain an optional `systemPrompt` field; replica (de)serialization round-trips it; a new read-only `ConductorHost.systemPrompt()` accessor is implemented across all three real hosts (`LiveConductorHost`, `TestHost`, the remote SDK) — never a legal `propose()` target.
- `ContextMap.svelte` renders a new panel below the protected-tail box: dashed accent-dim border (visually related to but distinct from `.box.prot`), gated on `store.systemPrompt` being non-null (absent — not a broken placeholder — for CC/demo/file sessions, which have no capture mechanism). Its tokens are already counted in the existing hero total; no separate line item.

## Test plan

- [x] `cd app && npm run check` — 0 errors, 0 warnings
- [x] `cd app && npm run test` — 746/746 passing, including new/extended coverage in `truth.test.ts`, `protocol.test.ts`, `replica.test.ts`, `liveHost.test.ts`, `hostAdapter.test.ts`, `store.test.ts`
- [x] `cd extension && node smoke.mjs` — passing, including a new controlled A/B proving the calibration multiplier genuinely shifts once the system prompt is captured (not just that the field round-trips)
- [x] `cd extension && npm pack --dry-run` — full pipeline (app build → client copy → extension bundle → remote-sdk rebuild → both smoke suites → tarball) succeeds
- [ ] Manual: open the desktop/browser app against a live pi session and visually confirm panel placement, expand/collapse, and that the hero token count already includes it (not yet done — needs a live pi session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)