### PR TITLE
Inspector: show head+tail instead of head-only when clipping large block content

### DIFF
--- a/app/src/lib/ui/map/Inspector.svelte
+++ b/app/src/lib/ui/map/Inspector.svelte
@@ -27,7 +27,8 @@
 		tool_result: "Tool result",
 	};
 
-	const CAP = 6000;
+	const HEAD_CAP = 3000;
+	const TAIL_CAP = 3000;
 	const fmt = (n: number) => n.toLocaleString();
 
 	const folded = $derived(block ? store.isFolded(block) : false);
@@ -60,12 +61,28 @@
 	const canFoldPartner = $derived(partner ? store.canFold(partner) : false);
 	const partnerFolded = $derived(partner ? store.isFolded(partner) : false);
 
-	function body(b: Block): { text: string; clipped: number } {
+	function body(
+		b: Block,
+	): { text: string; clipped: number } | { head: string; tail: string; clipped: number; omitted: number } {
 		const t = b.text ?? "";
-		return t.length > CAP ? { text: t.slice(0, CAP) + "…", clipped: t.length } : { text: t, clipped: 0 };
+		if (t.length <= HEAD_CAP + TAIL_CAP) return { text: t, clipped: 0 };
+		return {
+			head: t.slice(0, HEAD_CAP),
+			tail: t.slice(-TAIL_CAP),
+			clipped: t.length,
+			omitted: t.length - HEAD_CAP - TAIL_CAP,
+		};
 	}
 
 	const bd = $derived(block ? body(block) : { text: "", clipped: 0 });
+
+	// flat single-slice preview for the compact partner strip (unlike the main content
+	// view, this one isn't split into head/tail — it's just a short peek)
+	function previewText(b: Block): string {
+		const t = b.text ?? "";
+		const cap = HEAD_CAP + TAIL_CAP;
+		return t.length > cap ? t.slice(0, cap) + "…" : t;
+	}
 
 	const isMono = $derived(block?.kind === "tool_call" || block?.kind === "tool_result");
 
@@ -342,14 +359,24 @@
 				<span class="eyebrow section-eyebrow">Content</span>
 			{/if}
 
-			<pre
-				class="content"
-				class:content-mono={isMono}
-			>{bd.text}</pre>
+			{#if "text" in bd}
+				<pre
+					class="content"
+					class:content-mono={isMono}
+				>{bd.text}</pre>
+			{:else}
+				<pre
+					class="content"
+					class:content-mono={isMono}
+				>{bd.head}</pre>
+				<div class="gap-note mono">⋯ {fmt(bd.omitted)} chars omitted ⋯</div>
+				<pre
+					class="content"
+					class:content-mono={isMono}
+				>{bd.tail}</pre>
 
-			{#if bd.clipped}
 				<p class="clip-note mono">
-					showing first {fmt(CAP)} of {fmt(bd.clipped)} chars
+					showing first {fmt(HEAD_CAP)} and last {fmt(TAIL_CAP)} of {fmt(bd.clipped)} chars
 				</p>
 			{/if}
 		</div>
@@ -390,7 +417,7 @@
 					{partnerFolded ? "Unfold" : canFoldPartner ? "Fold" : partnerProtected ? "Protected" : "Fold"} partner
 				</button>
 
-				<pre class="partner-preview mono">{body(partner).text}</pre>
+				<pre class="partner-preview mono">{previewText(partner)}</pre>
 			</div>
 		{/if}
 	</aside>
@@ -807,6 +834,14 @@
 
 	.clip-note {
 		margin: 0;
+		font-size: var(--fs-xs);
+		color: var(--faint);
+		letter-spacing: 0.04em;
+	}
+
+	.gap-note {
+		margin: 0.5rem 0;
+		text-align: center;
 		font-size: var(--fs-xs);
 		color: var(--faint);
 		letter-spacing: 0.04em;


### PR DESCRIPTION
## Summary
- When a block's content exceeds 6,000 chars, the Inspector's content panel now shows the first 3,000 and last 3,000 chars (instead of just the first 6,000), with a `⋯ N chars omitted ⋯` gap marker between them.
- Footer note updated to `showing first 3,000 and last 3,000 of N chars`.
- The compact partner-preview strip (call/result pairing) keeps its original flat single-slice behavior — it's a short peek, not the main content view this change targets.

## Test plan
- [x] `npx svelte-check --tsconfig ./tsconfig.json` — 0 errors / 0 warnings
- [x] `npx vitest run` — 47 files, 927 tests passing
- [ ] Manual UI check in `npm run tauri dev`: open a block with >6,000 chars and confirm head/gap/tail rendering


---
_Generated by [Claude Code](https://claude.ai/code/session_01HDFxukM11TAVUmnB8QRoGV)_