### PR TITLE
fix: restore system block dice weight cue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,6 +184,7 @@ Colors are brand **Spectrum** identity colors — defined in [brand/accordion-br
 
 | kind | hex |
 |------|-----|
+| `system` | `#FFF6A4` |
 | `user` | `#044EFF` |
 | `text` | `#1AA6E8` |
 | `thinking` | `#B480DF` |
@@ -196,7 +197,7 @@ Colors are brand **Spectrum** identity colors — defined in [brand/accordion-br
 - Group tiles use the current chestnut group palette from `app/src/app.css`: `--group #7C5230 · --group-edge #0A0A0A · --group-accent #E8E8E8`. Summary/sliver tiles stay dark neutral via `--k-summary`.
 - Dark surfaces: `--bg #0A0A0A`, `--panel #1C1C1C` — no blue tint (blue is reserved for `user` blocks)
 - Fonts: **IBM Plex Sans** (`--sans`) / **IBM Plex Mono** (`--mono`) via `@fontsource` in `routes/+layout.svelte`
-- **Map grid:** every block is the same-size square in conversation order. Token weight = dice face 1–6. Thresholds in `ContextMap.svelte → faceFor()`: ≤100→1 · ≤500→2 · ≤1.5k→3 · ≤5k→4 · ≤15k→5 · >15k→6
+- **Map grid:** every block is the same-size square in conversation order. Token weight = dice face 1–6, including the bolted `system` block; that tile adds four inset Smoke-gray L corners as its immutable-context cue without replacing the dice face. Thresholds in `ContextMap.svelte → faceFor()`: ≤100→1 · ≤500→2 · ≤1.5k→3 · ≤5k→4 · ≤15k→5 · >15k→6
 - **Two-box layout:** grid splits at `store.protectedFromIndex` — foldable region above (thin border), protected tail below (thick accented border, `.box.prot`)
 
 ## Pi extension hooks

--- a/app/src/app.css
+++ b/app/src/app.css
@@ -31,17 +31,15 @@
 	--ok: #5CB88A;             /* muted green */
 	--warn: #D6A24E;           /* muted amber — kept distinct from peach --k-tool_result */
 
-	/* block kinds — track the brand Spectrum identity (brand/accordion-brand-kit/brand.md).
-	   These VALUES intentionally override the former "DO NOT CHANGE" contract: the spectrum
-	   is now the canonical block-kind palette. Names are still load-bearing — do not rename. */
+	/* block kinds — track the semantic brand palette (brand/accordion-brand-kit/brand.md).
+	   Names are load-bearing — do not rename. */
 	--k-user: #044EFF;
 	--k-text: #1AA6E8;         /* brand spectrum azure — the assistant-reply spine
 	                              (a real gradient stop, distinct from the 4 kinds; not gray) */
 	--k-thinking: #B480DF;
 	--k-tool_call: #21D4C1;
 	--k-tool_result: #E19C7D;
-	--k-system: #7D6EE6;       /* brand spectrum indigo — the bolted `system` kind (v22);
-	                              the one gradient stop no other kind had claimed yet */
+	--k-system: #FFF6A4;       /* pale fixed-context yellow — the bolted `system` kind (v22) */
 	/* synthesized-summary tile (sliver fold mode) — dark neutral recessed tone; distinct
 	   from a folded group's brown so the summary never collides */
 	--k-summary: #2A2A2A;

--- a/app/src/lib/ui/map/tileDraw.test.ts
+++ b/app/src/lib/ui/map/tileDraw.test.ts
@@ -1,5 +1,68 @@
 import { describe, it, expect } from "vitest";
-import { faceFor, computeGeometry, tileRectCss, hitTest, desaturate, resetSprites, getSprites, type TileSpec } from "./tileDraw";
+import {
+  faceFor,
+  computeGeometry,
+  tileRectCss,
+  hitTest,
+  desaturate,
+  resetSprites,
+  getSprites,
+  drawTile,
+  type Palette,
+  type TileSpec,
+} from "./tileDraw";
+
+type DrawCall = {
+  type: "drawImage" | "stroke" | "moveTo" | "lineTo";
+  image?: CanvasImageSource;
+  strokeStyle?: string | CanvasGradient | CanvasPattern;
+  lineWidth?: number;
+  x?: number;
+  y?: number;
+};
+
+function recordingContext(): { ctx: CanvasRenderingContext2D; calls: DrawCall[] } {
+  const calls: DrawCall[] = [];
+  const raw = {
+    fillStyle: "",
+    strokeStyle: "",
+    lineWidth: 1,
+    lineCap: "butt",
+    lineJoin: "miter",
+    globalAlpha: 1,
+    save() {},
+    restore() {},
+    beginPath() {},
+    closePath() {},
+    fill() {},
+    clip() {},
+    arc() {},
+    arcTo() {},
+    setLineDash() {},
+    moveTo(x: number, y: number) { calls.push({ type: "moveTo", x, y }); },
+    lineTo(x: number, y: number) { calls.push({ type: "lineTo", x, y }); },
+    stroke() {
+      calls.push({ type: "stroke", strokeStyle: raw.strokeStyle, lineWidth: raw.lineWidth });
+    },
+    drawImage(image: CanvasImageSource) { calls.push({ type: "drawImage", image }); },
+  };
+  return { ctx: raw as unknown as CanvasRenderingContext2D, calls };
+}
+
+const DRAW_PALETTE: Palette = {
+  kindColors: {
+    system: "#FFF6A4",
+    user: "#044EFF",
+    text: "#1AA6E8",
+    thinking: "#B480DF",
+    tool_call: "#21D4C1",
+    tool_result: "#E19C7D",
+  },
+  accent: "#E8E8E8",
+  accentDim: "#2C2C2C",
+  group: "#7C5230",
+  groupAccent: "#E8E8E8",
+};
 
 // ---------------------------------------------------------------------------
 // faceFor
@@ -48,6 +111,58 @@ describe("buildSprites — face 0 produces a blank sprite (no pips)", () => {
     // verify the exported faceFor thresholds don't collide with 0, and that
     // faceFor(0) still returns 1 (the caller must pass 0 explicitly for drop groups).
     expect(faceFor(0)).toBe(1); // faceFor never returns 0 — callers pass 0 directly
+  });
+});
+
+describe("drawTile — system block visual grammar", () => {
+  const spec: TileSpec = {
+    id: "sys:0",
+    kind: "system",
+    face: 5,
+    folded: false,
+    pinned: false,
+    selected: false,
+    inrange: false,
+  };
+
+  it("draws the calibrated dice-face sprite instead of replacing it with a glyph", () => {
+    const { ctx, calls } = recordingContext();
+    const face5 = {} as HTMLCanvasElement;
+
+    drawTile(ctx, { x: 10, y: 20, w: 40, h: 40 }, spec, DRAW_PALETTE, new Map([[5, face5]]));
+
+    expect(calls.find((call) => call.type === "drawImage")?.image).toBe(face5);
+  });
+
+  it("draws option J's heavy Smoke corners as the final layer above selection", () => {
+    const { ctx, calls } = recordingContext();
+    const face5 = {} as HTMLCanvasElement;
+
+    drawTile(
+      ctx,
+      { x: 10, y: 20, w: 40, h: 40 },
+      { ...spec, selected: true },
+      DRAW_PALETTE,
+      new Map([[5, face5]]),
+    );
+
+    const selectionStroke = calls.findIndex(
+      (call) => call.type === "stroke" && call.strokeStyle === DRAW_PALETTE.accent,
+    );
+    const cornerStroke = calls.findIndex(
+      (call) => call.type === "stroke" && call.strokeStyle === "#9A9A9A",
+    );
+    expect(selectionStroke).toBeGreaterThanOrEqual(0);
+    expect(cornerStroke).toBeGreaterThan(selectionStroke);
+    expect(calls[cornerStroke].lineWidth).toBeCloseTo(1.8);
+
+    const cornerMoves = calls.filter((call) => call.type === "moveTo").slice(-4);
+    const expectedMoves = [[13.2, 30.4], [39.6, 23.2], [46.8, 49.6], [20.4, 56.8]];
+    expect(cornerMoves).toHaveLength(expectedMoves.length);
+    cornerMoves.forEach((call, index) => {
+      expect(call.x).toBeCloseTo(expectedMoves[index][0]);
+      expect(call.y).toBeCloseTo(expectedMoves[index][1]);
+    });
   });
 });
 

--- a/app/src/lib/ui/map/tileDraw.ts
+++ b/app/src/lib/ui/map/tileDraw.ts
@@ -81,9 +81,9 @@ export function readPalette(): Palette {
   const v = (name: string) => s.getPropertyValue(name).trim();
   return {
     kindColors: {
-      // Brand Spectrum indigo — the bolted `system` kind (v22). Fill color for the bolt-head
-      // tile drawn by `drawTile`/`drawBoltHead` below; see CLAUDE.md "Visual grammar".
-      system: v("--k-system") || "#7D6EE6",
+      // Pale fixed-context yellow — the bolted `system` kind (v22). It uses the same dice-face
+      // weight grammar as every other block, plus neutral corner brackets drawn below.
+      system: v("--k-system") || "#FFF6A4",
       user: v("--k-user") || "#044EFF",
       text: v("--k-text") || "#1AA6E8",
       thinking: v("--k-thinking") || "#B480DF",
@@ -515,33 +515,20 @@ export function drawTile(
     ctx.stroke();
   }
 
-  // ---- bolt head (BOLTED kinds) INSTEAD OF dice pips, or dice pips (blitted from sprite) ----
-  // The `system` kind draws a hex bolt head in place of its dice face — never on top of it.
-  // Dice faces 4/5/6 place pips in the tile's corners, so a corner rivet motif would collide,
-  // and a centre-only overlay would just fight the existing centre pip on faces 1/3/5. A bolted
-  // block also never folds (`isBolted` in core/digest.ts), so there is no drained/dimmed variant
-  // to handle here — the glyph is always drawn at full strength. Below ~9px the stroked hexagon
-  // degrades to an indistinct smudge, so it's skipped there; the indigo fill alone still marks
-  // the tile as different from its neighbours at that size.
-  if (spec.kind === "system") {
-    if (Math.min(w, h) >= 9) drawBoltHead(ctx, x + w / 2, y + h / 2, Math.min(w, h) * BOLT_RADIUS_RATIO);
-  } else {
-    // Folded tiles KEEP their dice face (the old DOM showed pips at the cell's
-    // .36 opacity). Drawing them dimmed-but-visible keeps a folded block reading
-    // as "a recessed version of the colored tile," not a blank square.
-    const spriteCanvas = sprites.get(spec.face);
-    if (spriteCanvas) {
-      if (spec.folded) {
-        // Drained tiles read as near-black recessed squares — keep the pips a faint
-        // ghost (the weight is still legible up close) so the tile doesn't sprout
-        // loud white dots that fight the drain. Hover relights toward full.
-        ctx.save();
-        ctx.globalAlpha = opts.hovered ? 0.7 : 0.22;
-        ctx.drawImage(spriteCanvas, x, y, w, h);
-        ctx.restore();
-      } else {
-        ctx.drawImage(spriteCanvas, x, y, w, h);
-      }
+  // ---- dice pips (blitted from sprite) ----
+  // Every block kind, including the bolted `system` prompt, keeps the shared weight grammar.
+  // Folded tiles retain their face as a dim ghost so they still read as recessed versions of
+  // the same weighted block. (`system` can never fold, but using the common path here prevents
+  // its immutable status from erasing its token-size signal again.)
+  const spriteCanvas = sprites.get(spec.face);
+  if (spriteCanvas) {
+    if (spec.folded) {
+      ctx.save();
+      ctx.globalAlpha = opts.hovered ? 0.7 : 0.22;
+      ctx.drawImage(spriteCanvas, x, y, w, h);
+      ctx.restore();
+    } else {
+      ctx.drawImage(spriteCanvas, x, y, w, h);
     }
   }
 
@@ -595,43 +582,62 @@ export function drawTile(
     ctx.stroke();
   }
 
+  // The system prompt is a normal weighted block with one extra immutable-context cue. Draw the
+  // brackets LAST so selection/hover overlays never cover them; they remain on the tile itself,
+  // inset from the ordinary selection ring rather than becoming an outside decoration.
+  if (spec.kind === "system") drawSystemCorners(ctx, x, y, w, h);
+
   ctx.restore();
 }
 
 // ---------------------------------------------------------------------------
-// Bolt head — the BOLTED-kind mark (see CLAUDE.md "Visual grammar")
+// System corners — the BOLTED-kind mark (see CLAUDE.md "Visual grammar")
 // ---------------------------------------------------------------------------
 
-/** Hex radius as a fraction of the tile's short side — leaves a margin so the glyph
- *  never touches the tile's edge/rings (pinned, in-range, selected all stroke inset). */
-const BOLT_RADIUS_RATIO = 0.3;
+const SYSTEM_CORNER_COLOR = "#9A9A9A"; // Smoke — neutral, distinct from every block-kind hue
+const SYSTEM_CORNER_INSET_RATIO = 0.08;
+const SYSTEM_CORNER_ARM_RATIO = 0.18;
+const SYSTEM_CORNER_STROKE_RATIO = 0.045; // approved option J: heavy, same-length arms
 
 /**
- * Draw a hex "bolt head" glyph centered at (cx, cy): a stroked hexagon, flat edge
- * top/bottom (per the settled design), plus a small filled centre dot. SAME geometry
- * as the `bolt` icon in `Icon.svelte` (six vertices at 0/60/120/180/240/300°, radius r)
- * so the map tile, the transcript row flag, and the Inspector pill read as one metaphor
- * rather than three unrelated marks. No gradient, no ctx.filter — a plain stroke + a
- * plain fill, safe to run per-tile because there is exactly ONE system tile per session.
+ * Draw four heavy Smoke-gray L brackets inside the system tile's corners. The ratios are the
+ * approved option J treatment: 8% inset, 18% arms, 4.5% stroke. The minimum stroke keeps the
+ * immutable cue legible at the grid's smallest densities without affecting dice-sprite caching.
  */
-function drawBoltHead(ctx: CanvasRenderingContext2D, cx: number, cy: number, r: number): void {
+function drawSystemCorners(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+): void {
+  const size = Math.min(w, h);
+  const inset = size * SYSTEM_CORNER_INSET_RATIO;
+  const arm = size * SYSTEM_CORNER_ARM_RATIO;
+  const left = x + inset;
+  const right = x + w - inset;
+  const top = y + inset;
+  const bottom = y + h - inset;
+
   ctx.save();
   ctx.beginPath();
-  for (let i = 0; i < 6; i++) {
-    const a = (Math.PI / 180) * (i * 60);
-    const px = cx + r * Math.cos(a);
-    const py = cy - r * Math.sin(a); // canvas y grows down; negate to keep flat top/bottom
-    if (i === 0) ctx.moveTo(px, py);
-    else ctx.lineTo(px, py);
-  }
-  ctx.closePath();
-  ctx.strokeStyle = "rgba(255,255,255,0.82)";
-  ctx.lineWidth = Math.max(1, r * 0.16);
+  ctx.moveTo(left, top + arm);
+  ctx.lineTo(left, top);
+  ctx.lineTo(left + arm, top);
+  ctx.moveTo(right - arm, top);
+  ctx.lineTo(right, top);
+  ctx.lineTo(right, top + arm);
+  ctx.moveTo(right, bottom - arm);
+  ctx.lineTo(right, bottom);
+  ctx.lineTo(right - arm, bottom);
+  ctx.moveTo(left + arm, bottom);
+  ctx.lineTo(left, bottom);
+  ctx.lineTo(left, bottom - arm);
+  ctx.strokeStyle = SYSTEM_CORNER_COLOR;
+  ctx.lineWidth = Math.max(0.75, size * SYSTEM_CORNER_STROKE_RATIO);
+  ctx.lineCap = "square";
+  ctx.lineJoin = "miter";
   ctx.stroke();
-  ctx.beginPath();
-  ctx.arc(cx, cy, Math.max(1, r * 0.16), 0, Math.PI * 2);
-  ctx.fillStyle = "rgba(255,255,255,0.9)";
-  ctx.fill();
   ctx.restore();
 }
 

--- a/brand/accordion-brand-kit/brand.md
+++ b/brand/accordion-brand-kit/brand.md
@@ -79,9 +79,11 @@ Replace marketing language with observable facts. If a claim can't be seen in th
 
 ## Color
 
-Monochrome base carries everything; the six **spectrum** colors are semantic — each names a block
-kind in the product (and together they form the brand gradient). Never set body text in a spectrum
-hue, and never pair two spectrum hues as foreground/background. Maintain 4.5:1 contrast for body copy.
+Monochrome base carries everything. Five **spectrum** colors name conversational block kinds; the
+bolted system prompt uses a separate pale fixed-context yellow so its permanent floor reads apart
+from the conversation. The spectrum hues still form the brand gradient, with indigo retained as its
+bridge between user blue and thinking purple. Never set body text in a semantic hue, and never pair
+two semantic hues as foreground/background. Maintain 4.5:1 contrast for body copy.
 
 | Token | Hex | RGB | CMYK (approx) | Role |
 |---|---|---|---|---|
@@ -92,7 +94,7 @@ hue, and never pair two spectrum hues as foreground/background. Maintain 4.5:1 c
 | Cloud | `#E8E8E8` | 232, 232, 232 | 0,0,0,9 | Borders, dividers |
 | Paper | `#F6F6F6` | 246, 246, 246 | 0,0,0,4 | Background surfaces |
 | White | `#FFFFFF` | 255, 255, 255 | 0,0,0,0 | Base canvas |
-| System | `#7D6EE6` | 125, 110, 230 | 46,52,0,10 | Block kind: bolted system prompt |
+| System | `#FFF6A4` | 255, 246, 164 | 0,4,36,0 | Block kind: bolted system prompt |
 | User | `#044EFF` | 4, 78, 255 | 98,69,0,0 | Block kind: user message |
 | Reply | `#1AA6E8` | 26, 166, 232 | 89,28,0,9 | Block kind: assistant reply |
 | Thinking | `#B480DF` | 180, 128, 223 | 19,43,0,13 | Block kind: thinking |


### PR DESCRIPTION
## What changed

- Render the bolted system block through the same calibrated 1–6 dice-face path as every other map block.
- Replace the tile’s bolt-head glyph with the approved option J treatment: four heavy Smoke-gray L brackets drawn as the final inset layer so selection and hover do not cover them.
- Change the system kind color to `#fff6a4` and update the app token, canvas fallback, visual grammar, and brand source together.
- Add focused renderer regressions for the dice sprite and corner/selection draw order.

## Why

The system-specific canvas branch replaced the dice sprite with a bolt icon, erasing the map’s token-weight signal for that block. The system prompt still consumes context, so it must participate in the same dice grammar while retaining a separate immutable-context cue.

## Impact

The system prompt now reads as an ordinary weighted block with a distinct fixed-context color and corner treatment. Its engine-level bolted behavior is unchanged.

## Validation

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 807 passed, 20 skipped
- `npm pack --dry-run` — production app build, browser client copy, extension bundle, both smoke suites, conductor spawn, and tarball inspection passed
- Local browser preview — `--k-system` resolved to `#FFF6A4`; no console errors