### PR TITLE
Open any block as a .md file in the default program (#119)

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ use std::time::UNIX_EPOCH;
 
 use serde_json::Value;
 use tauri::Manager;
+use tauri_plugin_opener::OpenerExt;
 
 // Per-process cache for head-reads: path → (mtime_ms, title, cwd).
 // Avoids re-reading unchanged files on every 3-second poll.
@@ -540,6 +541,25 @@ fn read_claude_session(path: String) -> Result<String, String> {
     fs::read_to_string(&target).map_err(|e| format!("read failed: {e}"))
 }
 
+/// Write text to a temp `.md` file and open it with the OS's default handler for the
+/// extension (issue #119) — whatever the user already has associated with .md (VS Code,
+/// Notes, etc.), so a block's full content can be read outside the Inspector's clipped
+/// preview. Written into the OS temp dir and never explicitly deleted: the external
+/// program needs the file to persist while it's open, and OS temp dirs are periodically
+/// cleared on their own — the same "don't take up permanent storage" tradeoff the issue asked for.
+#[tauri::command]
+fn open_text_as_md(app: tauri::AppHandle, text: String) -> Result<(), String> {
+    let millis = std::time::SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let path = std::env::temp_dir().join(format!("accordion-block-{millis}.md"));
+    fs::write(&path, text).map_err(|e| format!("could not write temp file: {e}"))?;
+    app.opener()
+        .open_path(path.to_string_lossy().to_string(), None::<String>)
+        .map_err(|e| format!("could not open file: {e}"))
+}
+
 fn focus_main_window(app: &tauri::AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
         let _ = window.unminimize();
@@ -572,7 +592,8 @@ pub fn run() {
             read_claude_session,
             launch_mock_session,
             stop_mock_session,
-            mock_session_running
+            mock_session_running,
+            open_text_as_md
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/app/src/lib/ui/map/Inspector.svelte
+++ b/app/src/lib/ui/map/Inspector.svelte
@@ -4,6 +4,7 @@
 	import type { AccordionStore } from "../../engine/store.svelte";
 	import type { Block, Group } from "../../engine/types";
 	import { isBolted } from "$core/digest";
+	import { isTauriEnv } from "$lib/session.svelte";
 	import Icon from "$lib/ui/Icon.svelte";
 
 	let {
@@ -91,6 +92,57 @@
 
 	// Block mode: is this block part of a group? Used to render the "part of group" link.
 	const inGroup = $derived(block ? store.groupOf(block) : null);
+
+	// "Open as .md" (issue #119) — view-only, so it's offered regardless of steerLocked or
+	// bolted (the RULE: observation is never gated, only mutating controls are).
+	let openBusy = $state(false);
+	let openError = $state("");
+
+	function markdownFor(b: Block): string {
+		const stateBits = [folded ? "folded" : "live"];
+		if (protect) stateBits.push("protected");
+		if (pinned) stateBits.push("pinned");
+		if (bolted) stateBits.push("bolted");
+		const tok = store.calBlockTokens(b, folded ? store.effTokens(b) : b.tokens);
+		const header = [
+			`# ${KIND_LABEL[b.kind]} block`,
+			"",
+			`- kind: ${b.kind}`,
+			`- turn: ${bolted ? "preamble" : `turn ${b.turn}`}`,
+			`- tokens: ${fmt(tok)}`,
+			`- state: ${stateBits.join(", ")}`,
+			"",
+			"---",
+			"",
+		];
+		return header.join("\n") + (b.text ?? "");
+	}
+
+	async function openAsMd() {
+		if (!block) return;
+		const md = markdownFor(block);
+		openBusy = true;
+		openError = "";
+		try {
+			if (isTauriEnv) {
+				const { invoke } = await import("@tauri-apps/api/core");
+				await invoke("open_text_as_md", { text: md });
+			} else {
+				// Browser-served: no filesystem/shell access from the tab, so fall back
+				// to a plain download the user opens themselves.
+				const url = URL.createObjectURL(new Blob([md], { type: "text/markdown" }));
+				const a = document.createElement("a");
+				a.href = url;
+				a.download = `accordion-${block.id.replace(/[^a-zA-Z0-9_-]/g, "_")}.md`;
+				a.click();
+				URL.revokeObjectURL(url);
+			}
+		} catch (e) {
+			openError = e instanceof Error ? e.message : String(e);
+		} finally {
+			openBusy = false;
+		}
+	}
 
 	// Group mode derived values. Token readouts calibrated (issue #11 stage 1) — display only.
 	const gMembers = $derived(group ? store.groupMembers(group) : []);
@@ -364,6 +416,24 @@
 				</button>
 			</div>
 			{/if}
+
+			<!-- Open as .md (issue #119) — view-only, so it's offered even when bolted or locked. -->
+			<div class="action-row">
+				<button
+					class="action-btn action-outline"
+					class:action-disabled={openBusy}
+					disabled={openBusy}
+					aria-disabled={openBusy}
+					onclick={openAsMd}
+					title={isTauriEnv
+						? "Write the full block to a temp .md file and open it in your default program"
+						: "Download the full block as a .md file"}
+				>
+					<Icon name="file-text" size={14} />
+					{isTauriEnv ? "Open as .md" : "Download as .md"}
+				</button>
+				{#if openError}<span class="open-md-error mono">{openError}</span>{/if}
+			</div>
 		</div>
 
 		<!-- ── Body ───────────────────────────────────────────────── -->
@@ -690,6 +760,11 @@
 		align-items: center;
 		gap: var(--sp-2);
 		flex-wrap: wrap;
+	}
+
+	.open-md-error {
+		font-size: var(--fs-xs);
+		color: var(--danger);
 	}
 
 	/* ── Button system (brand spec) ─────────────────────────── */

--- a/app/src/lib/ui/map/Inspector.svelte
+++ b/app/src/lib/ui/map/Inspector.svelte
@@ -104,18 +104,9 @@
 		if (pinned) stateBits.push("pinned");
 		if (bolted) stateBits.push("bolted");
 		const tok = store.calBlockTokens(b, folded ? store.effTokens(b) : b.tokens);
-		const header = [
-			`# ${KIND_LABEL[b.kind]} block`,
-			"",
-			`- kind: ${b.kind}`,
-			`- turn: ${bolted ? "preamble" : `turn ${b.turn}`}`,
-			`- tokens: ${fmt(tok)}`,
-			`- state: ${stateBits.join(", ")}`,
-			"",
-			"---",
-			"",
-		];
-		return header.join("\n") + (b.text ?? "");
+		const turnLabel = bolted ? "preamble" : `turn ${b.turn}`;
+		const header = `> ${KIND_LABEL[b.kind]} — ${turnLabel} · ${fmt(tok)} tok · ${stateBits.join(", ")}`;
+		return header + "\n\n" + (b.text ?? "");
 	}
 
 	async function openAsMd() {


### PR DESCRIPTION
## Summary
- Adds an "Open as .md" button to the Inspector's block action row (view-only, so it's offered even on bolted/locked blocks).
- On desktop (Tauri): writes the block's full text — plus a small metadata header (kind, turn, tokens, state) — to a temp `.md` file in the OS temp dir via a new `open_text_as_md` Rust command, then opens it with the OS default handler through the already-bundled `tauri-plugin-opener`. The file is left in the OS temp dir (not explicitly cleaned up), matching the issue's "tmp file, don't take up permanent storage" ask.
- In browser-served mode (no Tauri backend, no filesystem/shell access from the tab): falls back to a plain browser download of the `.md` instead.

Closes #119.

## Test plan
- [x] `npx svelte-check` — 0 errors / 0 warnings
- [x] `cargo check` (app/src-tauri) — clean
- [x] Verified in `npm run dev` (browser-served path): loaded the bundled demo session, selected a block in the Inspector, confirmed the button renders as "Download the full block as a .md file" and triggers a download with no console errors
- [ ] Manual click-through of the Tauri desktop path (writes temp file + opens via OS default handler) — not exercised by an automated agent in this PR; please sanity-check locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)