### PR TITLE
docs(readme): refresh stale content since the hackathon

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,23 +106,44 @@ agent reasons over at full fidelity (the thick-bordered box below the fold line)
 
 ## The conductors
 
-Five ship today. Pick one from the header menu, or leave it on None and steer by hand.
+A conductor is a strategy for deciding what gets folded. It watches the session and proposes
+edits between turns, and every edit goes through the same rules your own hand folds do, so a
+conductor can never do something you couldn't do yourself. Five ship today. Pick one from the
+header menu, or leave it on None and steer everything by hand.
 
-| Conductor | What it does | Runs |
-|---|---|---|
-| **[thermocline](conductors/ws/thermocline/)** | Attention-gated compression under a hard budget cap. A small probe model scores how much the recent context still attends to each block, and the coldest ones get compressed first. | out of process |
-| **[triptych](conductors/ws/triptych/)** | Splits the context into thirds. The recent third stays raw, the middle turns code reads into tree-sitter skeletons (signatures kept, bodies dropped, still recoverable), the oldest third gets summarized. | out of process |
-| **[doorman](conductors/in-process/doorman/)** | Folds a huge tool result before the model ever sees it. | in process |
-| **[handoff](conductors/in-process/handoff/)** | Writes a real handoff document and folds the whole prior session behind it. | in process |
-| **[compaction-naive](conductors/in-process/compaction-naive/)** | A deliberately lossy `/compact` clone. It is the baseline the others get measured against. | in process |
+**[thermocline](conductors/ws/thermocline/)** is the strongest one so far, and the one the
+benchmark above used. It combines two earlier experiments: a small probe model that scores how
+much the recent context still attends to each block, which decides the order things get
+compressed in, and real LLM summaries, which decide how far each one gets compressed. On top of
+both it enforces a hard budget, and when your cap is genuinely impossible to hit it says so
+instead of quietly blowing past it.
+
+**[triptych](conductors/ws/triptych/)** came out of asking what actually fills a coding session
+up, which is almost always file reads. It splits the context into three bands by age: the recent
+third is left alone, the middle band turns code reads into tree-sitter skeletons that keep every
+signature and drop the bodies, and the oldest third gets summarized. The skeletons stay
+recoverable, so the agent can pull the full source back with `recall` when it needs it.
+
+**[doorman](conductors/in-process/doorman/)** fixes one specific problem. A huge tool result
+lands inside the protected tail the moment it arrives, so the model sees it at full size on the
+very first call, which is the exact thing a folding tool is supposed to prevent. Doorman catches
+those on their way out and folds them before they ever reach the model.
+
+**[handoff](conductors/in-process/handoff/)** automates the thing people already do by hand when
+a session gets too long: ask the agent to write a handoff document, kill the session, then paste
+that document into a fresh one. It does all three without you leaving the session.
+
+**[compaction-naive](conductors/in-process/compaction-naive/)** is a deliberately lossy clone of
+`/compact`. It exists as the baseline the others get measured against, so improvements have
+something honest to beat.
 
 Conductors are opt-in, same as folding itself. An exclusive one shows you a consent screen
 naming which controls it takes over, and detaching converts everything it did into your own
 edits so its work survives being removed.
 
-thermocline and triptych ship with the repo. They aren't in the npm package, so they only
-show up in the picker when you run Accordion from a checkout. Details on each are in
-**[conductors/](conductors/)**.
+thermocline and triptych run as their own process and ship with the repo. They aren't in the
+npm package, so they only show up in the picker when you run Accordion from a checkout. Details
+on each are in **[conductors/](conductors/)**.
 
 ## What works today
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 <img src="docs/assets/accordion-hero.gif" alt="Accordion — the context map demo: blocks folding and unfolding while the protected tail stays intact" width="820">
 
 <sub>Your whole context window split in 2 sections. The lower section represents your agent's most recent context and is protected against any interference</sub>
+
+[get-accordion.dev](https://get-accordion.dev/) &nbsp;·&nbsp; [npm](https://www.npmjs.com/package/@a-fig/accordion) &nbsp;·&nbsp; [VISION.md](VISION.md)
 </div>
 
 ---
@@ -28,11 +30,11 @@ your agent's entire context window at a glance and lets you manage it manually o
 
 ## Why it's different
 
-#### 1. No blocking calls for compaction 
+#### 1. No blocking calls for compaction
 > your context window is automatically managed for you in the background, keeping you below your limit
 
-#### 2. longer more useful sessions
-> The relevance of each block is ranked so we only fold bloat, and keep what's important. 
+#### 2. Longer, more useful sessions
+> The relevance of each block is ranked so we only fold bloat, and keep what's important.
 
 #### 3. Cheaper inference costs
 > Accordion keeps your context window lean, with cache optimizations in mind.
@@ -59,7 +61,7 @@ Accordion ships with a catalog of interchangeable **Conductors**. The strongest 
 **[Thermocline](conductors/ws/thermocline/)**, scores each block relevance to the most recent context using the attention from a 500M parameter model as a proxy.
 
 In a test run on **SlopCodeBench** (a long-horizon coding benchmark), Thermocline at a
-100k-token budget outperformed naive compaction with the same constrained context budget. Both used deepseekV4Pro.
+100k-token budget outperformed naive compaction with the same constrained context budget. Both used DeepSeek V4 Pro.
 
 | Conductor | Context Budget | Score | Checkpoints reached |
 |---|:---:|:---:|:---:|
@@ -102,17 +104,39 @@ agent reasons over at full fidelity (the thick-bordered box below the fold line)
 
 → Capability matrix, full walkthrough, and the deep spec: **[VISION.md](VISION.md)**
 
+## The conductors
+
+Five ship today. Pick one from the header menu, or leave it on None and steer by hand.
+
+| Conductor | What it does | Runs |
+|---|---|---|
+| **[thermocline](conductors/ws/thermocline/)** | Attention-gated compression under a hard budget cap. A small probe model scores how much the recent context still attends to each block, and the coldest ones get compressed first. | out of process |
+| **[triptych](conductors/ws/triptych/)** | Splits the context into thirds. The recent third stays raw, the middle turns code reads into tree-sitter skeletons (signatures kept, bodies dropped, still recoverable), the oldest third gets summarized. | out of process |
+| **[doorman](conductors/in-process/doorman/)** | Folds a huge tool result before the model ever sees it. | in process |
+| **[handoff](conductors/in-process/handoff/)** | Writes a real handoff document and folds the whole prior session behind it. | in process |
+| **[compaction-naive](conductors/in-process/compaction-naive/)** | A deliberately lossy `/compact` clone. It is the baseline the others get measured against. | in process |
+
+Conductors are opt-in, same as folding itself. An exclusive one shows you a consent screen
+naming which controls it takes over, and detaching converts everything it did into your own
+edits so its work survives being removed.
+
+thermocline and triptych ship with the repo. They aren't in the npm package, so they only
+show up in the picker when you run Accordion from a checkout. Details on each are in
+**[conductors/](conductors/)**.
+
 ## What works today
 
+- ✅ Browser-served UI: the full Map with no desktop app and no Rust.
 - ✅ Desktop app (Tauri + SvelteKit): the Map view, token budget, inspector, protected
   working tail.
 - ✅ Live link to a running pi session, with auto-discovery.
+- ✅ Multi-session: every live pi session on the machine in one sidebar, switchable.
 - ✅ Opt-in live steering — apply your fold plan to what the agent is shown.
 - ✅ Reversible, provider-safe folding with deterministic `{#code FOLDED}` digests the
   agent can ask to unfold.
 - ✅ Involvement locks — exclusive conductors, the consent gate, freeze-on-detach, and
   agent `recall`.
-- ✅ The Conductor — automatic fold/unfold between turns, based on context.
+- ✅ Five conductors — automatic fold/unfold between turns, based on context.
 - ✅ LLM-generated summaries, computed once and cached.
 - ✅ Read-only browsing of saved Claude Code transcripts.
 
@@ -127,6 +151,8 @@ groups, no replay. That's the build ahead.
 - [x] Agent-driven unfold + `recall`, involvement locks
 - [x] LLM-generated summaries, computed once and cached
 - [x] The Conductor — automatic fold/unfold between turns
+- [x] Browser-served UI and multi-session, no desktop app required
+- [ ] Broader benchmarks: more than one run, published
 - [ ] Hierarchical folding for million-turn sessions
 - [ ] Agent-driven pin
 - [ ] Replay — scrub how context evolved across a session
@@ -140,19 +166,29 @@ groups, no replay. That's the build ahead.
 ```bash
 pi install npm:@a-fig/accordion
 ```
-restart pi if it is already running, then inside of pi run:                                      
- ```bash
-    /accordion                                                                       
- ```
-That's it, assuming you have [pi](https://github.com/earendil-works/pi)
+restart pi if it is already running, then inside of pi run:
+
+```bash
+/accordion
+```
+
+That's it, assuming you have [pi](https://github.com/earendil-works/pi). The extension
+serves the UI and prints a local URL (`http://127.0.0.1:24317/...`). It is the same URL
+every time, and it keeps working when the session that printed it ends, so you don't have
+to go fish a fresh one out of pi's output. The page connects to your running session, and
+any other live pi session on the machine shows up in the sidebar.
+
+Folding starts **off**. Accordion just watches until you flip the **Folding** toggle in the
+header, then you can pick a conductor or steer by hand.
 
 ---
 
 ### Part 2 — Desktop app (Optional - full feature set)
 
-The desktop app adds **multi-session discovery** (switch between running pi sessions from
-a sidebar), conductors that require local model resources, and the `/accordion` command
-that foregrounds the right session automatically. It requires Node 20+ and Rust.
+The desktop app adds **read-only browsing of saved Claude Code transcripts** (which needs
+the native Rust layer) and the `/accordion` command that foregrounds the right session
+automatically. Running from a checkout is also what makes the out-of-process conductors
+(`thermocline`, `triptych`) selectable. It requires Node 20+ and Rust.
 
 > **Don't double-register the extension.** Part 1's `pi install npm:@a-fig/accordion`
 > already registered the extension (the `/accordion` command, the `unfold`/`recall`
@@ -223,8 +259,7 @@ npm run tauri dev   # opens the native window; hot-reloads on save
 
 Run pi in any project. It advertises itself in `~/.accordion/sessions/` and appears in
 Accordion's **Sessions** sidebar within ~1s. Click it (or run `/accordion` in that
-terminal) and its context populates live. Folding is preview-only by default; use the
-header's **Folding** toggle to opt in to steering the live agent's context.
+terminal) and its context populates live.
 
 Only one surface steers at a time, machine-wide across every session — the rest are live
 mirrors. If you open Accordion from a second tab or window while another is already
@@ -244,11 +279,10 @@ Setup, the quality gate, and platform gotchas are in **[CONTRIBUTING.md](CONTRIB
 Our main frontier right now is **better conductors**: researching which context actually
 matters, developing stronger strategies, and testing them against real sessions. We're not
 chasing a long tail of mediocre ones — the goal is one to three conductors that genuinely
-hold up. Four ship today (`compaction-naive`, `handoff`, `doorman`, and the attention-gated
-`thermocline`) against a small, frozen contract (`core/conductor/contract.ts`): a conductor
-attaches to a host, reacts to context-change events, and proposes fold/group edits between
-turns — clamped by the exact same rules a human fold goes through, never a privileged write
-path. If you don't need that finer-grained event stream, `core/conductor/view.ts`'s
+hold up. The five listed above run against a small, frozen contract
+(`core/conductor/contract.ts`): a conductor attaches to a host, reacts to context-change
+events, and proposes fold/group edits between turns — clamped by the exact same rules a
+human fold goes through, never a privileged write path. If you don't need that finer-grained event stream, `core/conductor/view.ts`'s
 `ViewConductor` adapter lets you write the simpler `conduct(view) → Command[]` shape instead
 (what `compaction-naive` and `handoff` do); one line in `core/conductor/registry.ts` registers
 it. Strategies can range from simple oldest-first folding to scoring each block's relevance

--- a/README.md
+++ b/README.md
@@ -124,18 +124,21 @@ third is left alone, the middle band turns code reads into tree-sitter skeletons
 signature and drop the bodies, and the oldest third gets summarized. The skeletons stay
 recoverable, so the agent can pull the full source back with `recall` when it needs it.
 
-**[doorman](conductors/in-process/doorman/)** fixes one specific problem. A huge tool result
-lands inside the protected tail the moment it arrives, so the model sees it at full size on the
-very first call, which is the exact thing a folding tool is supposed to prevent. Doorman catches
-those on their way out and folds them before they ever reach the model.
+**[doorman](conductors/in-process/doorman/)** takes its idea from
+[The Token Company](https://thetokencompany.com): shrink content on the way to the model,
+before it ever costs you full price. The problem it solves is that a huge tool result lands
+inside the protected tail the moment it arrives, so the model sees it at full size on the very
+first call, which is the exact thing a folding tool is supposed to prevent. Doorman catches
+those on their way out and folds them before they reach the model at all.
 
-**[handoff](conductors/in-process/handoff/)** automates the thing people already do by hand when
-a session gets too long: ask the agent to write a handoff document, kill the session, then paste
-that document into a fresh one. It does all three without you leaving the session.
+**[handoff](conductors/in-process/handoff/)** is `/handoff`, automatic. The manual version is to
+ask the agent to write a handoff document, kill the session, and paste that document into a
+fresh one. This does all three for you without you leaving the session.
 
-**[compaction-naive](conductors/in-process/compaction-naive/)** is a deliberately lossy clone of
-`/compact`. It exists as the baseline the others get measured against, so improvements have
-something honest to beat.
+**[compaction-naive](conductors/in-process/compaction-naive/)** re-implements the `/compact` you
+already have in Claude Code, ChatGPT and everywhere else. It is the baseline the other four get
+measured against, and it makes the point that Accordion covers what exists today before it does
+anything past that.
 
 Conductors are opt-in, same as folding itself. An exclusive one shows you a consent screen
 naming which controls it takes over, and detaching converts everything it did into your own

--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ recoverable, so the agent can pull the full source back with `recall` when it ne
 
 **[doorman](conductors/in-process/doorman/)** takes its idea from
 [The Token Company](https://thetokencompany.com): shrink content on the way to the model,
-before it ever costs you full price. The problem it solves is that a huge tool result lands
-inside the protected tail the moment it arrives, so the model sees it at full size on the very
-first call, which is the exact thing a folding tool is supposed to prevent. Doorman catches
-those on their way out and folds them before they reach the model at all.
+before it ever costs you full price. A huge tool result lands inside the protected tail the
+moment it arrives, so the model sees it at full size on the very first call, and doorman
+catches those on their way out and folds them before they reach the model at all. It's a cheap
+proof of concept, so don't reach for it as a real strategy.
 
 **[handoff](conductors/in-process/handoff/)** is `/handoff`, automatic. The manual version is to
 ask the agent to write a handoff document, kill the session, and paste that document into a

--- a/extension/README.md
+++ b/extension/README.md
@@ -80,10 +80,11 @@ reasons over at full fidelity.
 
 **Conductors are opt-in, same as folding itself** — pick one from the header's Conductor
 menu, or leave it on "None" for fully manual steering. `compaction-naive`, `handoff`, and
-`doorman` run right inside this extension, no extra setup. The fourth, `thermocline`
-(attention-gated compression under a hard budget invariant), runs as its own out-of-process
-Node program; its runner ships with the full [GitHub repo](https://github.com/a-Fig/Accordion),
-not with this npm package, so it only shows up in the picker when Accordion is running from a
+`doorman` run right inside this extension, no extra setup. Two more, `thermocline`
+(attention-gated compression under a hard budget invariant) and `triptych` (pressure-gated
+thirds with tree-sitter code skeletons), each run as their own out-of-process Node program.
+Their runners ship with the full [GitHub repo](https://github.com/a-Fig/Accordion) and not
+with this npm package, so they only show up in the picker when Accordion is running from a
 repo checkout (e.g. the desktop app build) rather than a bare `pi install`. Picking a
 conductor that takes over any steering control shows you a consent screen first — cancel or
 detach anytime and your own edits are preserved.


### PR DESCRIPTION
The README hadn't kept up with what shipped after the hackathon. This is a correction pass, not a rewrite. Structure, voice, images, and the honesty caveats are all left alone.

## What was actually wrong

**Conductor count was stale.** Contributing said "Four ship today" and named `compaction-naive`, `handoff`, `doorman`, `thermocline`. `triptych` shipped and was never added. The README also never listed the conductors anywhere a reader would find them, so I added a table under "How it works" with one line each and a link to its directory. Same stale count in `extension/README.md` (the npm-page README), fixed there too.

**Part 2 claimed the desktop app is what gives you multi-session discovery.** That stopped being true when browser-served mode landed. Rewritten to say what the desktop app actually adds now: Claude Code transcript browsing (needs the Rust layer). Running from a checkout is the separate thing that makes `thermocline` and `triptych` selectable.

**"What works today" was missing two shipped features:** browser-served UI (no desktop app, no Rust) and multi-session.

**Part 1 was thin and the code block was mangled** (stray indentation inside the fence). Now says what `/accordion` actually gives you: the stable `127.0.0.1:24317` URL that survives the printing session ending, folding being off by default, other sessions in the sidebar.

## Smaller stuff

- Roadmap: checked off browser-served + multi-session, added broader benchmarks as an open item.
- Linked get-accordion.dev and npm from the header. Neither appeared anywhere in the README before.
- `deepseekV4Pro` → `DeepSeek V4 Pro`, heading capitalization, trailing whitespace.
- Dropped one duplicated "folding is off by default" sentence in Part 2, now that Part 1 covers it.

## Checked

- Every relative link and directory path in the README resolves against the tree.
- Claims verified against the code, not assumed: 20k protected tail (`core/truth.ts:154`), `DOOR_PORT = 24317` (`core/protocol.ts:154`), and the "no agent-driven pinning" caveat is still accurate (`unfold` and `recall` are the only registered tools).

Numbers in the benchmark table and the hackathon-scale caveat are untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FL7ffH4MkJPvdyRzkpipN9)_