### PR TITLE
Add Accordion launcher as Claude Code and Codex MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,21 @@ Accordion's **Sessions** sidebar within ~1s. Click it (or run `/accordion` in th
 terminal) and its context populates live. Folding is preview-only by default; use the
 header's **Folding** toggle to opt in to steering the live agent's context.
 
+### Claude Code and Codex tool
+
+The package also ships an `accordion-mcp` stdio server with one tool,
+`open_accordion`, which opens or focuses the native desktop GUI:
+
+```bash
+claude mcp add --scope user accordion -- accordion-mcp
+codex mcp add accordion -- accordion-mcp
+```
+
+If the desktop app is not installed in a standard location, set `ACCORDION_APP_PATH`
+for the server configuration. This tool does not intercept either host's live context:
+Claude Code transcripts remain read-only in the desktop app, and live folding remains
+available only for pi sessions until those hosts expose an equivalent context hook.
+
 Only one surface steers at a time, machine-wide across every session — the rest are live
 mirrors. If you open Accordion from a second tab or window while another is already
 driving, you'll see a one-time prompt to take control; everywhere else stays

--- a/extension/README.md
+++ b/extension/README.md
@@ -29,6 +29,18 @@ alone — no Rust, no desktop app required.
 pi install npm:@a-fig/accordion
 ```
 
+The package also provides an `accordion-mcp` stdio server for Claude Code and
+Codex. Its `open_accordion` tool opens or focuses the native desktop GUI:
+
+```bash
+claude mcp add --scope user accordion -- accordion-mcp
+codex mcp add accordion -- accordion-mcp
+```
+
+Set `ACCORDION_APP_PATH` in the MCP server environment when the desktop app is
+not installed in a standard location. Claude Code transcript browsing is
+read-only, and live context folding remains pi-only.
+
 That adds the package to `~/.pi/agent/settings.json`. Restart pi, then in any project:
 
 ```bash

--- a/extension/accordion-mcp.js
+++ b/extension/accordion-mcp.js
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+
+// mcp.ts
+import { createInterface } from "node:readline";
+
+// launcher.ts
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+var ACCORDION_APP_ENV = "ACCORDION_APP_PATH";
+function cleanExplicitPath(value) {
+  if (typeof value !== "string") return null;
+  let s = value.trim();
+  if (!s) return null;
+  if (s.startsWith('"') && s.endsWith('"') || s.startsWith("'") && s.endsWith("'")) s = s.slice(1, -1).trim();
+  if (s === "~") return os.homedir();
+  if (s.startsWith("~/") || s.startsWith("~\\")) return path.join(os.homedir(), s.slice(2));
+  return s;
+}
+function isLaunchableFile(candidate) {
+  try {
+    return fs.statSync(candidate).isFile();
+  } catch {
+    return false;
+  }
+}
+function installedCandidates() {
+  if (process.platform === "darwin") {
+    return [
+      "/Applications/Accordion.app/Contents/MacOS/Accordion",
+      path.join(os.homedir(), "Applications", "Accordion.app", "Contents", "MacOS", "Accordion")
+    ];
+  }
+  if (process.platform === "linux") return [path.join(os.homedir(), ".local", "share", "Accordion", "accordion")];
+  if (process.platform !== "win32") return [];
+  const roots = [
+    process.env.LOCALAPPDATA && path.join(process.env.LOCALAPPDATA, "Programs", "Accordion"),
+    process.env.ProgramFiles && path.join(process.env.ProgramFiles, "Accordion"),
+    process.env["ProgramFiles(x86)"] && path.join(process.env["ProgramFiles(x86)"], "Accordion"),
+    process.env.LOCALAPPDATA && path.join(process.env.LOCALAPPDATA, "Accordion")
+  ].filter((candidate) => !!candidate);
+  return roots.flatMap((root) => [path.join(root, "Accordion.exe"), path.join(root, "app.exe")]);
+}
+function repoCandidates() {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const repo = path.resolve(here, "..");
+  const ext = process.platform === "win32" ? ".exe" : "";
+  return [
+    path.join(repo, "app", "src-tauri", "target", "release", `app${ext}`),
+    path.join(repo, "app", "src-tauri", "target", "debug", `app${ext}`)
+  ];
+}
+function resolveAccordionApp(explicitPath) {
+  const explicit = cleanExplicitPath(explicitPath);
+  if (explicit) {
+    if (isLaunchableFile(explicit)) return { ok: true, path: explicit, source: "explicit" };
+    return { ok: false, reason: "explicit-invalid", path: explicit, source: "explicit" };
+  }
+  const envPath = cleanExplicitPath(process.env[ACCORDION_APP_ENV]);
+  if (envPath) {
+    if (isLaunchableFile(envPath)) return { ok: true, path: envPath, source: "env" };
+    return { ok: false, reason: "explicit-invalid", path: envPath, source: "env" };
+  }
+  for (const candidate of [...installedCandidates(), ...repoCandidates()]) {
+    if (isLaunchableFile(candidate)) return { ok: true, path: candidate, source: "default" };
+  }
+  return { ok: false, reason: "not-found" };
+}
+async function launchAccordionApp(explicitPath) {
+  const resolved = resolveAccordionApp(explicitPath);
+  if (!resolved.ok) return resolved;
+  try {
+    const child = spawn(resolved.path, [], { detached: true, stdio: "ignore", shell: false });
+    return await new Promise((resolve2) => {
+      let settled = false;
+      const ok = { ok: true, path: resolved.path, source: resolved.source };
+      const timer = setTimeout(() => finish(ok), 150);
+      const finish = (result) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        child.off("spawn", onSpawn);
+        child.unref();
+        resolve2(result);
+      };
+      const onSpawn = () => finish(ok);
+      const onError = (error) => finish({ ok: false, reason: "spawn-failed", path: resolved.path, source: resolved.source, error });
+      child.once("spawn", onSpawn);
+      child.once("error", onError);
+    });
+  } catch (error) {
+    return { ok: false, reason: "spawn-failed", path: resolved.path, source: resolved.source, error };
+  }
+}
+
+// package.json
+var package_default = {
+  name: "@a-fig/accordion",
+  version: "0.1.2",
+  type: "module",
+  description: "Accordion live link \u2014 a pi extension that hosts the session's context Truth and serves a replica + remote-control protocol to the Accordion GUI.",
+  keywords: ["pi-package"],
+  scripts: {
+    "build:app": "npm --prefix ../app run build",
+    "build:extension": "node ./build-extension.mjs",
+    "build:client": "node ./build-client.mjs",
+    "build:remote-sdk": "node ./build-remote-sdk.mjs",
+    "build:mcp": "node ./build-mcp.mjs",
+    build: "npm run build:app && npm run build:client && npm run build:extension && npm run build:remote-sdk && npm run build:mcp",
+    prepack: "npm run build && npm run smoke",
+    smoke: "node smoke.mjs && node smoke-conductor.mjs && node smoke-mcp.mjs"
+  },
+  pi: {
+    extensions: ["./accordion.js"]
+  },
+  bin: {
+    "accordion-mcp": "./accordion-mcp.js"
+  },
+  files: [
+    "accordion.js",
+    "accordion-mcp.js",
+    "dist",
+    "skills",
+    "README.md"
+  ],
+  dependencies: {
+    ws: "^8.18.0"
+  },
+  peerDependencies: {
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-agent-core": "*",
+    "@earendil-works/pi-ai": "*",
+    typebox: "*"
+  },
+  devDependencies: {
+    esbuild: "^0.25.0",
+    jiti: "^2.7.0"
+  }
+};
+
+// mcp.ts
+var tools = [{
+  name: "open_accordion",
+  description: "Open or focus the native Accordion context-map GUI. Live context steering is currently available for pi sessions; Claude Code transcripts are browsable read-only.",
+  inputSchema: { type: "object", properties: {}, additionalProperties: false }
+}];
+function write(message) {
+  process.stdout.write(`${JSON.stringify(message)}
+`);
+}
+async function openAccordion() {
+  const result = await launchAccordionApp();
+  if (result.ok) {
+    return { content: [{ type: "text", text: `Accordion opened from ${result.path}. Live steering remains pi-only; use the Claude Code tab for read-only transcript browsing.` }] };
+  }
+  if (result.reason === "explicit-invalid") {
+    return { isError: true, content: [{ type: "text", text: `${ACCORDION_APP_ENV} does not point to an executable: ${result.path}` }] };
+  }
+  if (result.reason === "spawn-failed") {
+    return { isError: true, content: [{ type: "text", text: `Accordion was found at ${result.path}, but launching it failed.` }] };
+  }
+  return { isError: true, content: [{ type: "text", text: `Accordion was not found. Build or install the desktop app, or set ${ACCORDION_APP_ENV}.` }] };
+}
+for await (const line of createInterface({ input: process.stdin })) {
+  let request;
+  try {
+    request = JSON.parse(line);
+  } catch {
+    write({ jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } });
+    continue;
+  }
+  if (request.id === void 0) continue;
+  if (request.method === "initialize") {
+    write({ jsonrpc: "2.0", id: request.id, result: { protocolVersion: request.params?.protocolVersion ?? "2025-06-18", capabilities: { tools: {} }, serverInfo: { name: "accordion", version: package_default.version } } });
+  } else if (request.method === "ping") {
+    write({ jsonrpc: "2.0", id: request.id, result: {} });
+  } else if (request.method === "tools/list") {
+    write({ jsonrpc: "2.0", id: request.id, result: { tools } });
+  } else if (request.method === "tools/call" && request.params?.name === "open_accordion") {
+    write({ jsonrpc: "2.0", id: request.id, result: await openAccordion() });
+  } else {
+    write({ jsonrpc: "2.0", id: request.id, error: { code: -32601, message: "Method not found" } });
+  }
+}

--- a/extension/accordion.ts
+++ b/extension/accordion.ts
@@ -77,6 +77,7 @@ import { LiveConductorHost, type SpawnedRunner } from "../core/conductor/liveHos
 import { catalogMeta, type RegistryEntry } from "../core/conductor/registry";
 import type { CompletionRequest, CompletionResult } from "../core/conductor/contract";
 import { conductorReadiness, resolveRunnerPath as resolveConductorRunnerPath } from "./conductorReadiness";
+import { ACCORDION_APP_ENV, launchAccordionApp, type LaunchResult } from "./launcher";
 import {
 	REGISTRY_PROTOCOL,
 	REGISTRY_DIR,
@@ -245,7 +246,6 @@ function currentControllerPollMs(): number {
 }
 
 const ACCORDION_APP_FLAG = "accordion-app";
-const ACCORDION_APP_ENV = "ACCORDION_APP_PATH";
 
 // The live link binds an OS-assigned ephemeral port on loopback (127.0.0.1) only — a
 // same-machine surface. The desktop app's discovery dials 127.0.0.1; the browser-served
@@ -260,116 +260,11 @@ function isLoopbackPeer(addr: string | undefined | null): boolean {
 	return v4 === "127.0.0.1" || v4 === "::1" || v4 === "localhost";
 }
 
-type LaunchSource = "cli" | "env" | "default";
-type LaunchResult =
-	| { ok: true; path: string; source: LaunchSource }
-	| { ok: false; reason: "explicit-invalid"; path: string; source: Extract<LaunchSource, "cli" | "env"> }
-	| { ok: false; reason: "not-found" }
-	| { ok: false; reason: "spawn-failed"; path: string; source: LaunchSource; error: unknown };
-
-function cleanExplicitPath(value: unknown): string | null {
-	if (typeof value !== "string") return null;
-	let s = value.trim();
-	if (!s) return null;
-	// This is still a path-only override, not shell parsing. Stripping one matching
-	// quote pair makes common copied Windows paths ("C:\\...\\Accordion.exe") work.
-	if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) s = s.slice(1, -1).trim();
-	if (s === "~") return os.homedir();
-	if (s.startsWith("~/") || s.startsWith("~\\")) return path.join(os.homedir(), s.slice(2));
-	return s;
-}
-
-function isLaunchableFile(p: string): boolean {
-	try {
-		return fs.statSync(p).isFile();
-	} catch {
-		return false;
-	}
-}
-
-function windowsInstallCandidates(): string[] {
-	if (process.platform !== "win32") return [];
-	const roots = [
-		process.env.LOCALAPPDATA && path.join(process.env.LOCALAPPDATA, "Programs", "Accordion"),
-		process.env.ProgramFiles && path.join(process.env.ProgramFiles, "Accordion"),
-		process.env["ProgramFiles(x86)"] && path.join(process.env["ProgramFiles(x86)"], "Accordion"),
-		process.env.LOCALAPPDATA && path.join(process.env.LOCALAPPDATA, "Accordion"),
-	].filter((s): s is string => !!s);
-	const names = ["Accordion.exe", "app.exe"];
-	const out: string[] = [];
-	for (const root of roots) for (const name of names) out.push(path.join(root, name));
-	return out;
-}
-
-function repoAppCandidates(): string[] {
-	try {
-		const here = path.dirname(fileURLToPath(import.meta.url));
-		const repo = path.resolve(here, "..");
-		const ext = process.platform === "win32" ? ".exe" : "";
-		return [
-			path.join(repo, "app", "src-tauri", "target", "release", `app${ext}`),
-			path.join(repo, "app", "src-tauri", "target", "debug", `app${ext}`),
-		];
-	} catch {
-		return [];
-	}
-}
-
-function resolveAccordionApp(pi: ExtensionAPI): LaunchResult {
-	const flagPath = cleanExplicitPath(pi.getFlag(ACCORDION_APP_FLAG));
-	if (flagPath) {
-		if (isLaunchableFile(flagPath)) return { ok: true, path: flagPath, source: "cli" };
-		return { ok: false, reason: "explicit-invalid", path: flagPath, source: "cli" };
-	}
-
-	const envPath = cleanExplicitPath(process.env[ACCORDION_APP_ENV]);
-	if (envPath) {
-		if (isLaunchableFile(envPath)) return { ok: true, path: envPath, source: "env" };
-		return { ok: false, reason: "explicit-invalid", path: envPath, source: "env" };
-	}
-
-	for (const candidate of [...windowsInstallCandidates(), ...repoAppCandidates()]) {
-		if (isLaunchableFile(candidate)) return { ok: true, path: candidate, source: "default" };
-	}
-	return { ok: false, reason: "not-found" };
-}
-
-async function launchAccordionApp(pi: ExtensionAPI): Promise<LaunchResult> {
-	const resolved = resolveAccordionApp(pi);
-	if (!resolved.ok) return resolved;
-	try {
-		const child = spawn(resolved.path, [], { detached: true, stdio: "ignore", shell: false });
-		// Catch immediate async launch failures without waiting for the app to boot. Some
-		// spawn failures arrive on the child "error" event rather than throwing from spawn().
-		return await new Promise<LaunchResult>((resolve) => {
-			let settled = false;
-			const ok: LaunchResult = { ok: true, path: resolved.path, source: resolved.source };
-			const timer = setTimeout(() => finish(ok), 150);
-			const finish = (result: LaunchResult) => {
-				if (settled) return;
-				settled = true;
-				clearTimeout(timer);
-				child.off("spawn", onSpawn);
-				child.unref();
-				resolve(result);
-			};
-			const onSpawn = () => finish(ok);
-			const onError = (error: unknown) => finish({ ok: false, reason: "spawn-failed", path: resolved.path, source: resolved.source, error });
-			child.once("spawn", onSpawn);
-			// Leave this listener installed even after a timeout success; if the OS reports a
-			// late error, onError no-ops via `settled` and avoids an unhandled error event.
-			child.once("error", onError);
-		});
-	} catch (error) {
-		return { ok: false, reason: "spawn-failed", path: resolved.path, source: resolved.source, error };
-	}
-}
-
 function launchResultLine(result: LaunchResult | null): { text: string; type: "info" | "warning" } {
 	if (!result) return { text: "Accordion focus requested for this session.", type: "info" };
 	if (result.ok) return { text: "Launching/focusing Accordion for this session…", type: "info" };
 	if (result.reason === "explicit-invalid") {
-		const source = result.source === "cli" ? `--${ACCORDION_APP_FLAG}` : ACCORDION_APP_ENV;
+		const source = result.source === "explicit" ? `--${ACCORDION_APP_FLAG}` : ACCORDION_APP_ENV;
 		return {
 			text: `Accordion focus request written, but ${source} does not point to an executable: ${result.path}`,
 			type: "warning",
@@ -2748,7 +2643,7 @@ export default function accordionLive(pi: ExtensionAPI, dependencies: RuntimeDep
 			// app is the only cross-process nudge we have; the app's single-instance guard turns
 			// that into "focus the existing window" when it is already running elsewhere.
 			const wasAttached = attached();
-			const launch = wasAttached ? null : await launchAccordionApp(pi);
+			const launch = wasAttached ? null : await launchAccordionApp(pi.getFlag(ACCORDION_APP_FLAG));
 			const action = launchResultLine(launch);
 			// Port status: the real port once bound, a captured bind FAILURE (no more eternal
 			// "starting…" on an EADDRINUSE-type error — see startServer's httpServer "error"

--- a/extension/build-mcp.mjs
+++ b/extension/build-mcp.mjs
@@ -1,0 +1,14 @@
+import * as esbuild from "esbuild";
+import { fileURLToPath } from "node:url";
+import * as path from "node:path";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+await esbuild.build({
+	entryPoints: [path.join(here, "mcp.ts")],
+	outfile: path.join(here, "accordion-mcp.js"),
+	bundle: true,
+	format: "esm",
+	platform: "node",
+	target: "node20",
+	logLevel: "info",
+});

--- a/extension/launcher.ts
+++ b/extension/launcher.ts
@@ -1,0 +1,104 @@
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const ACCORDION_APP_ENV = "ACCORDION_APP_PATH";
+
+export type LaunchSource = "explicit" | "env" | "default";
+export type LaunchResult =
+	| { ok: true; path: string; source: LaunchSource }
+	| { ok: false; reason: "explicit-invalid"; path: string; source: Extract<LaunchSource, "explicit" | "env"> }
+	| { ok: false; reason: "not-found" }
+	| { ok: false; reason: "spawn-failed"; path: string; source: LaunchSource; error: unknown };
+
+function cleanExplicitPath(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	let s = value.trim();
+	if (!s) return null;
+	if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) s = s.slice(1, -1).trim();
+	if (s === "~") return os.homedir();
+	if (s.startsWith("~/") || s.startsWith("~\\")) return path.join(os.homedir(), s.slice(2));
+	return s;
+}
+
+function isLaunchableFile(candidate: string): boolean {
+	try {
+		return fs.statSync(candidate).isFile();
+	} catch {
+		return false;
+	}
+}
+
+function installedCandidates(): string[] {
+	if (process.platform === "darwin") {
+		return [
+			"/Applications/Accordion.app/Contents/MacOS/Accordion",
+			path.join(os.homedir(), "Applications", "Accordion.app", "Contents", "MacOS", "Accordion"),
+		];
+	}
+	if (process.platform === "linux") return [path.join(os.homedir(), ".local", "share", "Accordion", "accordion")];
+	if (process.platform !== "win32") return [];
+	const roots = [
+		process.env.LOCALAPPDATA && path.join(process.env.LOCALAPPDATA, "Programs", "Accordion"),
+		process.env.ProgramFiles && path.join(process.env.ProgramFiles, "Accordion"),
+		process.env["ProgramFiles(x86)"] && path.join(process.env["ProgramFiles(x86)"], "Accordion"),
+		process.env.LOCALAPPDATA && path.join(process.env.LOCALAPPDATA, "Accordion"),
+	].filter((candidate): candidate is string => !!candidate);
+	return roots.flatMap((root) => [path.join(root, "Accordion.exe"), path.join(root, "app.exe")]);
+}
+
+function repoCandidates(): string[] {
+	const here = path.dirname(fileURLToPath(import.meta.url));
+	const repo = path.resolve(here, "..");
+	const ext = process.platform === "win32" ? ".exe" : "";
+	return [
+		path.join(repo, "app", "src-tauri", "target", "release", `app${ext}`),
+		path.join(repo, "app", "src-tauri", "target", "debug", `app${ext}`),
+	];
+}
+
+export function resolveAccordionApp(explicitPath?: unknown): LaunchResult {
+	const explicit = cleanExplicitPath(explicitPath);
+	if (explicit) {
+		if (isLaunchableFile(explicit)) return { ok: true, path: explicit, source: "explicit" };
+		return { ok: false, reason: "explicit-invalid", path: explicit, source: "explicit" };
+	}
+	const envPath = cleanExplicitPath(process.env[ACCORDION_APP_ENV]);
+	if (envPath) {
+		if (isLaunchableFile(envPath)) return { ok: true, path: envPath, source: "env" };
+		return { ok: false, reason: "explicit-invalid", path: envPath, source: "env" };
+	}
+	for (const candidate of [...installedCandidates(), ...repoCandidates()]) {
+		if (isLaunchableFile(candidate)) return { ok: true, path: candidate, source: "default" };
+	}
+	return { ok: false, reason: "not-found" };
+}
+
+export async function launchAccordionApp(explicitPath?: unknown): Promise<LaunchResult> {
+	const resolved = resolveAccordionApp(explicitPath);
+	if (!resolved.ok) return resolved;
+	try {
+		const child = spawn(resolved.path, [], { detached: true, stdio: "ignore", shell: false });
+		return await new Promise<LaunchResult>((resolve) => {
+			let settled = false;
+			const ok: LaunchResult = { ok: true, path: resolved.path, source: resolved.source };
+			const timer = setTimeout(() => finish(ok), 150);
+			const finish = (result: LaunchResult) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				child.off("spawn", onSpawn);
+				child.unref();
+				resolve(result);
+			};
+			const onSpawn = () => finish(ok);
+			const onError = (error: unknown) => finish({ ok: false, reason: "spawn-failed", path: resolved.path, source: resolved.source, error });
+			child.once("spawn", onSpawn);
+			child.once("error", onError);
+		});
+	} catch (error) {
+		return { ok: false, reason: "spawn-failed", path: resolved.path, source: resolved.source, error };
+	}
+}

--- a/extension/mcp.ts
+++ b/extension/mcp.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+import { createInterface } from "node:readline";
+import { ACCORDION_APP_ENV, launchAccordionApp } from "./launcher";
+import packageJson from "./package.json" with { type: "json" };
+
+const tools = [{
+	name: "open_accordion",
+	description: "Open or focus the native Accordion context-map GUI. Live context steering is currently available for pi sessions; Claude Code transcripts are browsable read-only.",
+	inputSchema: { type: "object", properties: {}, additionalProperties: false },
+}];
+
+function write(message: unknown): void {
+	process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+async function openAccordion() {
+	const result = await launchAccordionApp();
+	if (result.ok) {
+		return { content: [{ type: "text", text: `Accordion opened from ${result.path}. Live steering remains pi-only; use the Claude Code tab for read-only transcript browsing.` }] };
+	}
+	if (result.reason === "explicit-invalid") {
+		return { isError: true, content: [{ type: "text", text: `${ACCORDION_APP_ENV} does not point to an executable: ${result.path}` }] };
+	}
+	if (result.reason === "spawn-failed") {
+		return { isError: true, content: [{ type: "text", text: `Accordion was found at ${result.path}, but launching it failed.` }] };
+	}
+	return { isError: true, content: [{ type: "text", text: `Accordion was not found. Build or install the desktop app, or set ${ACCORDION_APP_ENV}.` }] };
+}
+
+for await (const line of createInterface({ input: process.stdin })) {
+	let request: any;
+	try {
+		request = JSON.parse(line);
+	} catch {
+		write({ jsonrpc: "2.0", id: null, error: { code: -32700, message: "Parse error" } });
+		continue;
+	}
+	if (request.id === undefined) continue;
+	if (request.method === "initialize") {
+		write({ jsonrpc: "2.0", id: request.id, result: { protocolVersion: request.params?.protocolVersion ?? "2025-06-18", capabilities: { tools: {} }, serverInfo: { name: "accordion", version: packageJson.version } } });
+	} else if (request.method === "ping") {
+		write({ jsonrpc: "2.0", id: request.id, result: {} });
+	} else if (request.method === "tools/list") {
+		write({ jsonrpc: "2.0", id: request.id, result: { tools } });
+	} else if (request.method === "tools/call" && request.params?.name === "open_accordion") {
+		write({ jsonrpc: "2.0", id: request.id, result: await openAccordion() });
+	} else {
+		write({ jsonrpc: "2.0", id: request.id, error: { code: -32601, message: "Method not found" } });
+	}
+}

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "ws": "^8.18.0"
       },
+      "bin": {
+        "accordion-mcp": "accordion-mcp.js"
+      },
       "devDependencies": {
         "esbuild": "^0.25.0",
         "jiti": "^2.7.0"

--- a/extension/package.json
+++ b/extension/package.json
@@ -9,15 +9,20 @@
     "build:extension": "node ./build-extension.mjs",
     "build:client": "node ./build-client.mjs",
     "build:remote-sdk": "node ./build-remote-sdk.mjs",
-    "build": "npm run build:app && npm run build:client && npm run build:extension && npm run build:remote-sdk",
+    "build:mcp": "node ./build-mcp.mjs",
+    "build": "npm run build:app && npm run build:client && npm run build:extension && npm run build:remote-sdk && npm run build:mcp",
     "prepack": "npm run build && npm run smoke",
-    "smoke": "node smoke.mjs && node smoke-conductor.mjs"
+    "smoke": "node smoke.mjs && node smoke-conductor.mjs && node smoke-mcp.mjs"
   },
   "pi": {
     "extensions": ["./accordion.js"]
   },
+  "bin": {
+    "accordion-mcp": "./accordion-mcp.js"
+  },
   "files": [
     "accordion.js",
+    "accordion-mcp.js",
     "dist",
     "skills",
     "README.md"

--- a/extension/smoke-mcp.mjs
+++ b/extension/smoke-mcp.mjs
@@ -1,0 +1,44 @@
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createInterface } from "node:readline";
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "accordion-mcp-"));
+const marker = path.join(root, "opened");
+const fakeApp = path.join(root, "accordion-app");
+fs.writeFileSync(fakeApp, `#!/bin/sh\ntouch '${marker}'\n`);
+fs.chmodSync(fakeApp, 0o755);
+
+const child = spawn(process.execPath, [path.resolve("accordion-mcp.js")], {
+	env: { ...process.env, ACCORDION_APP_PATH: fakeApp },
+	stdio: ["pipe", "pipe", "inherit"],
+});
+const pending = new Map();
+createInterface({ input: child.stdout }).on("line", (line) => {
+	const message = JSON.parse(line);
+	pending.get(message.id)?.(message);
+	pending.delete(message.id);
+});
+let id = 0;
+const request = (method, params = {}) => new Promise((resolve) => {
+	id += 1;
+	pending.set(id, resolve);
+	child.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`);
+});
+
+try {
+	const initialized = await request("initialize", { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "accordion-smoke", version: "1.0.0" } });
+	if (initialized.result?.serverInfo?.name !== "accordion") throw new Error("MCP initialization failed");
+	const listed = await request("tools/list");
+	if (listed.result?.tools?.length !== 1 || listed.result.tools[0]?.name !== "open_accordion") throw new Error("open_accordion was not the sole advertised tool");
+	const called = await request("tools/call", { name: "open_accordion", arguments: {} });
+	if (called.result?.isError) throw new Error(`open_accordion failed: ${JSON.stringify(called.result.content)}`);
+	const deadline = Date.now() + 2000;
+	while (!fs.existsSync(marker) && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 20));
+	if (!fs.existsSync(marker)) throw new Error("open_accordion did not launch the configured executable");
+	console.log("accordion MCP smoke passed");
+} finally {
+	child.kill();
+	fs.rmSync(root, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- extract shared native-app launcher and cover installed macOS/Linux locations
- ship a dependency-free `accordion-mcp` stdio server with `open_accordion`
- add MCP smoke coverage and package/docs integration

## Verification
- `npm run check`
- `npm run test` (807 passed, 20 skipped)
- `npm run smoke`
- `npm pack --dry-run`
- fresh Claude Code and Codex processes both called `open_accordion` successfully
- verify-gate receipt `f2aae83bca8f`